### PR TITLE
CI: publish wasm artifacts to github pages

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -7,6 +7,11 @@ on:
   release:
     types: [ created ]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build:
     name: "${{ matrix.configurations.name }} | ${{ matrix.cmake-build-type }}"
@@ -64,3 +69,22 @@ jobs:
       shell: bash
       run: cmake --build ../build
 
+    - name: Setup Pages
+      uses: actions/configure-pages@v3
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: '../build/CMakeExternals/Build/ui-wasm/web/'
+        
+  deploy_pages:
+    name: Deploy to GitHub Pages
+    if: ${{ github.ref == 'main' && github.event_name == 'push' }}
+    environment: github-pages
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+    - name: "Setup Pages"
+      uses: actions/configure-pages@v3
+    - name: "Deploy to pages"
+      id: deployment
+      uses: actions/deploy-pages@v2


### PR DESCRIPTION
Adds a github action job which publishes the wasm artifacts from the `web` subfolder of the wasm build to [github-pages](https://fair-accc.github.io/opendigitizer/).