### PR TITLE
Implement a side panel with block controls

### DIFF
--- a/src/service/acquisition/test/acqWorker_test.cpp
+++ b/src/service/acquisition/test/acqWorker_test.cpp
@@ -72,7 +72,7 @@ const boost::ut::suite basic_acq_worker_tests = [] {
 
         client.unsubscribe(URI("mds://127.0.0.1:12345/DeviceName/Acquisition?channelNameFilter=saw"));
         client.unsubscribe(URI("mds://127.0.0.1:12345/DeviceName/Acquisition"));
-        fmt::print("received client updates: {} for 'A' and {} for 'A,B'\n", receivedA, receivedAB);
+        fmt::print("received client updates: {} for 'A' and {} for 'A,B'\n", receivedA.load(), receivedAB.load());
         expect(int(receivedA) >= 2_i);
         expect(int(receivedAB) >= 2_i);
         client.stop();

--- a/src/service/main.cpp
+++ b/src/service/main.cpp
@@ -81,7 +81,7 @@ int main() {
 
     client.unsubscribe(URI("mds://127.0.0.1:12345/DeviceName/Acquisition?channelNameFilter=saw"));
     client.unsubscribe(URI("mds://127.0.0.1:12345/DeviceName/Acquisition"));
-    fmt::print("received client updates: {} for 'sine' and {} for 'sine,saw'\n", receivedA, receivedAB);
+    fmt::print("received client updates: {} for 'sine' and {} for 'sine,saw'\n", receivedA.load(), receivedAB.load());
     client.stop();
 
     // shutdown

--- a/src/ui/app.h
+++ b/src/ui/app.h
@@ -51,6 +51,7 @@ public:
     std::array<ImFont *, 2>    fontLarge   = { nullptr, nullptr }; /// 0: production 1: prototype use
     ImFont                    *fontIcons;
     ImFont                    *fontIconsSolid;
+    std::chrono::seconds       editPaneCloseDelay{ 15 };
 
 private:
     App();

--- a/src/ui/app_header/fair_header.h
+++ b/src/ui/app_header/fair_header.h
@@ -89,7 +89,7 @@ void draw_header_bar(std::string_view title, ImFont *title_font, Style style) {
     using namespace detail;
     // localtime
     const auto clock         = std::chrono::system_clock::now();
-    const auto utcClock      = fmt::format("{:%Y-%m-%d %H:%M:%S (LOC)}", clock);
+    const auto utcClock      = fmt::format("{:%Y-%m-%d %H:%M:%S (LOC)}", std::chrono::round<std::chrono::seconds>(clock));
     const auto utcStringSize = ImGui::CalcTextSize(utcClock.c_str());
 
     const auto topLeft       = ImGui::GetCursorPos();

--- a/src/ui/assets/sampleDashboards/DemoDashboard.yml
+++ b/src/ui/assets/sampleDashboards/DemoDashboard.yml
@@ -7,12 +7,12 @@ sources:
     block: sine source 3
     port: 0
     color: 4281939916
-  - name: source for sink 1.out
-    block: source for sink 1
+  - name: sink 1
+    block: sink 1
     port: 0
     color: 4281816053
-  - name: source for sink 2.out
-    block: source for sink 2
+  - name: sink 2
+    block: sink 2
     port: 0
     color: 4284689254
 plots:
@@ -41,7 +41,7 @@ plots:
         min: 0.0003612833097577095
         max: 0.78648322820663452
     sources:
-      - source for sink 2.out
+      - sink 2
     rect:
       - 0
       - 8
@@ -56,7 +56,7 @@ plots:
         min: -1.991981029510498
         max: 1.9978399276733398
     sources:
-      - source for sink 1.out
+      - sink 1
     rect:
       - 8
       - 0

--- a/src/ui/assets/sampleDashboards/ExtendedDemoDashboard.yml
+++ b/src/ui/assets/sampleDashboards/ExtendedDemoDashboard.yml
@@ -15,12 +15,12 @@ sources:
     block: sine source 6
     port: 0
     color: 4285336815
-  - name: source for sink 1.out
-    block: source for sink 1
+  - name: sink 1
+    block: sink 1
     port: 0
     color: 4285977777
-  - name: source for sink 2.out
-    block: source for sink 2
+  - name: sink 2
+    block: sink 2
     port: 0
     color: 4286162635
 plots:
@@ -48,7 +48,7 @@ plots:
         min: -3.2323789596557617
         max: 3.2323942184448242
     sources:
-      - source for sink 1.out
+      - sink 1
     rect:
       - 8
       - 0
@@ -78,7 +78,7 @@ plots:
         min: 0
         max: 1
     sources:
-      - source for sink 2.out
+      - sink 2
     rect:
       - 8
       - 8

--- a/src/ui/dashboard.cpp
+++ b/src/ui/dashboard.cpp
@@ -222,10 +222,16 @@ Dashboard::Dashboard(const std::shared_ptr<DashboardDescription> &desc)
     m_desc->lastUsed                        = std::chrono::floor<std::chrono::days>(std::chrono::system_clock::now());
 
     localFlowGraph.sourceBlockAddedCallback = [this](Block *b) {
+        if (dynamic_cast<DataSinkSource *>(b)) {
+            return;
+        }
         for (int i = 0; i < b->type->outputs.size(); ++i) {
             auto name = fmt::format("{}.{}", b->name, b->type->outputs[i].name);
             m_sources.insert({ b, i, name, randomColor() });
         }
+    };
+    localFlowGraph.sinkBlockAddedCallback = [this](Block *b) {
+        m_sources.insert({ b, -1, b->name, randomColor() });
     };
     localFlowGraph.blockDeletedCallback = [this](Block *b) {
         for (auto &p : m_plots) {
@@ -238,6 +244,17 @@ Dashboard::Dashboard(const std::shared_ptr<DashboardDescription> &desc)
 }
 
 Dashboard::~Dashboard() {
+}
+
+DataSink *Dashboard::createSink() {
+    int  n       = localFlowGraph.sinkBlocks().size() + 1;
+    auto name    = fmt::format("sink {}", n);
+    auto sink    = std::make_unique<DigitizerUi::DataSink>(name);
+    auto sinkptr = sink.get();
+    localFlowGraph.addSinkBlock(std::move(sink));
+    name = fmt::format("source for sink {}", n);
+    localFlowGraph.addSourceBlock(std::make_unique<DigitizerUi::DataSinkSource>(name));
+    return sinkptr;
 }
 
 void Dashboard::setNewDescription(const std::shared_ptr<DashboardDescription> &desc) {
@@ -299,11 +316,11 @@ void Dashboard::doLoad(const std::string &desc) {
         auto colorNum = color.as<uint32_t>();
 
         auto source   = std::find_if(m_sources.begin(), m_sources.end(), [&](const auto &s) {
-            return s.block->name == blockStr && s.port == portNum;
+            return s.name == nameStr;
           });
         if (source == m_sources.end()) {
             fmt::print("Unable to find the source '{}.{}'\n", blockStr, portNum);
-            return;
+            continue;
         }
 
         source->name  = nameStr;
@@ -360,6 +377,7 @@ void Dashboard::doLoad(const std::string &desc) {
             auto source = std::find_if(m_sources.begin(), m_sources.end(), [&](const auto &s) { return s.name == str; });
             if (source == m_sources.end()) {
                 fmt::print("Unable to find source {}\n", str);
+                continue;
             }
             plot.sources.push_back(&*source);
         }

--- a/src/ui/dashboard.h
+++ b/src/ui/dashboard.h
@@ -25,6 +25,7 @@ namespace DigitizerUi {
 class Block;
 class FlowGraph;
 struct DashboardDescription;
+class DataSink;
 
 struct DashboardSource {
     ~DashboardSource() noexcept;
@@ -116,6 +117,8 @@ public:
     void         saveRemoteServiceFlowgraph(Service *s);
 
     inline auto &remoteServices() { return m_services; }
+
+    DataSink    *createSink();
 
     FlowGraph    localFlowGraph;
 

--- a/src/ui/dashboardpage.h
+++ b/src/ui/dashboardpage.h
@@ -2,7 +2,9 @@
 #define DASHBOARDPAGE_H
 
 #include "grid_layout.h"
+#include "imguiutils.h"
 #include <imgui.h>
+#include <stack>
 #include <string>
 #include <vector>
 
@@ -26,7 +28,7 @@ public:
     };
 
 private:
-    ImVec2           pane_size{ 0, 0 };     // updated by draw(...)
+    ImVec2           pane_size{ 0, 0 };     // updated by drawPlots(...)
     ImVec2           legend_box{ 500, 40 }; // updated by drawLegend(...)
     GridLayout       plot_layout;
 
@@ -48,13 +50,15 @@ public:
 
 public:
     void draw(App *app, Dashboard *Dashboard, Mode mode = Mode::View) noexcept;
+    void newPlot(Dashboard *dashboard);
 
 private:
-    void        drawPlots(App *app, DigitizerUi::DashboardPage::Mode mode, Dashboard *dashboard);
-    void        drawGrid(float w, float h);
-    void        drawLegend(App *app, Dashboard *dashboard, const Mode &mode) noexcept;
-    void        newPlot(Dashboard *dashboard);
-    static void drawPlot(DigitizerUi::Dashboard::Plot &plot) noexcept;
+    void                           drawPlots(App *app, DigitizerUi::DashboardPage::Mode mode, Dashboard *dashboard);
+    void                           drawGrid(float w, float h);
+    void                           drawLegend(App *app, Dashboard *dashboard, const Mode &mode) noexcept;
+    static void                    drawPlot(DigitizerUi::Dashboard::Plot &plot) noexcept;
+
+    ImGuiUtils::BlockControlsPanel m_editPane;
 };
 
 } // namespace DigitizerUi

--- a/src/ui/flowgraph.cpp
+++ b/src/ui/flowgraph.cpp
@@ -598,6 +598,9 @@ void FlowGraph::addSourceBlock(std::unique_ptr<Block> &&block) {
 void FlowGraph::addSinkBlock(std::unique_ptr<Block> &&block) {
     block->m_flowGraph = this;
     block->update();
+    if (sinkBlockAddedCallback) {
+        sinkBlockAddedCallback(block.get());
+    }
     m_sinkBlocks.push_back(std::move(block));
 }
 
@@ -632,7 +635,7 @@ void FlowGraph::deleteBlock(Block *block) {
     }
 }
 
-void FlowGraph::connect(Block::Port *a, Block::Port *b) {
+Connection *FlowGraph::connect(Block::Port *a, Block::Port *b) {
     assert(a->kind != b->kind);
     // make sure a is the output and b the input
     if (a->kind == Block::Port::Kind::Input) {
@@ -641,6 +644,7 @@ void FlowGraph::connect(Block::Port *a, Block::Port *b) {
     auto it = m_connections.insert(Connection(a, b));
     a->connections.push_back(&(*it));
     b->connections.push_back(&(*it));
+    return &(*it);
 }
 
 void FlowGraph::disconnect(Connection *c) {

--- a/src/ui/flowgraph.h
+++ b/src/ui/flowgraph.h
@@ -201,7 +201,8 @@ public:
     const std::string             name;
     const std::string             id;
 
-protected:
+    // protected:
+    auto &inputs() { return m_inputs; }
     auto &outputs() { return m_outputs; }
 
 private:
@@ -246,7 +247,7 @@ public:
     void                         addSourceBlock(std::unique_ptr<Block> &&block);
     void                         addSinkBlock(std::unique_ptr<Block> &&block);
 
-    void                         connect(Block::Port *a, Block::Port *b);
+    Connection                  *connect(Block::Port *a, Block::Port *b);
 
     void                         disconnect(Connection *c);
 
@@ -257,6 +258,7 @@ public:
     void                         registerRemoteSource(std::unique_ptr<BlockType> &&type, std::string_view uri);
 
     std::function<void(Block *)> sourceBlockAddedCallback;
+    std::function<void(Block *)> sinkBlockAddedCallback;
     std::function<void(Block *)> blockDeletedCallback;
 
 private:

--- a/src/ui/flowgraphitem.h
+++ b/src/ui/flowgraphitem.h
@@ -58,6 +58,7 @@ private:
         std::string                    settings;
     };
     std::unordered_map<FlowGraph *, Context> m_editors;
+    ImGuiUtils::BlockControlsPanel           m_editPane;
 };
 
 } // namespace DigitizerUi

--- a/src/ui/imguiutils.cpp
+++ b/src/ui/imguiutils.cpp
@@ -1,4 +1,13 @@
 #include "imguiutils.h"
+#include "app.h"
+#include "flowgraph.h"
+
+#include <fmt/format.h>
+
+#include <imgui_internal.h>
+
+#include "app.h"
+#include "flowgraph/datasink.h"
 
 namespace ImGuiUtils {
 
@@ -24,6 +33,431 @@ DialogButton drawDialogButtons(bool okEnabled) {
         return DialogButton::Cancel;
     }
     return DialogButton::None;
+}
+
+float splitter(ImVec2 space, bool vertical, float size, float defaultRatio) {
+    auto   storage    = ImGui::GetStateStorage();
+
+    auto   ctxid      = ImGui::GetID("splitter_context");
+    float  startRatio = storage->GetFloat(ctxid, defaultRatio);
+    auto   ratioId    = ImGui::GetID("splitter_ratio");
+
+    float *ratio      = storage->GetFloatRef(ratioId, startRatio);
+    float  s          = vertical ? space.x : space.y;
+    auto   w          = s * *ratio;
+    if (vertical) {
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + s - w - size / 2.f);
+    } else {
+        ImGui::SetCursorPosY(ImGui::GetCursorPosY() + s - w - size / 2.f);
+    }
+
+    ImGui::BeginChild("##c");
+    ImGui::Button("##sep", vertical ? ImVec2{ size, space.y } : ImVec2{ space.x, size });
+
+    const auto cursor = vertical ? ImGuiMouseCursor_ResizeEW : ImGuiMouseCursor_ResizeNS;
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetMouseCursor(cursor);
+    }
+
+    if (ImGui::IsItemActive()) {
+        ImGui::SetMouseCursor(cursor);
+        const auto delta = ImGui::GetMouseDragDelta();
+        *ratio           = startRatio - (vertical ? delta.x : delta.y) / s;
+    } else {
+        storage->SetFloat(ctxid, *ratio);
+    }
+    ImGui::EndChild();
+    return *ratio;
+}
+
+void drawBlockControlsPanel(BlockControlsPanel &ctx, const ImVec2 &pos, const ImVec2 &frameSize, bool verticalLayout) {
+    using namespace DigitizerUi;
+
+    auto size = frameSize;
+    if (ctx.block) {
+        if (ctx.closeTime < std::chrono::system_clock::now()) {
+            ctx = {};
+            return;
+        }
+
+        auto &app = App::instance();
+        ImGui::PushFont(app.fontIconsSolid);
+        const float lineHeight = ImGui::GetTextLineHeightWithSpacing() * 1.5f;
+        ImGui::PopFont();
+
+        auto resetTime = [&]() {
+            ctx.closeTime = std::chrono::system_clock::now() + app.editPaneCloseDelay;
+        };
+
+        const auto itemSpacing    = ImGui::GetStyle().ItemSpacing;
+
+        auto       calcButtonSize = [&](int numButtons) -> ImVec2 {
+            if (verticalLayout) {
+                return { (size.x - float(numButtons - 1) * itemSpacing.x) / float(numButtons), lineHeight };
+            }
+            return { lineHeight, (size.y - float(numButtons - 1) * itemSpacing.y) / float(numButtons) };
+        };
+
+        ImGui::SetCursorPos(pos);
+
+        if (ImGui::BeginChildFrame(1, size, ImGuiWindowFlags_NoScrollbar)) {
+            size = ImGui::GetContentRegionAvail();
+
+            // don't close the panel while the mouse is hovering it.
+            if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
+                resetTime();
+            }
+
+            auto duration = float(std::chrono::duration_cast<std::chrono::milliseconds>(ctx.closeTime - std::chrono::system_clock::now()).count()) / float(std::chrono::duration_cast<std::chrono::milliseconds>(app.editPaneCloseDelay).count());
+            ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImGui::ColorConvertFloat4ToU32(ImGui::GetStyle().Colors[ImGuiCol_Button]));
+            ImGui::ProgressBar(1.f - duration, { size.x, 3 });
+            ImGui::PopStyleColor();
+
+            auto minpos      = ImGui::GetCursorPos();
+            size             = ImGui::GetContentRegionAvail();
+
+            int outputsCount = 0;
+            {
+                const char *prevString = verticalLayout ? "\uf062" : "\uf060";
+                for (const auto &out : ctx.block->outputs()) {
+                    outputsCount += out.connections.size();
+                }
+                if (outputsCount == 0) {
+                    ImGuiUtils::DisabledGuard dg;
+                    ImGui::PushFont(app.fontIconsSolid);
+                    ImGui::Button(prevString, calcButtonSize(1));
+                    ImGui::PopFont();
+                } else {
+                    const auto buttonSize = calcButtonSize(outputsCount);
+
+                    ImGui::BeginGroup();
+                    int id = 1;
+                    for (auto &out : ctx.block->outputs()) {
+                        for (const auto *conn : out.connections) {
+                            ImGui::PushID(id++);
+
+                            ImGui::PushFont(app.fontIconsSolid);
+                            if (ImGui::Button(prevString, buttonSize)) {
+                                ctx.block = conn->ports[1]->block;
+                            }
+                            ImGui::PopFont();
+                            if (ImGui::IsItemHovered()) {
+                                ImGui::SetTooltip("%s", conn->ports[1]->block->name.c_str());
+                            }
+                            ImGui::PopID();
+                            if (verticalLayout) {
+                                ImGui::SameLine();
+                            }
+                        }
+                    }
+                    ImGui::EndGroup();
+                }
+            }
+
+            if (!verticalLayout) {
+                ImGui::SameLine();
+            }
+
+            {
+                // Draw the two add block buttons
+                ImGui::BeginGroup();
+                const auto buttonSize = calcButtonSize(2);
+                {
+                    ImGuiUtils::DisabledGuard dg(ctx.mode != BlockControlsPanel::Mode::None || outputsCount == 0);
+                    ImGui::PushFont(app.fontIconsSolid);
+                    if (ImGui::Button("\uf055", buttonSize)) {
+                        if (outputsCount > 1) {
+                            ImGui::OpenPopup("insertBlockPopup");
+                        } else {
+                            [&]() {
+                                int index = 0;
+                                for (auto &out : ctx.block->outputs()) {
+                                    for (auto *conn : out.connections) {
+                                        ctx.insertFrom      = conn->ports[0];
+                                        ctx.insertBefore    = conn->ports[1];
+                                        ctx.breakConnection = conn;
+                                        return;
+                                    }
+                                    ++index;
+                                }
+                            }();
+                            ctx.mode = BlockControlsPanel::Mode::Insert;
+                        }
+                    }
+                    ImGui::PopFont();
+                    setItemTooltip("Insert new block before the next");
+
+                    if (ImGui::BeginPopup("insertBlockPopup")) {
+                        int index = 0;
+                        for (auto &out : ctx.block->outputs()) {
+                            for (auto *conn : out.connections) {
+                                auto text = fmt::format("Before block '{}'", conn->ports[1]->block->name);
+                                if (ImGui::Selectable(text.c_str())) {
+                                    ctx.insertBefore    = conn->ports[1];
+                                    ctx.mode            = BlockControlsPanel::Mode::Insert;
+                                    ctx.insertFrom      = conn->ports[0];
+                                    ctx.breakConnection = conn;
+                                }
+                            }
+                            ++index;
+                        }
+                        ImGui::EndPopup();
+                    }
+
+                    if (verticalLayout) {
+                        ImGui::SameLine();
+                    }
+                }
+
+                ImGui::PushFont(app.fontIconsSolid);
+                DisabledGuard dg(ctx.mode != BlockControlsPanel::Mode::None || ctx.block->outputs().empty());
+                if (ImGui::Button("\uf0fe", buttonSize)) {
+                    if (ctx.block->outputs().size() > 1) {
+                        ImGui::OpenPopup("addBlockPopup");
+                    } else {
+                        ctx.mode       = BlockControlsPanel::Mode::AddAndBranch;
+                        ctx.insertFrom = &ctx.block->outputs()[0];
+                    }
+                }
+                ImGui::PopFont();
+                setItemTooltip("Add new block");
+
+                if (ImGui::BeginPopup("addBlockPopup")) {
+                    int index = 0;
+                    for (const auto &out : ctx.block->type->outputs) {
+                        if (ImGui::Selectable(out.name.c_str())) {
+                            ctx.insertFrom = &ctx.block->outputs()[index];
+                            ctx.mode       = BlockControlsPanel::Mode::AddAndBranch;
+                        }
+                        ++index;
+                    }
+                }
+
+                ImGui::EndGroup();
+
+                if (!verticalLayout) {
+                    ImGui::SameLine();
+                }
+            }
+
+            if (ctx.mode != BlockControlsPanel::Mode::None) {
+                ImGui::BeginGroup();
+
+                auto listSize = verticalLayout ? ImVec2(size.x, 200) : ImVec2(200, size.y - ImGui::GetFrameHeightWithSpacing());
+                auto ret      = filteredListBox(
+                             "blocks", BlockType::registry().types(), [](auto &it) -> std::pair<BlockType *, std::string> {
+                            if (it.second->inputs.size() != 1 || it.second->outputs.size() != 1) {
+                                return {};
+                            }
+                            return std::pair{ it.second.get(), it.first };
+                             },
+                             listSize);
+
+                {
+                    DisabledGuard dg(!ret.has_value());
+                    if (ImGui::Button("Ok")) {
+                        BlockType  *selected = ret->first;
+                        auto        name     = fmt::format("{}({})", selected->name, ctx.block->name);
+                        auto        block    = selected->createBlock(name);
+
+                        Connection *c1;
+                        if (ctx.mode == BlockControlsPanel::Mode::Insert) {
+                            // mode Insert means that the new block should be added in between this block and the next one.
+                            // put the new block in between this block and the following one
+                            c1 = app.dashboard->localFlowGraph.connect(&block->outputs()[0], ctx.insertBefore);
+                            app.dashboard->localFlowGraph.connect(ctx.insertFrom, &block->inputs()[0]);
+                            app.dashboard->localFlowGraph.disconnect(ctx.breakConnection);
+                            ctx.breakConnection = nullptr;
+                        } else {
+                            // mode AddAndBranch means the new block should feed its data to a new sink to be also plotted together with the old one.
+                            auto *newsink = app.dashboard->createSink();
+                            c1            = app.dashboard->localFlowGraph.connect(&block->outputs()[0], &newsink->inputs()[0]);
+                            app.dashboard->localFlowGraph.connect(ctx.insertFrom, &block->inputs()[0]);
+
+                            auto source = std::find_if(app.dashboard->sources().begin(), app.dashboard->sources().end(), [&](const auto &s) {
+                                return s.block == newsink;
+                            });
+
+                            app.dashboardPage.newPlot(app.dashboard.get());
+                            app.dashboard->plots().back().sources.push_back(&*source);
+                        }
+                        ctx.block = block.get();
+
+                        app.dashboard->localFlowGraph.addBlock(std::move(block));
+                        ctx.mode = BlockControlsPanel::Mode::None;
+                    }
+                }
+                ImGui::SameLine();
+                if (ImGui::Button("Cancel")) {
+                    ctx.mode = BlockControlsPanel::Mode::None;
+                }
+
+                ImGui::EndGroup();
+
+                if (!verticalLayout) {
+                    ImGui::SameLine();
+                }
+            }
+
+            ImGui::BeginChild("Settings", verticalLayout ? ImVec2(size.x, ImGui::GetContentRegionAvail().y - lineHeight - itemSpacing.y) : ImVec2(ImGui::GetContentRegionAvail().x - lineHeight - itemSpacing.x, size.y), true,
+                    ImGuiWindowFlags_HorizontalScrollbar);
+            ImGui::TextUnformatted(ctx.block->name.c_str());
+            ImGuiUtils::blockParametersControls(ctx.block, verticalLayout);
+
+            if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
+                resetTime();
+            }
+            ImGui::EndChild();
+
+            ImGui::SetCursorPos(minpos);
+
+            // draw the button(s) that go to the previous block(s).
+            const char *nextString = verticalLayout ? "\uf063" : "\uf061";
+            ImGui::PushFont(app.fontIconsSolid);
+            if (ctx.block->inputs().empty()) {
+                auto buttonSize = calcButtonSize(1);
+                if (verticalLayout) {
+                    ImGui::SetCursorPosY(ImGui::GetContentRegionMax().y - buttonSize.y);
+                } else {
+                    ImGui::SetCursorPosX(ImGui::GetContentRegionMax().x - buttonSize.x);
+                }
+                ImGuiUtils::DisabledGuard dg;
+                ImGui::Button(nextString, buttonSize);
+            } else {
+                auto buttonSize = calcButtonSize(ctx.block->inputs().size());
+                if (verticalLayout) {
+                    ImGui::SetCursorPosY(ImGui::GetContentRegionMax().y - buttonSize.y);
+                } else {
+                    ImGui::SetCursorPosX(ImGui::GetContentRegionMax().x - buttonSize.x);
+                }
+
+                ImGui::BeginGroup();
+                int id = 1;
+                for (auto &in : ctx.block->inputs()) {
+                    ImGui::PushID(id++);
+                    ImGuiUtils::DisabledGuard dg(in.connections.empty());
+
+                    if (ImGui::Button(nextString, buttonSize)) {
+                        ctx.block = in.connections.front()->ports[0]->block;
+                    }
+                    if (ImGui::IsItemHovered()) {
+                        ImGui::PopFont();
+                        ImGui::SetTooltip("%s", in.connections.front()->ports[0]->block->name.c_str());
+                        ImGui::PushFont(app.fontIconsSolid);
+                    }
+                    ImGui::PopID();
+                    if (verticalLayout) {
+                        ImGui::SameLine();
+                    }
+                }
+                ImGui::EndGroup();
+            }
+            ImGui::PopFont();
+        }
+
+        ImGui::EndChild();
+    }
+}
+
+void blockParametersControls(DigitizerUi::Block *b, bool verticalLayout, const ImVec2 &size) {
+    const auto availableSize = ImGui::GetContentRegionAvail();
+
+    auto       storage       = ImGui::GetStateStorage();
+    ImGui::PushID("block_controls");
+
+    const auto &style     = ImGui::GetStyle();
+    const auto  indent    = style.IndentSpacing;
+    const auto  textColor = ImGui::ColorConvertFloat4ToU32(style.Colors[ImGuiCol_Text]);
+
+    for (int i = 0; i < b->type->parameters.size(); ++i) {
+        const auto &p  = b->type->parameters[i];
+
+        auto        id = ImGui::GetID(p.label.c_str());
+        ImGui::PushID(id);
+        auto *enabled = storage->GetBoolRef(id, true);
+
+        ImGui::BeginGroup();
+        const auto curpos = ImGui::GetCursorPos();
+        ImGui::SetCursorPosY(curpos.y + ImGui::GetFrameHeightWithSpacing());
+        ImGui::BeginGroup();
+
+        if (*enabled) {
+            char label[64];
+            snprintf(label, sizeof(label), "##parameter_%d", i);
+
+            if (auto *e = std::get_if<DigitizerUi::BlockType::EnumParameter>(&p.impl)) {
+                auto value = std::get<DigitizerUi::Block::EnumParameter>(b->parameters()[i]);
+
+                for (int j = 0; j < e->options.size(); ++j) {
+                    auto &opt      = e->options[j];
+
+                    bool  selected = value.optionIndex == j;
+                    if (ImGui::RadioButton(opt.c_str(), selected)) {
+                        value.optionIndex = j;
+                        b->setParameter(i, value);
+                        b->update();
+                    }
+                }
+            } else if (auto *ip = std::get_if<DigitizerUi::Block::NumberParameter<int>>(&b->parameters()[i])) {
+                int val = ip->value;
+                ImGui::SetNextItemWidth(100);
+                ImGui::DragInt(label, &val);
+                b->setParameter(i, DigitizerUi::Block::NumberParameter<int>{ val });
+                b->update();
+            } else if (auto *fp = std::get_if<DigitizerUi::Block::NumberParameter<float>>(&b->parameters()[i])) {
+                float val = fp->value;
+                ImGui::SetNextItemWidth(100);
+                ImGui::DragFloat(label, &val, 0.1f);
+                b->setParameter(i, DigitizerUi::Block::NumberParameter<float>{ val });
+                b->update();
+            } else if (auto *rp = std::get_if<DigitizerUi::Block::RawParameter>(&b->parameters()[i])) {
+                std::string val = rp->value;
+                ImGui::SetNextItemWidth(100);
+                ImGui::InputText(label, &val);
+                b->setParameter(i, DigitizerUi::Block::RawParameter{ std::move(val) });
+                b->update();
+            }
+        }
+        ImGui::EndGroup();
+        ImGui::SameLine(0, 0);
+
+        auto        width = verticalLayout ? availableSize.x : ImGui::GetCursorPosX() - curpos.x;
+        const auto *text  = *enabled || verticalLayout ? p.label.c_str() : "";
+        width             = std::max(width, indent + ImGui::CalcTextSize(text).x + style.FramePadding.x * 2);
+
+        if (*enabled) {
+            ImGui::PushStyleColor(ImGuiCol_Button, style.Colors[ImGuiCol_ButtonActive]);
+        } else {
+            ImGui::PushStyleColor(ImGuiCol_Button, style.Colors[ImGuiCol_TabUnfocusedActive]);
+        }
+
+        ImGui::SetCursorPos(curpos);
+
+        float height = !verticalLayout && !*enabled ? availableSize.y : 0.f;
+        if (ImGui::Button("##nothing", { width, height })) {
+            *enabled = !*enabled;
+        }
+        ImGui::PopStyleColor();
+
+        setItemTooltip(p.label.c_str());
+
+        ImGui::SetCursorPos(curpos + ImVec2(style.FramePadding.x, style.FramePadding.y));
+        ImGui::RenderArrow(ImGui::GetWindowDrawList(), ImGui::GetCursorScreenPos(), textColor, *enabled ? ImGuiDir_Down : ImGuiDir_Right, 1.0f);
+
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + indent);
+        if (*enabled || verticalLayout) {
+            ImGui::TextUnformatted(p.label.c_str());
+        }
+
+        ImGui::EndGroup();
+
+        if (!verticalLayout) {
+            ImGui::SameLine();
+        }
+
+        ImGui::PopID();
+    }
+    ImGui::PopID();
 }
 
 } // namespace ImGuiUtils

