### PR TITLE
Acq worker spec

### DIFF
--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -37,6 +37,12 @@ if (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     endif ()
 endif ()
 
+if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR GENERATOR_IS_MULTI_CONFIG)
+    option(ENABLE_COVERAGE "Enable Coverage" ON)
+else ()
+    option(ENABLE_COVERAGE "Enable Coverage" OFF)
+endif ()
+
 # enable cache system
 include(cmake/Cache.cmake)
 
@@ -46,7 +52,20 @@ add_library(project_warnings INTERFACE)
 include(cmake/CompilerWarnings.cmake)
 set_project_warnings(project_warnings)
 
-# add_subdirectory(acquisition) # worker providing mock data
+if (ENABLE_COVERAGE)
+    if (UNIX AND NOT APPLE) # Linux
+        message("Coverage reporting enabled")
+        include(cmake/CodeCoverage.cmake) # https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake
+        # (License: BSL-1.0)
+        target_compile_options(project_options INTERFACE --coverage -O0 -g -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0) # fortify_source is not possible without optimization
+        target_link_libraries(project_options INTERFACE --coverage)
+        append_coverage_compiler_flags()
+    else ()
+        message(WARNING "Coverage is only supported on linux")
+    endif ()
+endif()
+
+add_subdirectory(acquisition)
 add_subdirectory(flowgraph) # worker providing access to the mock flowgraph and allows editing it
 add_subdirectory(rest) # worker providing access to static assets
 
@@ -55,4 +74,4 @@ file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/demo_sslcert/demo_private.key" DESTINATIO
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/demo_sslcert/demo_public.crt" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
 
 add_executable(opendigitizer main.cpp)
-target_link_libraries(opendigitizer PRIVATE od_flowgraph od_rest majordomo project_options project_warnings assets::rest)
+target_link_libraries(opendigitizer PRIVATE od_flowgraph od_acquisition od_rest majordomo client project_options project_warnings assets::rest)

--- a/src/service/acquisition/CMakeLists.txt
+++ b/src/service/acquisition/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(od_acquisition INTERFACE acqWorker.hpp daq_api.hpp)
+target_include_directories(od_acquisition INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/.)
+target_link_libraries(od_acquisition INTERFACE majordomo disruptor project_options project_warnings)
+
+add_subdirectory(test)

--- a/src/service/acquisition/acqWorker.hpp
+++ b/src/service/acquisition/acqWorker.hpp
@@ -1,155 +1,132 @@
-#include <majordomo/base64pp.hpp>
-#include <majordomo/Broker.hpp>
-#include <majordomo/RestBackend.hpp>
-#include <majordomo/Worker.hpp>
-
-#include <atomic>
-#include <cmath>
-#include <fstream>
-#include <iomanip>
-#include <numeric>
-#include <ranges>
-#include <string_view>
-#include <thread>
+#ifndef OPENDIGITIZER_SERVICE_ACQWORKER_H
+#define OPENDIGITIZER_SERVICE_ACQWORKER_H
 
 #include "daq_api.hpp"
