### PR TITLE
optional multi-touch gesture diagnostics and touch-mouse-button-2 emulation

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -29,4 +29,9 @@ restylers:
   - clang-format:
       image:
         tag: v16
-  - "*"
+  - cmake-format
+  - prettier-markdown
+  - prettier-yaml
+  - shellcheck
+  - whitespace
+  - black

--- a/src/ui/app.h
+++ b/src/ui/app.h
@@ -50,11 +50,12 @@ struct App {
     std::unique_ptr<Dashboard> dashboard;
     OpenDashboardPage          openDashboardPage;
     SDLState                  *sdlState;
-    bool                       running       = true;
-    WindowMode                 windowMode    = WindowMode::RESTORED;
-    std::string                mainViewMode  = "";
+    bool                       running          = true;
+    WindowMode                 windowMode       = WindowMode::RESTORED;
+    std::string                mainViewMode     = "";
 
-    bool                       prototypeMode = true;
+    bool                       prototypeMode    = true;
+    bool                       touchDiagnostics = false;
     std::chrono::milliseconds  execTime; /// time it took to handle events and draw one frame
     float                      defaultDPI  = 76.2f;
     float                      verticalDPI = defaultDPI;

--- a/src/ui/app_header/fair_header.h
+++ b/src/ui/app_header/fair_header.h
@@ -43,9 +43,8 @@ bool   LoadTextureFromFile(const char *filename, GLuint *out_texture, ImVec2 &te
     auto           file         = fs.open(filename);
 
     unsigned char *image_data   = stbi_load_from_memory(reinterpret_cast<const unsigned char *>(file.begin()), file.size(), &image_width, &image_height, nullptr, 4);
-    if (image_data == nullptr) {
+    if (image_data == NULL)
         return false;
-    }
 
     // Create a OpenGL texture identifier
     GLuint image_texture;
@@ -239,9 +238,26 @@ void draw_header_bar(std::string_view title, ImFont *title_font, Style style) {
                     },
                     app.fontIconsSolidBig, app.windowMode == MAXIMISED ? "restore window" : "maximise window");
             ImGui::PopStyleColor();
+        }
 
+        ImGui::PushStyleColor(ImGuiCol_Button, { .3f, .3f, 1.0f, 1.f }); // blue
+#ifdef __EMSCRIPTEN__
+        constexpr bool newLine = false;
+#else
+        constexpr bool newLine = true;
+#endif
+        rightMenu.addButton<false, newLine>(
+                "", [&app](MenuButton &button) {
+                    app.touchDiagnostics = !app.touchDiagnostics;
+                    button.font          = app.touchDiagnostics ? app.fontIconsBig : app.fontIconsSolidBig;
+                    button.toolTip       = app.touchDiagnostics ? "disable extra touch diagnostics" : "enable extra touch diagnostics";
+                },
+                app.touchDiagnostics ? app.fontIconsBig : app.fontIconsSolidBig, app.touchDiagnostics ? "disable extra touch diagnostics" : "enable extra touch diagnostics");
+        ImGui::PopStyleColor();
+
+        if (app.isDesktop) {
             ImGui::PushStyleColor(ImGuiCol_Button, { 1.f, .0f, 0.f, 1.f }); // red
-            rightMenu.addButton<false, true>(
+            rightMenu.addButton(
                     "", [&app, &rightMenu]() { fmt::print("request exit: {} \n", app.running); app.running = false; rightMenu.forceClose(); }, app.fontIconsBig, "close app");
             ImGui::PopStyleColor();
         }


### PR DESCRIPTION
... based on SDL2, this is meant for initial device testing before being integrated for drag and pinch-and-zoom gestures into ImGui and notably ImPlot. The additional diagnostics (<->via console printout and/or `chrome:://inspect`) can be enabled via context menu in the upper right corner:

![image](https://github.com/fair-acc/opendigitizer/assets/46007894/3b499e6b-417b-471d-9a18-28250262f2f0)

Example print out:
```text
detected multi-gesture event -- touchId:1 numFingers: 2 @(0.47890633,0.40000013) dDist:0.000708133 dTheta:0.0013456944
(index):40 touch -- pressed two fingers emulating mouse button two
(index):40 touch: finger motion: 2 fingerID: 0 p:1 @(0.703125,0.29642856) motion (dx,dy): (0.0015624762, 0)
(index):40 detected multi-gesture event -- touchId:1 numFingers: 2 @(0.47968757,0.40000013) dDist:0.00070858 dTheta:0.0013379459
```

Two fingers on the touchpad are interpreted as a right mouse click. This can be changed and optimised w.r.t. click-position etc. but should serve only as an example to expand upon.