### PR TITLE
GnuRadioWorker: allow replacing running graph

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -9,7 +9,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         graph-prototype
         GIT_REPOSITORY https://github.com/fair-acc/graph-prototype.git
-        GIT_TAG fb8b080767ce47789a30c226f2a2ad51b8e2430a # main as of 2024-01-31
+        GIT_TAG c9b2dd33dcfaf7ab56dc6b1c42b73f46e7dfc001 # main as of 2024-02-01
 )
 
 FetchContent_Declare(

--- a/src/service/cmake/Dependencies.cmake
+++ b/src/service/cmake/Dependencies.cmake
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
         gr-digitizers
         GIT_REPOSITORY https://github.com/fair-acc/gr-digitizers.git
-        GIT_TAG 1a09de8345d40720911049c8c2998470276a5cc9 # dev-prototype as of 2024-02-01
+        GIT_TAG aff5eae3f55eb9a9fcfbf841b08921d5530078b2 # dev-prototype as of 2024-02-01
 )
 
 FetchContent_MakeAvailable(gr-digitizers)

--- a/src/service/gnuradio/test/CountSource.hpp
+++ b/src/service/gnuradio/test/CountSource.hpp
@@ -66,7 +66,11 @@ struct CountSource : public gr::Block<CountSource<T>> {
             }
             _waiting = false;
         }
-        auto n = std::min(output.size(), static_cast<std::size_t>(n_samples) - _produced);
+        const auto samplesLeft = static_cast<std::size_t>(n_samples) - _produced;
+        if (samplesLeft == 0) {
+            this->requestStop();
+        }
+        auto n = std::min(output.size(), samplesLeft);
         // chunk data so that there's one tag max, at index 0 in the chunk
         auto tagIt = _pending_tags.begin();
         if (tagIt != _pending_tags.end()) {
@@ -91,7 +95,7 @@ struct CountSource : public gr::Block<CountSource<T>> {
         }
         output.publish(n);
         _produced += n;
-        return n > 0 ? OK : DONE;
+        return OK;
     }
 };
 

--- a/src/service/main.cpp
+++ b/src/service/main.cpp
@@ -153,7 +153,7 @@ connections:
     gr::BlockRegistry registry;
     registerTestBlocks(&registry);
     gr::PluginLoader pluginLoader(&registry, {});
-    GrAcqWorker      grAcqWorker(broker, std::chrono::milliseconds(50));
+    GrAcqWorker      grAcqWorker(broker, &pluginLoader, std::chrono::milliseconds(50));
     GrFgWorker       grFgWorker(broker, &pluginLoader, { grc, {} }, grAcqWorker);
 
     std::jthread     grAcqWorkerThread([&grAcqWorker] { grAcqWorker.run(); });

--- a/src/ui/cmake/Dependencies.cmake
+++ b/src/ui/cmake/Dependencies.cmake
@@ -49,7 +49,7 @@ FetchContent_Declare(
 FetchContent_Declare(
     graph-prototype
     GIT_REPOSITORY https://github.com/fair-acc/graph-prototype.git
-    GIT_TAG fb8b080767ce47789a30c226f2a2ad51b8e2430a # main as of 2024-01-31
+    GIT_TAG c9b2dd33dcfaf7ab56dc6b1c42b73f46e7dfc001 # main as of 2024-02-01
 )
 
 FetchContent_MakeAvailable(imgui implot imgui-node-editor yaml-cpp stb opencmw-cpp plf_colony graph-prototype)


### PR DESCRIPTION
Use a mulithreaded scheduler, and allow the abortion and replacement of the currently running graph, also when its not terminating by itself.