+#include <majordomo/Worker.hpp>
+#include <ranges>
+#include <string_view>
+
+#include <chrono>
+#include <cmath>
+#include <unordered_map>
+#include <utility>
+
+namespace opendigitizer::acq {
+using opencmw::Annotated;
+using opencmw::NoUnit;
 
 using namespace opencmw::majordomo;
 using namespace std::chrono_literals;
 
-struct AcqFilterContext {
-    std::string             signalFilter;
-    opencmw::MIME::MimeType contentType = opencmw::MIME::BINARY;
-};
-ENABLE_REFLECTION_FOR(AcqFilterContext, signalFilter, contentType)
-
-using namespace opencmw::majordomo;
-
 template<units::basic_fixed_string serviceName, typename... Meta>
-class AcquisitionWorker : public Worker<serviceName, AcqFilterContext, Empty, Acquisition, Meta...> {
-    static constexpr size_t                                                     N_ELEMS = 100;
-    std::mutex                                                                  mockSignalsLock;
-    std::unordered_map<std::string, std::pair<int, std::array<float, N_ELEMS>>> mockSignals = { { "A", { 0, { 0.0f } } }, { "B", { 0, { 1.0f } } } }; // <signal name, <update inc, value>>
-    std::jthread                                                                notifyThread;
-    bool                                                                        shutdownRequested = false;
+class AcquisitionWorker : public Worker<serviceName, TimeDomainContext, Empty, Acquisition, Meta...> {
+    std::jthread              _notifyThread;
+    std::chrono::milliseconds _rate;
 
 public:
-    using super_t = Worker<serviceName, AcqFilterContext, Empty, Acquisition, Meta...>;
+    using super_t = Worker<serviceName, TimeDomainContext, Empty, Acquisition, Meta...>;
+    template<typename BrokerType>
+    explicit AcquisitionWorker(const BrokerType &broker, std::chrono::milliseconds rate)
+        : super_t(broker, {}), _rate(rate) {
+        _notifyThread = std::jthread([this, &rate](const std::stop_token &stoken) {
+            fmt::print("acqWorker: starting notify thread\n");
+            std::chrono::time_point update = std::chrono::system_clock::now();
+            while (!stoken.stop_requested()) {
+                fmt::print("acqWorker: active subscriptions: {}\n", super_t::activeSubscriptions() | std::ranges::views::transform([](auto &uri) { return uri.str(); }));
+                for (auto subTopic : super_t::activeSubscriptions()) { // loop over active subscriptions
+                    if (subTopic.path() != serviceName.c_str()) {
+                        continue;
+                    }
 
-    template<typename BrokerType, typename Interval>
-    explicit AcquisitionWorker(const BrokerType &broker, Interval updateInterval)
-        : super_t(broker, {}) {
-        notifyThread = std::jthread([this, updateInterval] {
-            while (!shutdownRequested) {
-                std::this_thread::sleep_for(updateInterval);
-                updateData();
+                    const auto              queryMap = subTopic.queryParamMap();
+                    const TimeDomainContext filterIn = opencmw::query::deserialise<TimeDomainContext>(queryMap);
+
+                    try {
+                        Acquisition                     reply;
+                        si::time<nanosecond, ::int64_t> triggerStamp{ std::chrono::duration_cast<std::chrono::nanoseconds>(update.time_since_epoch()).count() };
+
+                        std::string                     signals = filterIn.channelNameFilter.empty() ? "sine,saw" : filterIn.channelNameFilter;
+                        for (std::string_view signal : signals | std::ranges::views::split(',') | std::ranges::views::transform([](const auto &&r) { return std::string_view{ &*r.begin(), std::ranges::distance(r) }; })) {
+                            auto filterInLocal              = filterIn;
+                            filterInLocal.channelNameFilter = std::string{ signal };
+                            handleGetRequest(triggerStamp, filterInLocal, reply);
+
+                            TimeDomainContext filterOut = filterIn;
+                            filterOut.contentType       = opencmw::MIME::JSON;
+                            auto res                    = super_t::notify(std::string(serviceName.c_str()), filterOut, reply);
+                            fmt::print("acqWorker: {} update sent {}\n", signal, res);
+                        }
+                    } catch (const std::exception &ex) {
+                        fmt::print("caught exception '{}'\n", ex.what());
+                    }
+                }
+
+                auto next_update  = update + 2000ms;
+                auto willSleepFor = next_update - std::chrono::system_clock::now();
+                ;
+                if (willSleepFor > 0ms) {
+                    std::this_thread::sleep_for(willSleepFor);
+                }
+                update = next_update;
             }
+            fmt::print("acqWorker: stopped notify thread\n");
         });
 
-        super_t::setCallback([this](const RequestContext &rawCtx, const AcqFilterContext &filterIn, const Empty & /*in - unused*/, AcqFilterContext &filterOut, Acquisition &out) {
+        super_t::setCallback([this](RequestContext &rawCtx, const TimeDomainContext &requestContext, const Empty &, TimeDomainContext & /*replyContext*/, Acquisition &out) {
             if (rawCtx.request.command() == Command::Get) {
-                fmt::print("worker received 'get' request\n");
-                handleGetRequest(filterIn, filterOut, out);
-            } else if (rawCtx.request.command() == Command::Set) {
-                fmt::print("worker received 'set' request - ignoring for read-only property\n");
+                // for real data, where we cannot generate the data on the fly, the get has to implement some sort of caching
+                std::chrono::time_point         update = std::chrono::system_clock::now();
+                si::time<nanosecond, ::int64_t> triggerStamp{ std::chrono::duration_cast<std::chrono::nanoseconds>(update.time_since_epoch()).count() };
+                handleGetRequest(triggerStamp, requestContext, out);
             }
         });
     }
 
-    void updateData() { // some silly updating data
-        static int  counter      = 0;
-        const auto  notifySignal = counter % 2 == false ? "A" : "B";
-        const float t0           = M_2_PIf * static_cast<float>(counter) / 10.0f;
-        if (mockSignals.contains(notifySignal)) {
-            fmt::print("updateData({}) - update signal '{}'\n", counter, notifySignal);
-            std::lock_guard lockGuard(mockSignalsLock);
-            mockSignals[notifySignal].first++;
-            std::array<float, N_ELEMS> value{};
-            for (std::size_t i = 0; i < N_ELEMS; i++) {
-                const float t = t0 + static_cast<float>(i) * 2.0f / N_ELEMS;
-                value[i]      = { counter % 2 == false ? sinf(t) : cosf(t) };
-            }
-            mockSignals[notifySignal].second = value;
-        } else {
-            fmt::print("updateData({}) - updated nothing\n", counter);
-        }
-        counter++;
-        notifyUpdate();
+    ~AcquisitionWorker() {
+        _notifyThread.request_stop();
+        _notifyThread.join();
     }
 
-private:
-    void handleGetRequest(const AcqFilterContext &filterIn, AcqFilterContext & /*filterOut*/, Acquisition &out) {
-        // auto signals = std::string_view(filterIn.signalFilter) | std::ranges::views::split(',');
-        // for (const auto &signal : signals) {
-        //     out.channelNames.emplace_back(std::string_view(signal.begin(), signal.end()));
-        // }
-        for (const auto &[signal, data] : mockSignals) {
-            out.channelNames.emplace_back(std::string_view(signal.begin(), signal.end()));
-        }
-        out.channelUnits.value() = { "V", "A" };
-        fmt::print("handleGetRequest for '{}'\n", out.channelNames.value());
-        std::lock_guard lockGuard(mockSignalsLock);
-        out.channelTimeSinceRefTrigger.value().resize(N_ELEMS);
-        std::iota(out.channelTimeSinceRefTrigger.value().begin(), out.channelTimeSinceRefTrigger.value().end(), 2.0f / N_ELEMS);
-        out.channelValues.value() = opencmw::MultiArray<float, 2>({ out.channelNames.size(), N_ELEMS });
-        out.channelErrors.value() = opencmw::MultiArray<float, 2>({ out.channelNames.size(), N_ELEMS });
-        for (std::size_t i = 0; i < out.channelNames.size(); i++) {
-            const auto mock = mockSignals.at(out.channelNames.value()[i]);
-            const auto sig  = mock.second;
-            for (std::size_t j = 0; j < N_ELEMS; j++) {
-                out.channelValues.value()[{ i, j }] = sig[j];
-            }
-            if (i == 0) {
-                out.refTriggerStamp = mock.first;
-            }
-        }
-    }
+    void handleGetRequest(const si::time<nanosecond, ::int64_t> updateStamp, const TimeDomainContext &ctx, Acquisition &out) {
+        using std::chrono::milliseconds, std::chrono::duration_cast, std::chrono::system_clock;
+        using std::ranges::views::split, std::ranges::views::transform;
+        constexpr std::size_t N_SAMPLES = 32;
 
-    bool shallUpdateForTopic(const auto &filterIn) const noexcept {
-        // auto                               signals = std::string_view(filterIn.signalFilter) | std::ranges::views::split(',');
-        // std::set<std::string, std::less<>> requestedSignals;
-        // for (const auto &signal : signals) {
-        //     requestedSignals.emplace(std::string_view(signal.begin(), signal.end()));
-        // }
-        // if (requestedSignals.empty()) {
-        //     return false;
-        // }
-        // int updateCount = -1;
-        // for (const auto &signal : requestedSignals) {
-        //     if (!mockSignals.contains(signal)) {
-        //         fmt::print("requested unknown signal '{}'\n", signal);
-        //         return false;
-        //     }
-        //     if (updateCount < 0) {
-        //         updateCount = mockSignals.at(signal).first;
-        //     }
-        //     if (mockSignals.at(signal).first != updateCount || updateCount == 0) {
-        //         // here: don't update if the update count is not identical for all signals
-        //         return false;
-        //     }
-        // }
-        return true;
-    }
+        out.channelName                 = ctx.channelNameFilter;
 
-    void notifyUpdate() {
-        for (auto subTopic : super_t::activeSubscriptions()) { // loop over active subscriptions
+        out.acqTriggerTimeStamp         = updateStamp;
+        out.acqTriggerName              = "STREAMING";
 
-            const auto             queryMap = subTopic.queryParamMap();
-            const AcqFilterContext filterIn = opencmw::query::deserialise<AcqFilterContext>(queryMap);
-            if (!shallUpdateForTopic(filterIn)) {
-                fmt::print("active user subscription: '{}' is NOT being notified\n", subTopic.str());
-                break;
+        // missing move constructor... out.channelValues = {{}};
+        out.channelValue.resize(N_SAMPLES);
+        out.channelError.resize(N_SAMPLES);
+        out.channelTimeBase.resize(N_SAMPLES);
+
+        if (out.channelName.value() == "sine") {
+            const double amplitude = 1.0;
+            const int    n_period  = 20;
+            for (std::size_t i = 0; i < N_SAMPLES; i++) {
+                const float t       = (static_cast<float>((updateStamp.number() * N_SAMPLES / _rate.count() / 1000000 + i) % n_period)) * _rate.count() * 1e-3f / N_SAMPLES;
+                out.channelValue[i] = static_cast<float>(amplitude * std::sin(static_cast<double>(t) / n_period * std::numbers::pi));
+                out.channelError[i] = 0.0f;
+                // out.channelTimeBase[i] = static_cast<float>(i) * _rate.count() * 1e-3f / N_SAMPLES; // time in float seconds
+                out.channelTimeBase[i] = i * _rate.count() / N_SAMPLES; // time in integer nanoseconds
             }
-            AcqFilterContext filterOut = filterIn;
-            Acquisition      subscriptionReply;
-            try {
-                handleGetRequest(filterIn, filterOut, subscriptionReply);
-                super_t::notify(std::string(serviceName.c_str()), filterOut, subscriptionReply);
-            } catch (const std::exception &ex) {
-                fmt::print("caught specific exception '{}'\n", ex.what());
-            } catch (...) {
-                fmt::print("caught unknown generic exception\n");
+            out.channelUnit = "V";
+        } else if (out.channelName.value() == "saw") {
+            const double amplitude = 9.0;
+            const int    n_period  = 13;
+            for (std::size_t i = 0; i < N_SAMPLES; i++) {
+                const float t       = (static_cast<float>((updateStamp.number() * N_SAMPLES / _rate.count() / 1000000 + i) % n_period)) * _rate.count() * 1e-3f / N_SAMPLES;
+                out.channelValue[i] = static_cast<float>(amplitude * static_cast<double>(t) / n_period);
+                out.channelError[i] = 0.01f;
+                // out.channelTimeBase[i] = static_cast<float>(i) * _rate.count() * 1e-3f / N_SAMPLES; // time in float seconds
+                out.channelTimeBase[i] = i * _rate.count() / N_SAMPLES; // time in integer nanoseconds
             }
+            out.channelUnit = "A";
         }
+        out.temperature.value() = 20.0f;
     }
 };
+} // namespace opendigitizer::acq
+#endif // OPENDIGITIZER_SERVICE_ACQWORKER_H

--- a/src/service/acquisition/daq_api.hpp
+++ b/src/service/acquisition/daq_api.hpp
@@ -1,28 +1,81 @@
 #pragma once
 
-#include <iostream>
+#include <MultiArray.hpp>
 #include <opencmw.hpp>
+#include <string>
+#include <units/isq/si/frequency.h>
 #include <units/isq/si/time.h>
 #include <vector>
 
+using opencmw::Annotated;
+using namespace units::isq;
+using namespace units::isq::si;
+using namespace std::literals;
+
 /**
- * @brief Time-domain FEC acquisition user-interface
- * specified here: https://git.gsi.de/acc/specs/generic-daq#time-domain-fec-acquisition-properties-user-interface.
+ * Generic time domain data object.
+ * Specified in: https://edms.cern.ch/document/1823376/1 EDMS: 1823376 v.1 Section 4.3.1
  */
+// clang-format: OFF
 struct Acquisition {
-    opencmw::Annotated<std::string, opencmw::NoUnit, "Name of timing event used to align the data">                                                     refTriggerName = "NO_REF_TRIGGER";
-    opencmw::Annotated<int64_t, units::isq::si::time<units::isq::si::nanosecond>, "UTC timestamp on which the timing event occured">                    refTriggerStamp;
-    opencmw::Annotated<std::vector<float>, units::isq::si::time<units::isq::si::second>, "Relative time between the reference trigger and each sample"> channelTimeSinceRefTrigger;
-    opencmw::Annotated<float, units::isq::si::time<units::isq::si::second>, "User-defined delay">                                                       channelUserDelay;
-    opencmw::Annotated<float, units::isq::si::time<units::isq::si::second>, "Actual trigger delay">                                                     channelActualDelay;
-    opencmw::Annotated<std::vector<std::string>, opencmw::NoUnit, "Name(s) of the channel/signal">                                                      channelNames{};
-    opencmw::Annotated<opencmw::MultiArray<float, 2>, opencmw::NoUnit, "Values of the channel/signal">                                                  channelValues{};
-    opencmw::Annotated<opencmw::MultiArray<float, 2>, opencmw::NoUnit, "R.m.s. error of of the channel/signal">                                         channelErrors{};
-    opencmw::Annotated<std::vector<std::string>, opencmw::NoUnit, "S.I. unit of post-processed signal">                                                 channelUnits{};
-    opencmw::Annotated<std::vector<int64_t>, opencmw::NoUnit, "Status bit-mask bits for this channel/signal">                                           status{};
-    opencmw::Annotated<std::vector<float>, opencmw::NoUnit, "Minimum expected value for channel/signal">                                                channelRangeMin{};
-    opencmw::Annotated<std::vector<float>, opencmw::NoUnit, "Maximum expected value for channel/signal">                                                channelRangeMax{};
-    // Celsius is currently not supported: https://github.com/mpusz/units/pull/232
-    opencmw::Annotated<std::vector<float>, opencmw::NoUnit, "Temperature of the measurement device"> temperature{}; // [°C]
+    Annotated<std::string, opencmw::NoUnit, "property filter for sel. channel mode and name">    selectedFilter;                        // specified as Enum + String
+    Annotated<std::string, opencmw::NoUnit, "trigger name, e.g. STREAMING or INJECTION1">        acqTriggerName      = { "STREAMING" }; // specified as ENUM
+    Annotated<int64_t, si::time<nanosecond>, "UTC timestamp on which the timing event occurred"> acqTriggerTimeStamp = 0;               // specified as type WR timestamp
+    Annotated<int64_t, si::time<nanosecond>, "time-stamp w.r.t. beam-in trigger">                acqLocalTimeStamp   = 0;
+    Annotated<std::vector<::int32_t>, si::time<second>, "time scale">                            channelTimeBase; // todo either nanosecond or float
+    Annotated<float, si::time<second>, "user-defined delay">                                     channelUserDelay   = 0.0f;
+    Annotated<float, si::time<second>, "actual trigger delay">                                   channelActualDelay = 0.0f;
+    Annotated<std::string, opencmw::NoUnit, "name of the channel/signal">                        channelName;
+    Annotated<std::vector<float>, opencmw::NoUnit, "value of the channel/signal">                channelValue;
+    Annotated<std::vector<float>, opencmw::NoUnit, "r.m.s. error of of the channel/signal">      channelError;
+    Annotated<std::string, opencmw::NoUnit, "S.I. unit of post-processed signal">                channelUnit;
+    Annotated<int64_t, opencmw::NoUnit, "status bit-mask bits for this channel/signal">          status;
+    Annotated<float, opencmw::NoUnit, "minimum expected value for channel/signal">               channelRangeMin;
+    Annotated<float, opencmw::NoUnit, "minimum expected value for channel/signal">               channelRangeMax;
+    Annotated<float, opencmw::NoUnit, "temperature of the measurement device">                   temperature;
 };
-ENABLE_REFLECTION_FOR(Acquisition, refTriggerName, refTriggerStamp, channelTimeSinceRefTrigger, channelUserDelay, channelActualDelay, channelNames, channelValues, channelErrors, channelUnits, status, channelRangeMin, channelRangeMax)
+ENABLE_REFLECTION_FOR(Acquisition, selectedFilter, acqTriggerName, acqTriggerTimeStamp, acqLocalTimeStamp, channelTimeBase, channelUserDelay, channelActualDelay, channelName, channelValue, channelError, channelUnit, status, channelRangeMin, channelRangeMax, temperature)
+
+/**
+ * Generic frequency domain data object.
+ * Specified in: https://edms.cern.ch/document/1823376/1 EDMS: 1823376 v.1 Section 4.3.2
+ */
+// clang-format: OFF
+struct AcquisitionSpectra {
+    Annotated<std::string, opencmw::NoUnit, "property filter for sel. channel mode and name">    selectedFilter;                        // specified as Enum + String
+    Annotated<std::string, opencmw::NoUnit, "trigger name, e.g. STREAMING or INJECTION1">        acqTriggerName      = { "STREAMING" }; // specified as ENUM
+    Annotated<int64_t, si::time<nanosecond>, "UTC timestamp on which the timing event occurred"> acqTriggerTimeStamp = 0;               // specified as type WR timestamp
+    Annotated<int64_t, si::time<nanosecond>, "time-stamp w.r.t. beam-in trigger">                acqLocalTimeStamp   = 0;
+    Annotated<std::string, opencmw::NoUnit, "name of the channel/signal">                        channelName;
+    Annotated<std::vector<float>, opencmw::NoUnit, "magnitude spectra of signals">               channelMagnitude;
+    Annotated<std::vector<::int32_t>, opencmw::NoUnit, "{N_meas, N_binning}">                    channelMagnitude_dimensions;
+    Annotated<std::vector<std::string>, opencmw::NoUnit, "{'time', 'frequency'}">                channelMagnitude_labels;
+    Annotated<std::vector<long>, si::time<si::second>, "timestamps of samples">                  channelMagnitude_dim1_labels; // todo: either nanosecond or float
+    Annotated<std::vector<float>, opencmw::NoUnit, "freqency scale">                             channelMagnitude_dim2_labels; // unit: Hz or f_rev
+    Annotated<std::vector<float>, opencmw::NoUnit, "phase spectra of signals">                   channelPhase;
+    Annotated<std::vector<std::string>, opencmw::NoUnit, "{'time', 'frequency'}">                channelPhase_labels;
+    Annotated<std::vector<long>, si::time<si::second>, "timestamps of samples">                  channelPhase_dim1_labels; // todo: either nanosecond or float
+    Annotated<std::vector<float>, opencmw::NoUnit, "freqency scale">                             channelPhase_dim2_labels; // unit: Hz or f_rev
+};
+ENABLE_REFLECTION_FOR(AcquisitionSpectra, selectedFilter, acqTriggerName, acqTriggerTimeStamp, acqLocalTimeStamp, channelName, channelMagnitude, channelMagnitude_dimensions, channelMagnitude_labels, channelMagnitude_dim1_labels, channelMagnitude_dim2_labels, channelPhase, channelPhase_labels, channelPhase_dim1_labels, channelPhase_dim2_labels)
+// clang-format: ON
+
+struct TimeDomainContext {
+    std::string             channelNameFilter;
+    int32_t                 acquisitionModeFilter = 0; // STREAMING
+    std::string             triggerNameFilter;
+    int32_t                 maxClientUpdateFrequencyFilter = 25;
+    opencmw::MIME::MimeType contentType                    = opencmw::MIME::JSON;
+};
+
+ENABLE_REFLECTION_FOR(TimeDomainContext, channelNameFilter, acquisitionModeFilter, triggerNameFilter, maxClientUpdateFrequencyFilter, contentType)
+
+struct FreqDomainContext {
+    std::string             channelNameFilter;
+    int32_t                 acquisitionModeFilter = 0; // STREAMING
+    std::string             triggerNameFilter;
+    int32_t                 maxClientUpdateFrequencyFilter = 25;
+    opencmw::MIME::MimeType contentType                    = opencmw::MIME::JSON;
+};
+
+ENABLE_REFLECTION_FOR(FreqDomainContext, channelNameFilter, acquisitionModeFilter, triggerNameFilter, maxClientUpdateFrequencyFilter, contentType)

--- a/src/service/acquisition/test/CMakeLists.txt
+++ b/src/service/acquisition/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(acqWorkerTest acqWorker_test.cpp)
+target_include_directories(acqWorkerTest INTERFACE ../include)
+target_link_libraries(acqWorkerTest PRIVATE fmt ut od_acquisition client)

--- a/src/service/acquisition/test/acqWorker_test.cpp
+++ b/src/service/acquisition/test/acqWorker_test.cpp
@@ -1,0 +1,87 @@
+#include <Client.hpp>
+#include <majordomo/Broker.hpp>
+#include <majordomo/Settings.hpp>
+#include <majordomo/Worker.hpp>
+
+#include <fmt/format.h>
+#define __cpp_lib_source_location
+#include <boost/ut.hpp>
+
+#include <acqWorker.hpp>
+
+using opencmw::majordomo::Broker;
+using opencmw::majordomo::BrokerMessage;
+using opencmw::majordomo::Command;
+using opencmw::majordomo::MdpMessage;
+using opencmw::majordomo::MessageFrame;
+using opencmw::majordomo::Settings;
+using opencmw::majordomo::Worker;
+
+const boost::ut::suite basic_acq_worker_tests = [] {
+    using namespace boost::ut;
+
+    "GetDataTest"_test = [] {
+        using opencmw::URI;
+        using namespace opendigitizer::acq;
+        using namespace opencmw::majordomo;
+        using namespace std::chrono_literals;
+        using namespace boost::ut;
+        using namespace boost::ut::literals;
+        using namespace boost::ut::operators::terse;
+
+        // broker
+        Broker     broker("PrimaryBroker");
+
+        const auto brokerRouterAddress = broker.bind(URI<>("mds://127.0.0.1:12345"));
+        expect((brokerRouterAddress.has_value() == "bound successful"_b));
+        std::jthread brokerThread([&broker] {
+            broker.run();
+        });
+
+        // acquisition worker (mock)
+        using AcqWorker = AcquisitionWorker<"/DeviceName/Acquisition", description<"Provides data acquisition updates">>;
+        AcqWorker    acquisitionWorker(broker, 1000ms);
+        std::jthread acquisitionWorkerThread([&acquisitionWorker] { acquisitionWorker.run(); });
+
+        std::this_thread::sleep_for(100ms);
+
+        // start some simple subscription client
+        fmt::print("starting some client subscriptions\n");
+        const Context                                             zctx{};
+        std::vector<std::unique_ptr<opencmw::client::ClientBase>> clients;
+        clients.emplace_back(std::make_unique<opencmw::client::MDClientCtx>(zctx, 20ms, ""));
+        opencmw::client::ClientContext client{ std::move(clients) };
+
+        std::this_thread::sleep_for(100ms);
+
+        std::atomic<int> receivedA{ 0 };
+        std::atomic<int> receivedAB{ 0 };
+        client.subscribe(URI("mds://127.0.0.1:12345/DeviceName/Acquisition?channelNameFilter=saw"), [&receivedA](const opencmw::mdp::Message &update) {
+            fmt::print("Client('A') received message from service '{}' for endpoint '{}'\n", update.serviceName.str(), update.endpoint.str());
+            receivedA++;
+        });
+        client.subscribe(URI("mds://127.0.0.1:12345/DeviceName/Acquisition"), [&receivedAB](const opencmw::mdp::Message &update) {
+            fmt::print("Client('A,B') received message from service '{}' for endpoint '{}'\n", update.serviceName.str(), update.endpoint.str());
+            receivedAB++;
+        });
+
+        while (receivedA < 2 && receivedAB < 2) {
+            std::this_thread::sleep_for(200ms);
+        }
+
+        client.unsubscribe(URI("mds://127.0.0.1:12345/DeviceName/Acquisition?channelNameFilter=saw"));
+        client.unsubscribe(URI("mds://127.0.0.1:12345/DeviceName/Acquisition"));
+        fmt::print("received client updates: {} for 'A' and {} for 'A,B'\n", receivedA, receivedAB);
+        expect(int(receivedA) >= 2_i);
+        expect(int(receivedAB) >= 2_i);
+        client.stop();
+
+        broker.shutdown();
+
+        brokerThread.join();
+        acquisitionWorkerThread.join();
+    };
+};
+
+int main() { /* not needed for ut */
+}

--- a/src/service/cmake/Dependencies.cmake
+++ b/src/service/cmake/Dependencies.cmake
@@ -6,4 +6,10 @@ FetchContent_Declare(
         GIT_TAG main # todo: use proper release once available
 )
 
-FetchContent_MakeAvailable(opencmw-cpp)
+FetchContent_Declare(
+        ut
+        GIT_REPOSITORY https://github.com/boost-ext/ut.git
+        GIT_TAG 265199e173b16a75670fae62fc2446b9dffad39e # head as of 2022-12-19
+)
+
+FetchContent_MakeAvailable(opencmw-cpp ut)

--- a/src/service/main.cpp
+++ b/src/service/main.cpp
@@ -1,8 +1,8 @@
+#include <Client.hpp>
 #include <majordomo/Broker.hpp>
 #include <majordomo/Worker.hpp>
 
 #include <fstream>
-#include <iomanip>
 #include <thread>
 
 #include "acquisition/acqWorker.hpp"
@@ -13,6 +13,10 @@ using namespace opencmw::majordomo;
 
 int main() {
     using opencmw::URI;
+    using namespace opendigitizer::acq;
+    using namespace opencmw::majordomo;
+    using namespace std::chrono_literals;
+
     // broker
     Broker broker("PrimaryBroker");
     // REST backend
@@ -31,16 +35,45 @@ int main() {
     });
 
     // flowgraph worker (mock)
-    FlowgraphWorker<"flowgraph", description<"Provides R/W access to the flowgraph as a yaml serialized string">> flowgraphWorker(broker);
-    std::jthread                                                                                                  flowgraphWorkerThread([&flowgraphWorker] {
-        flowgraphWorker.run();
-                                                                                                     });
+    using FgWorker = FlowgraphWorker<"flowgraph", description<"Provides R/W access to the flowgraph as a yaml serialized string">>;
+    FgWorker     flowgraphWorker(broker);
+    std::jthread flowgraphWorkerThread([&flowgraphWorker] { flowgraphWorker.run(); });
 
-    // acquisition worker (mock) todo: implement
-    AcquisitionWorker<"acquisition", description<"Provides data acquisition updates">> acquisitionWorker(broker, 2000ms); // todo: change to 25Hz, just slow for debugging
-    std::jthread                                                                       acquisitionWorkerThread([&acquisitionWorker] {
-        acquisitionWorker.run();
-                                                                          });
+    // acquisition worker (mock)
+    using AcqWorker = AcquisitionWorker<"/DeviceName/Acquisition", description<"Provides data acquisition updates">>;
+    AcqWorker    acquisitionWorker(broker, 3000ms);
+    std::jthread acquisitionWorkerThread([&acquisitionWorker] { acquisitionWorker.run(); });
+
+    std::this_thread::sleep_for(100ms);
+
+    // start some simple subscription client
+    fmt::print("starting some client subscriptions\n");
+    const Context                                             zctx{};
+    std::vector<std::unique_ptr<opencmw::client::ClientBase>> clients;
+    clients.emplace_back(std::make_unique<opencmw::client::MDClientCtx>(zctx, 20ms, ""));
+    opencmw::client::ClientContext client{ std::move(clients) };
+
+    std::this_thread::sleep_for(100ms);
+
+    std::atomic<int> receivedA{ 0 };
+    std::atomic<int> receivedAB{ 0 };
+    client.subscribe(URI("mds://127.0.0.1:12345/DeviceName/Acquisition?channelNameFilter=saw"), [&receivedA](const opencmw::mdp::Message &update) {
+        fmt::print("Client('saw') received message from service '{}' for endpoint '{}'\n{}\n", update.serviceName.str(), update.endpoint.str(), update.data.asString());
+        receivedA++;
+    });
+    client.subscribe(URI("mds://127.0.0.1:12345/DeviceName/Acquisition"), [&receivedAB](const opencmw::mdp::Message &update) {
+        fmt::print("Client('all') received message from service '{}' for endpoint '{}'\n{}\n", update.serviceName.str(), update.endpoint.str(), update.data.asString());
+        receivedAB++;
+    });
+
+    while (receivedA < 2 || receivedAB < 4) {
+        std::this_thread::sleep_for(200ms);
+    }
+
+    client.unsubscribe(URI("mds://127.0.0.1:12345/DeviceName/Acquisition?channelNameFilter=saw"));
+    client.unsubscribe(URI("mds://127.0.0.1:12345/DeviceName/Acquisition"));
+    fmt::print("received client updates: {} for 'sine' and {} for 'sine,saw'\n", receivedA, receivedAB);
+    client.stop();
 
     // shutdown
     brokerThread.join();


### PR DESCRIPTION
Adds the acquisition property as specified in the [EDMS Specificaton](https://edms.cern.ch/document/1823376/1) and a simple worker generating mock data that can be subscribed to via the Majordomo broker.