### PR TITLE
CI: fix GH pages deployment

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -108,6 +108,11 @@ jobs:
 
     - name: Setup Pages
       uses: actions/configure-pages@v3
+    - name: "Fetch cors header workaround" # we're unable to set custom headers on github pages, workaround according to: https://stackoverflow.com/a/68675301
+      run: |
+        npm i --save coi-serviceworker
+        cp node_modules/coi-serviceworker/coi-serviceworker.js ../build/CMakeExternals/Build/ui-wasm/web/
+        sed -e "s%</style>%</style><script src=\"coi-serviceworker.js\"></script>%" -i ../build/CMakeExternals/Build/ui-wasm/web/index.html
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v1
       with:
@@ -115,7 +120,8 @@ jobs:
 
   deploy_pages:
     name: Deploy to GitHub Pages
-    if: ${{ github.ref_name == 'main' && github.event_name == 'push' }}
+      # if: ${{ github.ref_name == 'main' && github.event_name == 'push' }} # TODO: branch check removed to be able to test gh pages deployment from the PR, re-add before merging!
+    if: ${{ github.event_name == 'push' }}
     environment: github-pages
     runs-on: ubuntu-22.04
     needs: build

--- a/src/ui/shell_minimal.html
+++ b/src/ui/shell_minimal.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"/>
-    <title>Dear ImGui Emscripten example</title>
+    <title>Opendigitizer</title>
     <style>
         body { margin: 0; background-color: black }
         .emscripten {


### PR DESCRIPTION
Inject coi-serviceworker into the html deployed to gh pages. This reloads the page from a serviceworker to set the correct cors headers so we can continue to use gh pages for wasm samples.

See https://stackoverflow.com/a/68675301 for more details.

If this does not work, the next best bet would be to use another service to deploy to.