### PR TITLE
Enhancements for UI Rendering and Font Scaling

### DIFF
--- a/src/ui/app.h
+++ b/src/ui/app.h
@@ -41,9 +41,12 @@ public:
     SDLState                  *sdlState;
     bool                       running    = true;
 
+    float                      defaultDPI= 76.2f;
+    float                      verticalDPI= defaultDPI;
     ImFont                    *fontNormal = nullptr;
     ImFont                    *fontBig    = nullptr;
     ImFont                    *fontBigger = nullptr;
+    ImFont                    *fontLarge  = nullptr;
     ImFont                    *fontIcons;
     ImFont                    *fontIconsSolid;
 

--- a/src/ui/app.h
+++ b/src/ui/app.h
@@ -39,14 +39,16 @@ public:
     std::unique_ptr<Dashboard> dashboard;
     OpenDashboardPage          openDashboardPage;
     SDLState                  *sdlState;
-    bool                       running    = true;
+    bool                       running       = true;
 
-    float                      defaultDPI= 76.2f;
-    float                      verticalDPI= defaultDPI;
-    ImFont                    *fontNormal = nullptr;
-    ImFont                    *fontBig    = nullptr;
-    ImFont                    *fontBigger = nullptr;
-    ImFont                    *fontLarge  = nullptr;
+    bool                       prototypeMode = true;
+    std::chrono::milliseconds  execTime; /// time it took to handle events and draw one frame
+    float                      defaultDPI  = 76.2f;
+    float                      verticalDPI = defaultDPI;
+    std::array<ImFont *, 2>    fontNormal  = { nullptr, nullptr }; /// default font [0] production [1] prototype use
+    std::array<ImFont *, 2>    fontBig     = { nullptr, nullptr }; /// 0: production 1: prototype use
+    std::array<ImFont *, 2>    fontBigger  = { nullptr, nullptr }; /// 0: production 1: prototype use
+    std::array<ImFont *, 2>    fontLarge   = { nullptr, nullptr }; /// 0: production 1: prototype use
     ImFont                    *fontIcons;
     ImFont                    *fontIconsSolid;
 

