### PR TITLE
CI: set restyled to use clang format 16 and not open PRs

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,51 +1,15 @@
-# Default Restyler Configuration
-#
-# All keys are optional and default as shown. All list values can also be given
-# a single value, to indicate a single-element list.
-#
-####
-
-# Do anything at all?
-enabled: true
-
-# Patterns to exclude from all Restylers
-#
-# By default, we ignore directories that are often checked-in but rarely
-# represent project code. This glob is slightly complicated to match paths
-# within directories of these names appearing at any depth.
-#
-# This behavior can be disabled in your project with:
-#
-#   exclude: []
-#
+# Default Restyler Configuration: https://github.com/restyled-io/restyler/blob/main/config/default.yaml
 exclude:
   - "**/node_modules/**/*"
   - "**/vendor/**/*"
 
-# Push the style fixes directly to the original PR
-#
-# This setting implies pull_requests: false for origin PRs, and has no effect on
-# forked PRs (since we can't push to those).
-#
-auto: false
-
-# Download remote files before restyling
-#
-# Example:
-#
-#   remote_files:
-#     - url: https://raw.github.com/.../hlint.yaml
-#       path: .hlint.yaml
-#
-# Files must be publicly accessible.
-#
 remote_files: []
 
-# Open Restyle PRs?
-pull_requests: true
+pull_requests: false # Open Restyle PRs?
+request_review: none
+labels: []
 
-# Leave comments on the original PR linking to the Restyle PR?
-comments: false
+comments: false # Leave comments on the original PR linking to the Restyle PR?
 
 # Set commit statuses on the original PR?
 statuses:
@@ -56,152 +20,13 @@ statuses:
   # Red status if we encounter errors restyling
   error: true
 
-# Request review on the Restyle PR?
-#
-# Possible values:
-#
-#   author: From the author of the original PR
-#   owner: From the owner of the repository
-#   none: Don't
-#
-# One value will apply to both origin and forked PRs, but you can also specify
-# separate values.
-#
-#   request_review:
-#     origin: author
-#     forked: owner
-#
-request_review: none
-
-# Add labels to any created Restyle PRs
-#
-# These can be used to tell other automation to avoid our PRs.
-#
-labels: []
-
-# Labels to ignore
-#
-# PRs with any of these labels will be ignored by Restyled.
-#
 ignore_labels:
   - restyled-ignore
 
-# Version of the set of Restylers to run
-#
-# This should correspond to a ref on the restyled-io/restylers repository,
-# usually it's a tag that is a date of when that set was released. You could
-# re-specify the default in your own config if you prefer to avoid update
-# surprises.
-#
-restylers_version: "20191031"
+restylers_version: stable
 
-# Restylers to run, and how
-#
-# Setting this key to null accepts the defaults of the restylers_version named
-# above, including which Restylers to run.
-#
-# Restylers can be specified in three ways:
-#
-# A string, which means to run that Restyler with all defaults
-#
-#   ---
-#   restylers:
-#     - prettier
-#
-# A single key, that is a name, and override value:
-#
-#   ---
-#   restylers:
-#     - prettier:
-#         include:
-#           - "**/*.js"
-#
-# An object with a name key
-#
-#   ---
-#   restylers:
-#     - name: prettier:
-#       include:
-#         - "**/*.js"
-#
-# All three of the above are equivalent. The latter two are useful if you want
-# to run the same Restyler multiple ways:
-#
-#   ---
-#   restylers:
-#     - name: prettier
-#       arguments: ["--one-thing"]
-#       include: ["needs-one-thing/**/*.js"]
-#
-#     - name: prettier
-#       arguments: ["--another"]
-#       include: ["needs-another/**/*.js"]
-#
-# Valid keys in the override object are:
-#
-# - enabled: true|false
-#
-#   Restylers present in the list are considered enabled and those not in the
-#   list are considered not enabled, however this key is an explicit way to
-#   disable a Restyler without removing it from the list (e.g. temporarily).
-#
-# - arguments: string or array of string
-#
-#   Any additional argument(s) to pass to the restyling command.
-#
-# - include: pattern or array of pattern
-#
-#   Pattern(s) to match files that should be Restyled.
-#
-#   NOTE: these are processed in order, so be careful you don't accidentally do
-#   something like:
-#
-#     - "!/bad-file.hs"
-#     - "**/*.hs"
-#
-#   which says to exclude bad-file.hs, then immediately re-includes it via the
-#   wildcard.
-#
-# - interpreters: interpreter or array of interpreters
-#
-#   Extension-less files will be Restyled if they match interpreter(s) given
-#   here. Valid values are sh, bash, python, and ruby.
-#
-# Less-commonly needed:
-#
-# - image: string
-#
-#   The Docker image to run. Can be anything publicly pull-able.
-#
-# - command: string or array of string
-#
-#   The command (and any required argument(s)) to perform the Restyling.
-#
-# for info see: https://github.com/restyled-io/restyler/issues/134
-# N.B. the docker image version can be controlled via PRs:
-# https://github.com/restyled-io/restylers/tree/main/clang-format
 restylers:
-  - name: clang-format
-    image: 'restyled/restyler-clang-format:13.0.1'
-    command:
-      - clang-format
-      - "-i"
-    arguments: []
-    include:
-      - "**/*.c"
-      - "**/*.cc"
-      - "**/*.cpp"
-      - "**/*.cxx"
-      - "**/*.c++"
-      - "**/*.C"
-      - "**/*.cs"
-      - "**/*.h"
-      - "**/*.hh"
-      - "**/*.hpp"
-      - "**/*.hxx"
-      - "**/*.h++"
-      - "**/*.H"
-      - "**/*.java"
-      - "**/*.js"
-      - "**/*.m"
-    interpreters: []
+  - clang-format:
+      image:
+        tag: v16
+  - "*"


### PR DESCRIPTION
This updates the restyled.io config to always use ClangFormat16.
Additionally it disables the creation of pull requests to reduce noise, as I think our contributors can manually merge the restyled branch on their end if the status check fails. Since restyled opens a new PR for each time the formatting breaks it creates a lot of noise on longstanding (draft) PRs with many iterations.