### PR TITLE
Incorporate opencmw subscription fixes

### DIFF
--- a/src/service/cmake/Dependencies.cmake
+++ b/src/service/cmake/Dependencies.cmake
@@ -1,11 +1,10 @@
 include(FetchContent)
 
 # TODO use proper releases once available
-
 FetchContent_Declare(
         opencmw-cpp
         GIT_REPOSITORY https://github.com/fair-acc/opencmw-cpp.git
-        GIT_TAG a245ee17adaa61f530d95883da38b68fb53f4de8
+        GIT_TAG 57f31a19d8998da944ec73223d7f3fba4feeb324
 )
 
 # TODO this should be a graph-prototype dependency only, as gr-digitizer blocks

--- a/src/service/gnuradio/GnuRadioWorker.hpp
+++ b/src/service/gnuradio/GnuRadioWorker.hpp
@@ -245,9 +245,6 @@ private:
     bool handleSubscriptions(std::map<PollerKey, StreamingPollerEntry> &streamingPollers, std::map<PollerKey, DataSetPollerEntry> &dataSetPollers) {
         bool pollersFinished = true;
         for (const auto &subscription : super_t::activeSubscriptions()) {
-            if (subscription.path() != serviceName.c_str()) {
-                continue;
-            }
             const auto filterIn = opencmw::query::deserialise<TimeDomainContext>(subscription.params());
             try {
                 const auto acquisitionMode = parseAcquisitionMode(filterIn.acquisitionModeFilter);
@@ -318,7 +315,7 @@ private:
 
         const auto wasFinished = pollerEntry.poller->finished.load();
         if (pollerEntry.poller->process(processData)) {
-            super_t::notify(std::string(serviceName.c_str()), context, reply);
+            super_t::notify(context, reply);
         }
         return wasFinished;
     }
@@ -401,7 +398,7 @@ private:
 
         const auto wasFinished = pollerEntry.poller->finished.load();
         while (pollerEntry.poller->process(processData, 1)) {
-            super_t::notify(std::string(serviceName.c_str()), context, reply);
+            super_t::notify(context, reply);
         }
 
         return wasFinished;
@@ -479,7 +476,7 @@ private:
             auto                 filterOut = filterIn;
             flowgraph::Flowgraph subscriptionReply;
             handleGetRequest(filterIn, filterOut, subscriptionReply);
-            super_t::notify(std::string(serviceName.c_str()), filterOut, subscriptionReply);
+            super_t::notify(filterOut, subscriptionReply);
         }
     }
 };

--- a/src/ui/cmake/Dependencies.cmake
+++ b/src/ui/cmake/Dependencies.cmake
@@ -41,9 +41,9 @@ FetchContent_Declare( # needed to load images in ImGui
 
 # TODO use proper release once available
 FetchContent_Declare(
-        opencmw-cpp
-        GIT_REPOSITORY https://github.com/fair-acc/opencmw-cpp.git
-        GIT_TAG a245ee17adaa61f530d95883da38b68fb53f4de8
+    opencmw-cpp
+    GIT_REPOSITORY https://github.com/fair-acc/opencmw-cpp.git
+    GIT_TAG 57f31a19d8998da944ec73223d7f3fba4feeb324
 )
 
 FetchContent_Declare(

--- a/src/ui/dashboard.cpp
+++ b/src/ui/dashboard.cpp
@@ -90,7 +90,7 @@ auto fetch(const std::shared_ptr<DashboardSource> &source, const std::string &na
             }();
         }
 
-        command.endpoint = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", whatStr).build();
+        command.topic    = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", whatStr).build();
 
         command.callback = [callback = std::move(cb), errCallback = std::move(errCb)](const opencmw::mdp::Message &rep) mutable {
             std::array<std::string, N> reply;
@@ -464,13 +464,13 @@ void Dashboard::save() {
         opencmw::client::Command    hcommand;
         hcommand.command = opencmw::mdp::Command::Set;
         hcommand.data.put(std::string_view(headerOut.c_str(), headerOut.size()));
-        hcommand.endpoint = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", "header").build();
+        hcommand.topic = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", "header").build();
         client.request(hcommand);
 
         opencmw::client::Command dcommand;
         dcommand.command = opencmw::mdp::Command::Set;
         dcommand.data.put(std::string_view(dashboardOut.c_str(), dashboardOut.size()));
-        dcommand.endpoint = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", "dashboard").build();
+        dcommand.topic = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", "dashboard").build();
         client.request(dcommand);
 
         opencmw::client::Command fcommand;
@@ -478,7 +478,7 @@ void Dashboard::save() {
         std::stringstream stream;
         localFlowGraph.save(stream);
         fcommand.data.put(stream.str());
-        fcommand.endpoint = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", "flowgraph").build();
+        fcommand.topic = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", "flowgraph").build();
         client.request(fcommand);
 
     } else {
@@ -538,7 +538,7 @@ void Dashboard::addRemoteService(std::string_view uri) {
 
         opencmw::client::Command command;
         command.command  = opencmw::mdp::Command::Get;
-        command.endpoint = uri;
+        command.topic    = uri;
         command.callback = [&](const opencmw::mdp::Message &rep) {
             auto             buf = rep.data;
 
@@ -558,8 +558,8 @@ void Dashboard::saveRemoteServiceFlowgraph(Service *s) {
     s->flowGraph.save(stream);
 
     opencmw::client::Command command;
-    command.command  = opencmw::mdp::Command::Set;
-    command.endpoint = opencmw::URI<>(s->uri);
+    command.command = opencmw::mdp::Command::Set;
+    command.topic   = opencmw::URI<>(s->uri);
 
     FlowgraphMessage msg;
     msg.flowgraph = std::move(stream).str();

--- a/src/ui/opendashboardpage.cpp
+++ b/src/ui/opendashboardpage.cpp
@@ -51,7 +51,7 @@ void OpenDashboardPage::addSource(std::string_view path) {
     if (path.starts_with("http://")) {
         opencmw::client::Command command;
         command.command  = opencmw::mdp::Command::Subscribe;
-        command.endpoint = opencmw::URI<opencmw::STRICT>::UriFactory().path(path).build();
+        command.topic    = opencmw::URI<opencmw::STRICT>::UriFactory().path(path).build();
 
         command.callback = [this, source](const opencmw::mdp::Message &rep) {
             if (rep.data.size() == 0) {
@@ -101,8 +101,8 @@ void OpenDashboardPage::addSource(std::string_view path) {
 void OpenDashboardPage::unsubscribeSource(const std::shared_ptr<DashboardSource> &source) {
     if (source->path.starts_with("http://")) {
         opencmw::client::Command command;
-        command.command  = opencmw::mdp::Command::Unsubscribe;
-        command.endpoint = opencmw::URI<opencmw::STRICT>::UriFactory().path(source->path).build();
+        command.command = opencmw::mdp::Command::Unsubscribe;
+        command.topic   = opencmw::URI<opencmw::STRICT>::UriFactory().path(source->path).build();
         m_restClient->request(command);
     }
 }


### PR DESCRIPTION
REST clients can now subscribe to any signal, not only those hardcoded in the service.