--- a/src/ui/app_header/fair_header.h
+++ b/src/ui/app_header/fair_header.h
@@ -89,7 +89,7 @@ void draw_header_bar(std::string_view title, ImFont *title_font, Style style) {
     using namespace detail;
     // localtime
     const auto clock         = std::chrono::system_clock::now();
-    const auto utcClock      = fmt::format("{:%Y-%m-%d %H:%M:%S (UTC%z)}", clock);
+    const auto utcClock      = fmt::format("{:%Y-%m-%d %H:%M:%S (LOC)}", clock);
     const auto utcStringSize = ImGui::CalcTextSize(utcClock.c_str());
 
     const auto topLeft       = ImGui::GetCursorPos();
@@ -114,8 +114,7 @@ void draw_header_bar(std::string_view title, ImFont *title_font, Style style) {
     utctime.resize(32);
     pos.y += ImGui::GetTextLineHeightWithSpacing();
     ImGui::SetCursorPos(pos);
-    const auto len = strftime(utctime.data(), utctime.size(), "%H:%M:%S (UTC%z)", gmtime(&utc));
-    // ImGui::SetCursorPosY(ImGui::GetCursorPosY() - ImGui::GetTextLineHeight() - ImGui::GetStyle().ItemSpacing.y);
+    const auto len = strftime(utctime.data(), utctime.size(), "%H:%M:%S (UTC)", gmtime(&utc));
     TextRight(std::string_view(utctime.data(), len));
 
     // draw fair logo

--- a/src/ui/app_header/fair_header.h
+++ b/src/ui/app_header/fair_header.h
@@ -119,7 +119,8 @@ void draw_header_bar(std::string_view title, ImFont *title_font, Style style) {
 
     // draw fair logo
     ImGui::SetCursorPos(topLeft);
-    ImGui::Image((void *) (intptr_t) (style == Style::Light ? img_fair_tex : img_fair_tex_dark), ImVec2(img_fair_w / 2, img_fair_h / 2));
+    const auto scale = titleSize.y/img_fair_h;
+    ImGui::Image((void *) (intptr_t) (style == Style::Light ? img_fair_tex : img_fair_tex_dark), ImVec2(scale * img_fair_w, scale * img_fair_h));
 }
 
 } // namespace app_header

--- a/src/ui/app_header/fair_header.h
+++ b/src/ui/app_header/fair_header.h
@@ -119,7 +119,7 @@ void draw_header_bar(std::string_view title, ImFont *title_font, Style style) {
 
     // draw fair logo
     ImGui::SetCursorPos(topLeft);
-    const auto scale = titleSize.y/img_fair_h;
+    const auto scale = titleSize.y / img_fair_h;
     ImGui::Image((void *) (intptr_t) (style == Style::Light ? img_fair_tex : img_fair_tex_dark), ImVec2(scale * img_fair_w, scale * img_fair_h));
 }
 

--- a/src/ui/dashboard.h
+++ b/src/ui/dashboard.h
@@ -75,8 +75,9 @@ public:
         std::vector<Source *> sources;
         struct AxisData {
             Axis   axis;
-            double min;
-            double max;
+            float min;
+            float max;
+            float width = 1e99;
         };
         std::vector<AxisData> axes;
 

--- a/src/ui/dashboard.h
+++ b/src/ui/dashboard.h
@@ -74,7 +74,7 @@ public:
         std::string           name;
         std::vector<Source *> sources;
         struct AxisData {
-            Axis   axis;
+            Axis  axis;
             float min;
             float max;
             float width = 1e99;

--- a/src/ui/dashboardpage.cpp
+++ b/src/ui/dashboardpage.cpp
@@ -466,12 +466,11 @@ void DashboardPage::draw(App *app, Dashboard *dashboard, Mode mode) noexcept {
         // add new signal
     }
 
-    if (true /* TODO debug flag*/) {
+    if (app->prototypeMode) {
         // Retrieve FPS and milliseconds per iteration
-        const float fps       = ImGui::GetIO().Framerate;
-        const float deltaTime = 1000.0f * ImGui::GetIO().DeltaTime;
-        const auto  str       = fmt::format("FPS:{:5.0f}({:4.1f}ms)", fps, deltaTime);
-        const auto  estSize   = ImGui::CalcTextSize(str.c_str());
+        const float fps     = ImGui::GetIO().Framerate;
+        const auto  str     = fmt::format("FPS:{:5.0f}({:2}ms)", fps, app->execTime.count());
+        const auto  estSize = ImGui::CalcTextSize(str.c_str());
         alignForWidth(estSize.x, 1.0);
         ImGui::Text("%s", str.c_str());
     }
@@ -524,7 +523,7 @@ void DashboardPage::drawLegend(App *app, Dashboard *dashboard, const DashboardPa
         if (const auto nextSignal = std::next(iter, 1); nextSignal != dashboard->sources().cend()) {
             const auto widthEstimate = ImGui::CalcTextSize(nextSignal->name.c_str()).x + 20 /* icon width */;
             if ((_legendBox.x + widthEstimate) < 0.9f * _paneSize.x) {
-                ImGui::SameLine();  // keep item on the same line if compatible with overall pane width
+                ImGui::SameLine(); // keep item on the same line if compatible with overall pane width
             } else {
                 _legendBox.x = 0.f; // start a new line
             }

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -41,35 +41,39 @@ struct SDLState {
 static void main_loop(void *);
 
 static void loadFonts(DigitizerUi::App &app) {
-    auto         fs   = cmrc::ui_assets::get_filesystem();
-    auto         file = fs.open("assets/xkcd/xkcd-script.ttf");
+    auto loadDefaultFont = [&app](auto file, std::size_t index) {
+        ImFontConfig config;
+        // high oversample to have better looking text when zooming in on the flowgraph
+        config.OversampleH          = 4;
+        config.OversampleV          = 4;
+        config.PixelSnapH           = true;
+        config.FontDataOwnedByAtlas = false;
 
-    ImFontConfig config;
-    // high oversample to have better looking text when zooming in on the flowgraph
-    config.OversampleH          = 4;
-    config.OversampleV          = 4;
-    config.PixelSnapH           = true;
-    config.FontDataOwnedByAtlas = false;
+        ImGuiIO   &io               = ImGui::GetIO();
+        const auto fontSize         = [&app]() -> std::array<float, 4> {
+            const float scalingFactor = app.verticalDPI - app.defaultDPI;
+            if (std::abs(app.verticalDPI - app.defaultDPI) < 8.f) {
+                return { 20, 24, 28, 46 }; // 28" monitor
+            } else if (app.verticalDPI > 200) {
+                return { 16, 22, 23, 38 }; // likely mobile monitor
+            } else if (std::abs(app.defaultDPI - app.verticalDPI) >= 8.f) {
+                return { 22, 26, 30, 46 }; // likely large fixed display monitor
+            }
+            return { 18, 24, 26, 46 }; // default
+        }();
 
-    ImGuiIO   &io               = ImGui::GetIO();
-    const auto fontSize         = [&app]() -> std::array<float, 4> {
-        const float scalingFactor = app.verticalDPI - app.defaultDPI;
-        if (std::abs(app.verticalDPI - app.defaultDPI) < 8.f) {
-            return { 20, 24, 28, 46 }; // 28" monitor
-        } else if (app.verticalDPI > 200) {
-            return { 16, 22, 23, 38 }; // likely mobile monitor
-        } else if (std::abs(app.defaultDPI - app.verticalDPI) >= 8.f) {
-            return { 22, 26, 30, 46 }; // likely large fixed display monitor
-        }
-        return { 18, 24, 26, 46 };     // default
-    }();
+        app.fontNormal[index] = io.Fonts->AddFontFromMemoryTTF(const_cast<char *>(file.begin()), file.size(), fontSize[0], &config);
+        app.fontBig[index]    = io.Fonts->AddFontFromMemoryTTF(const_cast<char *>(file.begin()), file.size(), fontSize[1], &config);
+        app.fontBigger[index] = io.Fonts->AddFontFromMemoryTTF(const_cast<char *>(file.begin()), file.size(), fontSize[2], &config);
+        app.fontLarge[index]  = io.Fonts->AddFontFromMemoryTTF(const_cast<char *>(file.begin()), file.size(), fontSize[3], &config);
+    };
 
-    app.fontNormal     = io.Fonts->AddFontFromMemoryTTF(const_cast<char *>(file.begin()), file.size(), fontSize[0], &config);
-    app.fontBig        = io.Fonts->AddFontFromMemoryTTF(const_cast<char *>(file.begin()), file.size(), fontSize[1], &config);
-    app.fontBigger     = io.Fonts->AddFontFromMemoryTTF(const_cast<char *>(file.begin()), file.size(), fontSize[2], &config);
-    app.fontLarge      = io.Fonts->AddFontFromMemoryTTF(const_cast<char *>(file.begin()), file.size(), fontSize[3], &config);
+    loadDefaultFont(cmrc::fonts::get_filesystem().open("Roboto-Medium.ttf"), 0);
+    loadDefaultFont(cmrc::ui_assets::get_filesystem().open("assets/xkcd/xkcd-script.ttf"), 1);
+    ImGui::GetIO().FontDefault = app.fontNormal[app.prototypeMode];
 
-    auto loadIconsFont = [&](auto name) {
+    auto loadIconsFont         = [](auto name) {
+        ImGuiIO             &io            = ImGui::GetIO();
         static const ImWchar glyphRanges[] = {
             0xf005, 0xf2ed, // 0xf005 is "", 0xf2ed is "trash can"
             0xf055, 0x2b,   // circle-plus, plus
@@ -226,9 +230,9 @@ int main(int argc, char **argv) {
 }
 
 static void main_loop(void *arg) {
-    DigitizerUi::App *app = static_cast<DigitizerUi::App *>(arg);
-
-    ImGuiIO          &io  = ImGui::GetIO();
+    const auto        startLoop = std::chrono::high_resolution_clock::now();
+    DigitizerUi::App *app       = static_cast<DigitizerUi::App *>(arg);
+    ImGuiIO          &io        = ImGui::GetIO();
 
     app->fireCallbacks();
 
@@ -254,7 +258,7 @@ static void main_loop(void *arg) {
     ImGui::SetNextWindowSize({ float(width), float(height) });
     ImGui::Begin("Main Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus);
 
-    app_header::draw_header_bar("OpenDigitizer", app->fontLarge,
+    app_header::draw_header_bar("OpenDigitizer", app->fontLarge[app->prototypeMode],
             app->style() == DigitizerUi::Style::Light ? app_header::Style::Light : app_header::Style::Dark);
 
     const bool dashboardLoaded = app->dashboard != nullptr;
@@ -330,18 +334,48 @@ static void main_loop(void *arg) {
         }
     }
 
-    ImGui::SetCursorPos(pos + ImVec2(width - 50, 0));
+    ImGui::SetCursorPos(pos + ImVec2(width - 75, 0));
+    ImGui::PushFont(app->fontIcons);
+    if (app->prototypeMode) {
+        if (ImGui::Button("")) {
+            app->prototypeMode         = false;
+            ImGui::GetIO().FontDefault = app->fontNormal[app->prototypeMode];
+        }
+        ImGui::PopFont();
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("switch to production mode");
+        }
+    } else {
+        if (ImGui::Button("")) {
+            app->prototypeMode         = true;
+            ImGui::GetIO().FontDefault = app->fontNormal[app->prototypeMode];
+        }
+        ImGui::PopFont();
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("switch to prototype mode");
+        }
+    }
+    ImGui::SameLine();
     ImGui::PushFont(app->fontIcons);
     if (app->style() == DigitizerUi::Style::Light) {
         if (ImGui::Button("")) {
             app->setStyle(DigitizerUi::Style::Dark);
         }
+        ImGui::PopFont();
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("switch to dark mode");
+        }
     } else if (app->style() == DigitizerUi::Style::Dark) {
         if (ImGui::Button("")) {
             app->setStyle(DigitizerUi::Style::Light);
         }
+        ImGui::PopFont();
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("switch to light mode");
+        }
+    } else {
+        ImGui::PopFont();
     }
-    ImGui::PopFont();
 
     ImGui::End();
 
@@ -352,5 +386,8 @@ static void main_loop(void *arg) {
     glClearColor(1, 1, 1, 1);
     glClear(GL_COLOR_BUFFER_BIT);
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+
+    const auto stopLoop = std::chrono::high_resolution_clock::now();
+    app->execTime       = std::chrono::duration_cast<std::chrono::milliseconds>(stopLoop - startLoop);
     SDL_GL_SwapWindow(app->sdlState->window);
 }

--- a/src/ui/opendashboardpage.cpp
+++ b/src/ui/opendashboardpage.cpp
@@ -109,7 +109,7 @@ void OpenDashboardPage::unsubscribeSource(const std::shared_ptr<DashboardSource>
 
 void OpenDashboardPage::draw(App *app) {
     ImGui::Spacing();
-    ImGui::PushFont(app->fontBigger);
+    ImGui::PushFont(app->fontBigger[app->prototypeMode]);
     if (app->dashboard) {
         auto desc = app->dashboard->description();
         ImGui::Text("%s (%s)", desc->name.c_str(), desc->source->path.c_str());
@@ -196,7 +196,7 @@ void OpenDashboardPage::draw(App *app) {
     }
 
     ImGui::Dummy({ 0, 30 });
-    ImGui::PushFont(app->fontBigger);
+    ImGui::PushFont(app->fontBigger[app->prototypeMode]);
     ImGui::TextUnformatted("New Digitizer Window");
     ImGui::PopFont();
     ImGui::Dummy({ indent, 00 });
@@ -206,7 +206,7 @@ void OpenDashboardPage::draw(App *app) {
     }
 
     ImGui::Dummy({ 0, 30 });
-    ImGui::PushFont(app->fontBigger);
+    ImGui::PushFont(app->fontBigger[app->prototypeMode]);
     ImGui::TextUnformatted("Load a new Dashboard");
     ImGui::PopFont();
     ImGui::Spacing();
@@ -248,7 +248,7 @@ void OpenDashboardPage::draw(App *app) {
         auto  pos  = ImGui::GetCursorPos();
         auto  size = ImGui::GetContentRegionAvail();
         float h    = ImGui::GetTextLineHeightWithSpacing() * 2;
-        ImGui::PushFont(app->fontBig);
+        ImGui::PushFont(app->fontBig[app->prototypeMode]);
         h += ImGui::GetTextLineHeightWithSpacing();
 
         auto  pp       = ImGui::GetCursorScreenPos();


### PR DESCRIPTION
This PR includes several updates aimed at improving the user interface and performance metrics:

  * explicit 'prototype mode': a global switch, coupled with an illustrative button, has been incorporated to activate/deactivate additional metrics. In line with this, an XKCD-style font was adopted to signify the application's state of being in 'prototype mode', which, among other things, shall indicate some WIP status in contrast to 'production quality' views.
 * rendering time start/stop metric: Unlike FPS figures representing a target or achieved global repetition rate (typically locked at around 30 or 60 FPS), the added rendering time metric indicates the duration required for the actual frame computation. Note: This duration should ideally be much less than 1/60s or <16 ms.
 * shortened/simplified the header timestamp to help a cleaner, less cluttered user interface.
 * added font scaling based on the screen DPI to allow for fine adjustments for mobile, desktop and fixed-display scenarios.
 * limited axis title size to prevent oversized labels from disrupting the chart layout.
 
_N.B. for one of the next follow-up PRs the button/tabbed title, buttons and (optional) header should be rationalised. As an idea, maybe similar to the chart delete buttons that @giucam introduced for the chart themselves and that only appear while hovering over the given chart._ :thinking:
 
Some examples (WASM, mobile, prototype(light)/production(dark)-mode):

![image](https://github.com/fair-acc/opendigitizer/assets/46007894/e678df1d-f9ae-4328-812a-050479a8feb4)

![image](https://github.com/fair-acc/opendigitizer/assets/46007894/529baa89-54ef-4580-a545-eb308696a554) ![image](https://github.com/fair-acc/opendigitizer/assets/46007894/780a207d-d33e-44a0-ad9f-ecd66d9aebf4)

