### PR TITLE
flowgraph layouting and bug fixes

### DIFF
--- a/src/ui/dashboard.cpp
+++ b/src/ui/dashboard.cpp
@@ -250,9 +250,17 @@ DataSink *Dashboard::createSink() {
     auto sink    = std::make_unique<DigitizerUi::DataSink>(name);
     auto sinkptr = sink.get();
     localFlowGraph.addSinkBlock(std::move(sink));
-    name = fmt::format("source for sink {}", n);
-    localFlowGraph.addSourceBlock(std::make_unique<DigitizerUi::DataSinkSource>(name));
     return sinkptr;
+}
+
+DataSinkSource *Dashboard::createSource() {
+    int  n         = localFlowGraph.sourceBlocks().size() + 1;
+    auto name      = fmt::format("source {}", n);
+    auto source    = std::make_unique<DigitizerUi::DataSinkSource>(name);
+    auto sourceptr = source.get();
+    name           = fmt::format("source for sink {}", n);
+    localFlowGraph.addSourceBlock(std::move(source));
+    return sourceptr;
 }
 
 void Dashboard::setNewDescription(const std::shared_ptr<DashboardDescription> &desc) {

--- a/src/ui/dashboard.h
+++ b/src/ui/dashboard.h
@@ -26,6 +26,7 @@ class Block;
 class FlowGraph;
 struct DashboardDescription;
 class DataSink;
+class DataSinkSource;
 
 struct DashboardSource {
     ~DashboardSource() noexcept;
@@ -124,14 +125,15 @@ public:
         FlowGraph                   flowGraph;
         opencmw::client::RestClient client;
     };
-    void         addRemoteService(std::string_view uri);
-    void         saveRemoteServiceFlowgraph(Service *s);
+    void            addRemoteService(std::string_view uri);
+    void            saveRemoteServiceFlowgraph(Service *s);
 
-    inline auto &remoteServices() { return m_services; }
+    inline auto    &remoteServices() { return m_services; }
 
-    DataSink    *createSink();
+    DataSink       *createSink();
+    DataSinkSource *createSource();
 
-    FlowGraph    localFlowGraph;
+    FlowGraph       localFlowGraph;
 
 private:
     void                                  doLoad(const std::string &desc);

--- a/src/ui/flowgraph.h
+++ b/src/ui/flowgraph.h
@@ -321,7 +321,7 @@ public:
 
     virtual std::unique_ptr<gr::BlockModel> createGraphNode() = 0;
     virtual void                            setup(gr::Graph &graph) {}
-    auto                                   *graphNode() { return m_node; }
+    auto                                   *graphNode() const { return m_node; }
 
     inline FlowGraph                       *flowGraph() const { return m_flowGraph; }
     const BlockType                        *type;

--- a/src/ui/flowgraphitem.h
+++ b/src/ui/flowgraphitem.h
@@ -26,14 +26,15 @@ public:
     FlowGraphItem();
     ~FlowGraphItem();
 
-    void                             draw(FlowGraph *fg, const ImVec2 &size);
+    void                                draw(FlowGraph *fg, const ImVec2 &size);
 
-    std::function<void(FlowGraph *)> newSinkCallback;
+    std::function<Block *(FlowGraph *)> newSinkCallback;
+    std::function<Block *(FlowGraph *)> newSinkSourceCallback;
 
-    std::string                      settings(FlowGraph *fg) const;
-    void                             setSettings(FlowGraph *fg, const std::string &settings);
-    void                             clear();
-    void                             setStyle(Style style);
+    std::string                         settings(FlowGraph *fg) const;
+    void                                setSettings(FlowGraph *fg, const std::string &settings);
+    void                                clear();
+    void                                setStyle(Style style);
 
 private:
     enum class Alignment {
@@ -44,6 +45,9 @@ private:
     void                              addBlock(const Block &b, std::optional<ImVec2> nodePos = {}, Alignment alignment = Alignment::Left);
     void                              drawNewBlockDialog(FlowGraph *fg);
     void                              drawAddSourceDialog(FlowGraph *fg);
+    void                              sortNodes(FlowGraph *fg, const std::vector<const Block *> &blocks);
+    void                              arrangeUnconnectedNodes(FlowGraph *fg, const std::vector<const Block *> &blocks);
+    std::vector<const Block *>        getAllBlocks(FlowGraph *fg);
 
     QueryFilterElementList            querySignalFilters;
     SignalList                        signalList{ querySignalFilters };
@@ -56,6 +60,7 @@ private:
     bool                              m_addRemoteSignal             = false;
     bool                              m_addRemoteSignalDialogOpened = false;
     std::string                       m_addRemoteSignalUri;
+    std::vector<const Block *>        m_nodesToArrange;
 
     opencmw::service::dns::QueryEntry m_queryFilter;
 
@@ -70,6 +75,7 @@ private:
     };
     std::unordered_map<FlowGraph *, Context> m_editors;
     ImGuiUtils::BlockControlsPanel           m_editPane;
+    bool                                     m_layoutGraph{ true };
 };
 
 } // namespace DigitizerUi

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -219,7 +219,10 @@ int main(int argc, char **argv) {
     app.sdlState               = &sdlState;
 
     app.fgItem.newSinkCallback = [&](DigitizerUi::FlowGraph *) mutable {
-        app.dashboard->createSink();
+        return app.dashboard->createSink();
+    };
+    app.fgItem.newSinkSourceCallback = [&](DigitizerUi::FlowGraph *) mutable {
+        return app.dashboard->createSource();
     };
 
     app.verticalDPI = [&app]() -> float {


### PR DESCRIPTION
On load or on Context Menu Action the Flowgraph is lay out in columns depending on the topological order. Unconnected Blocks are put below, ordered Left/Center/Right depending on whether they have inputs, both or only outputs. This commit also contains a bunch of bug fixes and minor improvements.
- The Viewport of the Editor does not leave the window or scale when scaling the editor view
- EndGroups and PopID in block controls panel
- remove deprecated BeginChildFrame
- Arrows hit Pins in their center
-  the blocks filter button doesn't overlap text in bigger blocks anymore
- Text is properly rendered inside the Pins
- New Block Dialog can be opened again
- Buttons in the bottom Row
  - now align with the bottom
  - are not rendered on top of the sidebar

![image](https://github.com/fair-acc/opendigitizer/assets/57981/6308486f-0139-4bcc-9f57-a5adcfdc0fde)
![image](https://github.com/fair-acc/opendigitizer/assets/57981/c5699e44-bfef-4565-9544-595eb2161587)

