### PR TITLE
Use the default number of threads for the scheduler

### DIFF
--- a/src/ui/app.h
+++ b/src/ui/app.h
@@ -74,7 +74,7 @@ struct App {
     ImFont                    *fontIconsSolidLarge;
     std::chrono::seconds       editPaneCloseDelay{ 15 };
     // The thread limit here is mainly for emscripten
-    std::shared_ptr<gr::thread_pool::BasicThreadPool> schedulerThreadPool = std::make_shared<gr::thread_pool::BasicThreadPool>("scheduler-pool", gr::thread_pool::CPU_BOUND, 2, 4);
+    std::shared_ptr<gr::thread_pool::BasicThreadPool> schedulerThreadPool = std::make_shared<gr::thread_pool::BasicThreadPool>("scheduler-pool", gr::thread_pool::CPU_BOUND, 4, 4);
 
     template<typename Graph>
     void assignScheduler(Graph &&graph) {


### PR DESCRIPTION
When using CPU_BOUND min_threads cannot be less than max_threads or else the thread pool will create min_threads threads but the scheduler will assume it will have max_threads available, so it divides the blocks in max_thread jobs, but only min_threads jobs will run.