### PR TITLE
Remote flowgraphs support

### DIFF
--- a/src/service/flowgraph/flowgraphWorker.hpp
+++ b/src/service/flowgraph/flowgraphWorker.hpp
@@ -64,9 +64,11 @@ private:
 
     void handleSetRequest(const FilterContext & /*filterIn*/, FilterContext & /*filterOut*/, const Flowgraph &in, Flowgraph &out) {
         fmt::print("handleSetRequest for flowgraph\n");
-        std::lock_guard lockGuard(flowgraphLock);
-        flowgraph     = in.flowgraph;
-        out.flowgraph = flowgraph;
+        {
+            std::lock_guard lockGuard(flowgraphLock);
+            flowgraph     = in.flowgraph;
+            out.flowgraph = flowgraph;
+        }
         notifyUpdate();
     }
 

--- a/src/service/flowgraph/flowgraphWorker.hpp
+++ b/src/service/flowgraph/flowgraphWorker.hpp
@@ -23,16 +23,17 @@ ENABLE_REFLECTION_FOR(FilterContext, contentType)
 
 struct Flowgraph {
     std::string flowgraph;
+    std::string layout;
 };
 
-ENABLE_REFLECTION_FOR(Flowgraph, flowgraph)
+ENABLE_REFLECTION_FOR(Flowgraph, flowgraph, layout)
 
 using namespace opencmw::majordomo;
 
 template<units::basic_fixed_string serviceName, typename... Meta>
 class FlowgraphWorker : public Worker<serviceName, FilterContext, Flowgraph, Flowgraph, Meta...> {
-    std::string flowgraph;
-    std::mutex  flowgraphLock;
+    Flowgraph  flowgraph;
+    std::mutex flowgraphLock;
 
 public:
     using super_t = Worker<serviceName, FilterContext, Flowgraph, Flowgraph, Meta...>;
@@ -51,23 +52,23 @@ public:
         });
         auto fs                   = cmrc::flowgraphFilesystem::get_filesystem();
         auto defaultFlowgraphFile = fs.open("flowgraph.grc");
-        flowgraph.resize(defaultFlowgraphFile.size());
-        std::copy(defaultFlowgraphFile.begin(), defaultFlowgraphFile.end(), flowgraph.begin());
+        flowgraph.flowgraph.resize(defaultFlowgraphFile.size());
+        std::copy(defaultFlowgraphFile.begin(), defaultFlowgraphFile.end(), flowgraph.flowgraph.begin());
     }
 
 private:
     void handleGetRequest(const FilterContext & /*filterIn*/, FilterContext & /*filterOut*/, Flowgraph &out) {
         fmt::print("handleGetRequest for flowgraph\n");
         std::lock_guard lockGuard(flowgraphLock);
-        out.flowgraph = flowgraph;
+        out = flowgraph;
     }
 
     void handleSetRequest(const FilterContext & /*filterIn*/, FilterContext & /*filterOut*/, const Flowgraph &in, Flowgraph &out) {
         fmt::print("handleSetRequest for flowgraph\n");
         {
             std::lock_guard lockGuard(flowgraphLock);
-            flowgraph     = in.flowgraph;
-            out.flowgraph = flowgraph;
+            flowgraph = in;
+            out       = flowgraph;
         }
         notifyUpdate();
     }