--- a/src/ui/imguiutils.h
+++ b/src/ui/imguiutils.h
@@ -10,6 +10,8 @@
 #include <imgui.h>
 #include <misc/cpp/imgui_stdlib.h>
 
+#include "flowgraph.h"
+
 inline ImVec2 operator+(const ImVec2 a, const ImVec2 b) {
     ImVec2 r = a;
     r.x += b.x;
@@ -23,6 +25,11 @@ inline ImVec2 operator-(const ImVec2 a, const ImVec2 b) {
     r.y -= b.y;
     return r;
 }
+
+namespace DigitizerUi {
+class Block;
+class Dashboard;
+} // namespace DigitizerUi
 
 namespace ImGuiUtils {
 
@@ -125,7 +132,7 @@ std::optional<T> filteredListBox(const char *id, const ImVec2 &size, Items &&ite
     ImGui::PushItemWidth(size.x - (ImGui::GetCursorPosX() - x));
     bool scrollToSelected = ImGui::InputText("##filterBlockType", &ctx->filterString, ImGuiInputTextFlags_CallbackCompletion, completeItemName, &cbdata);
 
-    if (ImGui::BeginListBox("##Available Block types", size)) {
+    if (ImGui::BeginListBox("##Available Block types", { size.x, size.y - (ImGui::GetCursorPosY() - y) })) {
         auto filter = [&](std::string_view name) {
             if (!ctx->filterString.empty()) {
                 auto it = std::search(name.begin(), name.end(), ctx->filterString.begin(), ctx->filterString.end(),
@@ -212,6 +219,50 @@ enum class DialogButton {
 };
 
 DialogButton drawDialogButtons(bool okEnabled = true);
+float        splitter(ImVec2 space, bool vertical, float size, float defaultRatio = 0.5);
+
+struct BlockControlsPanel {
+    DigitizerUi::Block *block = {};
+    enum class Mode {
+        None,
+        Insert,
+        AddAndBranch
+    };
+    Mode                                               mode            = Mode::None;
+    DigitizerUi::Block::Port                          *insertBefore    = nullptr;
+    DigitizerUi::Block::Port                          *insertFrom      = nullptr;
+    DigitizerUi::Connection                           *breakConnection = nullptr;
+    std::chrono::time_point<std::chrono::system_clock> closeTime;
+};
+void drawBlockControlsPanel(BlockControlsPanel &context, const ImVec2 &pos, const ImVec2 &frameSize, bool verticalLayout);
+
+void blockParametersControls(DigitizerUi::Block *b, bool verticalLayout, const ImVec2 &size = { 0.f, 0.f });
+void setItemTooltip(const char *fmt, auto &&...args) {
+    if (ImGui::IsItemHovered()) {
+        if constexpr (sizeof...(args) == 0) {
+            ImGui::SetTooltip(fmt);
+        } else {
+            ImGui::SetTooltip(fmt, std::forward<decltype(args)...>(args...));
+        }
+    }
+}
+
+struct DisabledGuard {
+    explicit inline DisabledGuard(bool disable = true)
+        : m_disabled(disable) {
+        if (m_disabled) {
+            ImGui::BeginDisabled();
+        }
+    }
+    inline ~DisabledGuard() {
+        if (m_disabled) {
+            ImGui::EndDisabled();
+        }
+    }
+
+private:
+    const bool m_disabled;
+};
 
 } // namespace ImGuiUtils
 

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -153,11 +153,7 @@ int main(int argc, char **argv) {
     app.sdlState               = &sdlState;
 
     app.fgItem.newSinkCallback = [&](DigitizerUi::FlowGraph *fg) mutable {
-        int  n    = fg->sinkBlocks().size() + 1;
-        auto name = fmt::format("sink {}", n);
-        fg->addSinkBlock(std::make_unique<DigitizerUi::DataSink>(name));
-        name = fmt::format("source for sink {}", n);
-        fg->addSourceBlock(std::make_unique<DigitizerUi::DataSinkSource>(name));
+        app.dashboard->createSink();
     };
 
     app.verticalDPI = [&app]() -> float {


### PR DESCRIPTION
Clicking on a block in the flowgraph ones a side panel with controls to change the block settings. Likewise, clicking on a data signal in a plot legend opens a similar panel where it's possible to navigate back and forth in the blocks chain, add new blocks in the chain and change blocks settings. The panels close after 15 seconds of inactivity.

This implements issue #36.

![pic4](https://github.com/fair-acc/opendigitizer/assets/680260/7cb1b07c-aa5b-49df-ad7a-c30351fc7b52)
