### PR TITLE
Testing CI build for giulio/gpintegration

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -50,7 +50,7 @@ jobs:
         git clone --depth=1 https://github.com/emscripten-core/emsdk.git
         cd emsdk
         # Download and install emscripten.
-        ./emsdk install 3.1.44 # (latest = 3.1.47 -> 21/10/2023)
+        ./emsdk install 3.1.44
         # Make "active" for the current user. (writes .emscripten file)
         ./emsdk activate 3.1.44
 

--- a/src/service/gnuradio/test/CountSource.hpp
+++ b/src/service/gnuradio/test/CountSource.hpp
@@ -80,7 +80,7 @@ struct CountSource : public gr::Block<CountSource<T>> {
         if (!_pending_tags.empty() && _pending_tags[0].index == static_cast<gr::Tag::signed_index_type>(_produced)) {
             this->output_tags()[0] = { 0, _pending_tags[0].map };
             _pending_tags.pop_front();
-            this->forward_tags();
+            this->forwardTags();
         }
 
         const auto subspan = std::span(output.begin(), output.end()).first(n);

--- a/src/service/main.cpp
+++ b/src/service/main.cpp
@@ -53,7 +53,7 @@ struct TestSource : public gr::Block<TestSource<T>> {
         if (_produced == 0 && n > 0) {
             auto &tag = this->output_tags()[0];
             tag       = { 0, { { std::string(gr::tag::SIGNAL_MIN.key()), -0.3f }, { std::string(gr::tag::SIGNAL_MAX.key()), 0.3f } } };
-            this->forward_tags();
+            this->forwardTags();
         }
 
         const auto edgeLength = static_cast<std::size_t>(sample_rate / 200.f);

--- a/src/ui/cmake/Dependencies.cmake
+++ b/src/ui/cmake/Dependencies.cmake
@@ -43,7 +43,7 @@ FetchContent_Declare( # needed to load images in ImGui
 FetchContent_Declare(
         opencmw-cpp
         GIT_REPOSITORY https://github.com/fair-acc/opencmw-cpp.git
-        GIT_TAG 4e24c35f2c7055ff9fbd8a04c38e767838ff6351
+        GIT_TAG 99ae7d22d94e60180fc881cc82c726283a3474dc
 )
 
 FetchContent_Declare(

--- a/src/ui/cmake/Dependencies.cmake
+++ b/src/ui/cmake/Dependencies.cmake
@@ -43,7 +43,7 @@ FetchContent_Declare( # needed to load images in ImGui
 FetchContent_Declare(
         opencmw-cpp
         GIT_REPOSITORY https://github.com/fair-acc/opencmw-cpp.git
-        GIT_TAG a245ee17adaa61f530d95883da38b68fb53f4de8
+        GIT_TAG 4e24c35f2c7055ff9fbd8a04c38e767838ff6351
 )
 
 FetchContent_Declare(

--- a/src/ui/remotesignalsources.h
+++ b/src/ui/remotesignalsources.h
@@ -8,7 +8,7 @@
 #include <refl.hpp>
 #include <services/dns_client.hpp>
 
-struct QueryFilterElementList;
+class QueryFilterElementList;
 
 /*     Draws a Combo box, to choose the field to filter, the filter keyword and delete button for it     */
 struct QueryFilterElement {


### PR DESCRIPTION
The initial issue with the build was that debugging build also build tests for dependencies which didn't build on this CI setup (tried several approaches to disable building of tests for deps *).

- tested different versions of emscripten
- tested whether the correct node is used

Reached a state where the build error is not a compilation error, but that the build is terminated (return error code 143)

* TODO: Make all projects we control use prefixed cmake options - instead of `option(SOME_GENERIC_NAME ...)`, we should have `option(PROJECT_NAME_SOME_GENERIC_NAME ...)`.