--- a/src/ui/app.cpp
+++ b/src/ui/app.cpp
@@ -7,10 +7,7 @@
 namespace DigitizerUi {
 
 App &App::instance() {
-    static App app{
-        .fgItem        = { &app.flowGraph },
-        .dashboardPage = DashboardPage{ &app.flowGraph },
-    };
+    static App app;
     return app;
 }
 
@@ -33,6 +30,7 @@ void App::loadEmptyDashboard() {
 void App::loadDashboard(const std::shared_ptr<DashboardDescription> &desc) {
     fgItem.clear();
     dashboard = std::make_unique<Dashboard>(desc);
+    dashboard->load();
 }
 
 void App::loadDashboard(std::string_view url) {

--- a/src/ui/app.h
+++ b/src/ui/app.h
@@ -30,7 +30,6 @@ public:
     void                                      fireCallbacks();
 
     std::string                               executable;
-    FlowGraph                                 flowGraph;
     FlowGraphItem                             fgItem;
     DashboardPage                             dashboardPage;
     std::unique_ptr<Dashboard>                dashboard;

--- a/src/ui/dashboard.h
+++ b/src/ui/dashboard.h
@@ -11,10 +11,14 @@
 #include <cmrc/cmrc.hpp>
 CMRC_DECLARE(sample_dashboards);
 
+#include <RestClient.hpp>
+
 #ifdef EMSCRIPTEN
 #include "emscripten_compat.h"
 #endif
 #include <plf_colony.h>
+
+#include "flowgraph.h"
 
 namespace DigitizerUi {
 
@@ -84,6 +88,7 @@ public:
     explicit Dashboard(const std::shared_ptr<DashboardDescription> &desc);
     ~Dashboard();
 
+    void                         load();
     void                         save();
 
     void                         newPlot(int x, int y, int w, int h);
@@ -97,12 +102,28 @@ public:
     void                         setNewDescription(const std::shared_ptr<DashboardDescription> &desc);
     inline DashboardDescription *description() const { return m_desc.get(); }
 
+    struct Service {
+        Service(std::string n, std::string u)
+            : name(std::move(n)), uri(std::move(u)) {}
+        std::string                 name;
+        std::string                 uri;
+        FlowGraph                   flowGraph;
+        opencmw::client::RestClient client;
+    };
+    void         addRemoteService(std::string_view uri);
+    void         saveRemoteServiceFlowgraph(Service *s);
+
+    inline auto &remoteServices() { return m_services; }
+
+    FlowGraph    localFlowGraph;
+
 private:
     void                                  doLoad(const std::string &desc);
 
     std::shared_ptr<DashboardDescription> m_desc;
     std::vector<Plot>                     m_plots;
     plf::colony<Source>                   m_sources;
+    plf::colony<Service>                  m_services;
 };
 
 } // namespace DigitizerUi

--- a/src/ui/dashboardpage.cpp
+++ b/src/ui/dashboardpage.cpp
@@ -218,8 +218,7 @@ constexpr int gridSizeH = 16;
 
 } // namespace
 
-DashboardPage::DashboardPage(DigitizerUi::FlowGraph *fg)
-    : m_flowGraph(fg) {
+DashboardPage::DashboardPage() {
 }
 
 DashboardPage::~DashboardPage() {
@@ -227,8 +226,6 @@ DashboardPage::~DashboardPage() {
 
 void DashboardPage::draw(App *app, Dashboard *dashboard, Mode mode) {
     // ImPlot::ShowDemoWindow();
-
-    m_flowGraph->update();
 
     struct DndItem {
         Dashboard::Plot   *plotSource;

--- a/src/ui/dashboardpage.h
+++ b/src/ui/dashboardpage.h
@@ -9,11 +9,10 @@ namespace DigitizerUi {
 
 class App;
 class Dashboard;
-class FlowGraph;
 
 class DashboardPage {
 public:
-    explicit DashboardPage(FlowGraph *fg);
+    explicit DashboardPage();
     ~DashboardPage();
 
     enum class Mode {
@@ -23,9 +22,7 @@ public:
     void draw(App *app, Dashboard *Dashboard, Mode mode = Mode::View);
 
 private:
-    void       newPlot(Dashboard *dashboard);
-
-    FlowGraph *m_flowGraph;
+    void newPlot(Dashboard *dashboard);
 };
 
 } // namespace DigitizerUi

--- a/src/ui/flowgraph/datasink.cpp
+++ b/src/ui/flowgraph/datasink.cpp
@@ -41,7 +41,7 @@ void DataSink::processData() {
     }
 }
 
-void DataSink::registerBlockType(FlowGraph *fg) {
+void DataSink::registerBlockType() {
     auto t = std::make_unique<BlockType>("sink");
     t->inputs.resize(1);
     auto &in       = t->inputs[0];
@@ -52,7 +52,7 @@ void DataSink::registerBlockType(FlowGraph *fg) {
     };
     g_btype = t.get();
 
-    fg->addBlockType(std::move(t));
+    BlockType::registry().addBlockType(std::move(t));
 }
 
 DataSinkSource::DataSinkSource(std::string_view name)
@@ -67,7 +67,7 @@ void DataSinkSource::processData() {
     out.type       = sink->dataType;
 }
 
-void DataSinkSource::registerBlockType(FlowGraph *fg) {
+void DataSinkSource::registerBlockType() {
     auto t = std::make_unique<BlockType>("sink_source", "Sink Source", "", true);
     t->outputs.resize(1);
     auto &out      = t->outputs[0];
@@ -78,7 +78,7 @@ void DataSinkSource::registerBlockType(FlowGraph *fg) {
     };
     g_btypeSource = t.get();
 
-    fg->addBlockType(std::move(t));
+    BlockType::registry().addBlockType(std::move(t));
 }
 
 } // namespace DigitizerUi

--- a/src/ui/flowgraph/datasink.h
+++ b/src/ui/flowgraph/datasink.h
@@ -13,7 +13,7 @@ public:
     explicit DataSink(std::string_view name);
 
     void        processData() override;
-    static void registerBlockType(FlowGraph *fg);
+    static void registerBlockType();
 
     bool        hasData = false;
     DataType    dataType;
@@ -29,7 +29,7 @@ public:
     explicit DataSinkSource(std::string_view name);
 
     void        processData() override;
-    static void registerBlockType(FlowGraph *fg);
+    static void registerBlockType();
 
 private:
 };

--- a/src/ui/flowgraph/datasource.cpp
+++ b/src/ui/flowgraph/datasource.cpp
@@ -1,5 +1,8 @@
 #include "datasource.h"
 
+#include <fmt/format.h>
+#include <math.h>
+
 namespace DigitizerUi {
 
 namespace {
@@ -22,7 +25,7 @@ void DataSource::processData() {
     m_offset += 1;
 }
 
-void DataSource::registerBlockType(FlowGraph *fg) {
+void DataSource::registerBlockType() {
     auto t = std::make_unique<BlockType>("sine_source", "Sine wave", "Local signals", true);
     t->outputs.resize(1);
     t->outputs[0].name = "out";
@@ -39,7 +42,7 @@ void DataSource::registerBlockType(FlowGraph *fg) {
     };
     g_blockType = t.get();
 
-    fg->addBlockType(std::move(t));
+    BlockType::registry().addBlockType(std::move(t));
 }
 
 } // namespace DigitizerUi

--- a/src/ui/flowgraph/datasource.h
+++ b/src/ui/flowgraph/datasource.h
@@ -11,7 +11,7 @@ public:
     explicit DataSource(std::string_view name);
 
     void        processData() final;
-    static void registerBlockType(FlowGraph *fg);
+    static void registerBlockType();
 
 private:
     std::vector<float> m_data;

--- a/src/ui/flowgraph/remotedatasource.cpp
+++ b/src/ui/flowgraph/remotedatasource.cpp
@@ -127,6 +127,7 @@ void RemoteDataSource::registerBlockType(FlowGraph *fg, std::string_view uri) {
                 return;
             }
             fg->registerRemoteSource(std::move(t), uri);
+            dashboard->addRemoteService(uri);
         });
     };
     static opencmw::client::RestClient client;
@@ -137,5 +138,6 @@ void RemoteDataSource::registerBlockType(FlowGraph *fg, std::string_view uri, st
     auto t             = std::make_unique<RemoteBlockType>(uri);
     t->outputs[0].name = std::move(signalName);
     fg->registerRemoteSource(std::move(t), uri);
+    App::instance().dashboard->addRemoteService(uri);
 }
 } // namespace DigitizerUi

--- a/src/ui/flowgraphitem.h
+++ b/src/ui/flowgraphitem.h
@@ -15,17 +15,16 @@ class FlowGraph;
 
 class FlowGraphItem {
 public:
-    FlowGraphItem(FlowGraph *fg);
+    FlowGraphItem();
     ~FlowGraphItem();
 
-    void                  draw(const ImVec2 &size);
-    void                  resetBlocksPosition();
+    void                             draw(FlowGraph *fg, const ImVec2 &size);
 
-    std::function<void()> newSinkCallback;
+    std::function<void(FlowGraph *)> newSinkCallback;
 
-    std::string           settings() const;
-    void                  setSettings(const std::string &settings);
-    void                  clear();
+    std::string                      settings(FlowGraph *fg) const;
+    void                             setSettings(FlowGraph *fg, const std::string &settings);
+    void                             clear();
 
 private:
     enum class Alignment {
@@ -34,24 +33,29 @@ private:
     };
 
     void                          addBlock(const Block &b, std::optional<ImVec2> nodePos = {}, Alignment alignment = Alignment::Left);
-    void                          drawNewBlockDialog();
-    void                          drawAddSourceDialog();
+    void                          drawNewBlockDialog(FlowGraph *fg);
+    void                          drawAddSourceDialog(FlowGraph *fg);
 
-    FlowGraph                    *m_flowGraph;
     Block                        *m_selectedBlock = nullptr;
     std::vector<Block::Parameter> m_parameters;
     BlockType                    *m_selectedBlockType = nullptr;
     ImVec2                        m_mouseDrag         = { 0, 0 };
     bool                          m_createNewBlock    = false;
     ImVec2                        m_contextMenuPosition;
-    ax::NodeEditor::Config        m_config;
-    std::string                   m_settings;
     bool                          m_addRemoteSignal             = false;
     bool                          m_addRemoteSignalDialogOpened = false;
     std::string                   m_addRemoteSignalUri;
 
     // new block dialog data
     const Block *m_filterBlock = nullptr;
+    struct Context {
+        Context();
+
+        ax::NodeEditor::EditorContext *editor = nullptr;
+        ax::NodeEditor::Config         config;
+        std::string                    settings;
+    };
+    std::unordered_map<FlowGraph *, Context> m_editors;
 };
 
 } // namespace DigitizerUi


### PR DESCRIPTION
This builds on top of #60. It adds support for remote flowgraphs: when a remote signal is added a new tab appears that shows the flowgraph of that service. A save button appears at the top right of the tabbar to send changes to the server.

![pic4](https://github.com/fair-acc/opendigitizer/assets/680260/7cbc865f-4234-4bcc-a688-3292d9c9efdf)
