### PR TITLE
CI: fix (github pages) emscripten build

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -50,9 +50,9 @@ jobs:
         git clone --depth=1 https://github.com/emscripten-core/emsdk.git
         cd emsdk
         # Download and install emscripten.
-        ./emsdk install 3.1.44 # (latest = 3.1.47 -> 21/10/2023)
+        ./emsdk install 3.1.51 # (2023-12-14)
         # Make "active" for the current user. (writes .emscripten file)
-        ./emsdk activate 3.1.44
+        ./emsdk activate 3.1.51
 
     - name: Install gcovr
       shell: bash
@@ -79,7 +79,6 @@ jobs:
         sudo add-apt-repository 'deb https://labs.picotech.com/rc/picoscope7/debian/ picoscope main'
         sudo apt update
         sudo apt install -y udev libusb-1.0-0-dev libps3000a libps4000a libps5000a libps6000 libps6000a || true # ignore udev errors in post install because of udev in container
-
 
     - name: Configure CMake
       shell: bash

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -9,7 +9,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         graph-prototype
         GIT_REPOSITORY https://github.com/fair-acc/graph-prototype.git
-        GIT_TAG 52f48e9c6449a88ff99807479481a8e80d7ecae4
+        GIT_TAG 953501708db91ecda21805b6e2dd8af1da50399c
 )
 
 FetchContent_Declare(

--- a/src/service/gnuradio/test/CountSource.hpp
+++ b/src/service/gnuradio/test/CountSource.hpp
@@ -80,7 +80,7 @@ struct CountSource : public gr::Block<CountSource<T>> {
         if (!_pending_tags.empty() && _pending_tags[0].index == static_cast<gr::Tag::signed_index_type>(_produced)) {
             this->output_tags()[0] = { 0, _pending_tags[0].map };
             _pending_tags.pop_front();
-            this->forward_tags();
+            this->forwardTags();
         }
 
         const auto subspan = std::span(output.begin(), output.end()).first(n);

--- a/src/service/main.cpp
+++ b/src/service/main.cpp
@@ -14,7 +14,7 @@
 // TODO instead of including and registering blocks manually here, rely on the plugin system
 #include <gnuradio-4.0/basic/common_blocks.hpp>
 #include <gnuradio-4.0/basic/function_generator.h>
-#include <gnuradio-4.0/basic/selector.hpp>
+#include <gnuradio-4.0/basic/Selector.hpp>
 
 #ifndef __EMSCRIPTEN__
 #include <Picoscope4000a.hpp>
@@ -55,7 +55,7 @@ struct TestSource : public gr::Block<TestSource<T>> {
         if (_produced == 0 && n > 0) {
             auto &tag = this->output_tags()[0];
             tag       = { 0, { { std::string(gr::tag::SIGNAL_MIN.key()), -0.3f }, { std::string(gr::tag::SIGNAL_MAX.key()), 0.3f } } };
-            this->forward_tags();
+            this->forwardTags();
         }
 
         const auto edgeLength = static_cast<std::size_t>(sample_rate / 200.f);

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -35,7 +35,7 @@ add_subdirectory(utils)
 if(EMSCRIPTEN)
   message(STATUS "Detected emscripten webassembly build")
 
-  # CAUTION: The "SHELL:" before some compile/link options has to be used to explicity tell CMake to not sum up options
+  # CAUTION: The "SHELL:" before some compile/link options has to be used to explicitly tell CMake to not sum up options
   # (e.g. -option A -option B => -option A B)(CMake default behaviour), but instead keep them separated (needed for
   # proper operation of emscripten)
   add_compile_options(
@@ -185,12 +185,5 @@ target_link_libraries(
           fftw
           vir
           pmtv)
-target_include_directories(
-  ${target_name}
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../service/acquisition # for daq_api.hpp
-          ${graph-prototype_SOURCE_DIR}/core/include
-          ${graph-prototype_SOURCE_DIR}/meta/include
-          ${graph-prototype_SOURCE_DIR}/algorithm/include
-          ${graph-prototype_SOURCE_DIR}/blocks/basic/include
-          ${graph-prototype_SOURCE_DIR}/blocks/fourier/include)
+target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../service/acquisition) # for daq_api.hpp
 target_compile_options(${target_name} PRIVATE "-Wfatal-errors")

--- a/src/ui/cmake/Dependencies.cmake
+++ b/src/ui/cmake/Dependencies.cmake
@@ -49,7 +49,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         graph-prototype
         GIT_REPOSITORY https://github.com/fair-acc/graph-prototype.git
-        GIT_TAG 52f48e9c6449a88ff99807479481a8e80d7ecae4
+        GIT_TAG 953501708db91ecda21805b6e2dd8af1da50399c
 )
 
 FetchContent_MakeAvailable(imgui implot imgui-node-editor yaml-cpp stb opencmw-cpp plf_colony graph-prototype)


### PR DESCRIPTION
Still fallout from enabling pthreads support in emscripten build. The previous PR #129 fixed the CORS Headers for github pages, but there is another problem in the used emscripten version which prevents the SDL emscripten port from initializing when threads are enabled.

See corresponding issue and linked PR:
https://github.com/emscripten-core/emscripten/issues/19921

This bumps emscripten to the latest version which should contain the fix.