### PR TITLE
Follow-up fixes to get the build working everywhere again

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -28,10 +28,6 @@ set(GNURADIO_PREFIX
 add_subdirectory(app_header)
 add_subdirectory(utils)
 
-if(NOT TARGET digitizer_settings)
-  add_subdirectory(../utils ./common_utils)
-endif()
-
 if(EMSCRIPTEN)
   message(STATUS "Detected emscripten webassembly build")
 
@@ -140,9 +136,9 @@ if(EMSCRIPTEN)
     app
     DEPENDS ${outputFileName})
 
-  # TODO should be pulled via linking od_acquisition, but that's outside the source folder (src/ui) for the ui-wasm
-  # build
+  # TODO should be pulled via linking the targets, but they're outside the source folder (src/ui) for the ui-wasm build
   target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../acquisition) # for daq_api.hpp
+  target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include)
 
 else() # native build
 
@@ -167,6 +163,7 @@ else() # native build
             utils
             ui_assets
             sample_dashboards
+            digitizer_settings
             fonts)
   target_compile_definitions(${target_name} PRIVATE BLOCKS_DIR="${GNURADIO_PREFIX}/share/gnuradio/grc/blocks/")
 
@@ -185,7 +182,6 @@ target_link_libraries(
           gr-fourier
           fftw
           vir
-          digitizer_settings
           pmtv)
 target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../service/acquisition) # for daq_api.hpp
 target_compile_options(${target_name} PRIVATE "-Wfatal-errors")

--- a/src/ui/test/CMakeLists.txt
+++ b/src/ui/test/CMakeLists.txt
@@ -21,5 +21,8 @@ target_link_libraries(
           sample_dashboards
           client
           plf_colony)
+# workaround for getting out of source tree dependencies, should be modelled as proper targets
+target_include_directories(qa_play_stop_bar PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../acquisition) # for daq_api.hpp
+target_include_directories(qa_play_stop_bar PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/include)
 
 add_test(NAME qa_play_stop_bar COMMAND qa_play_stop_bar)

--- a/src/ui/toolbar_block.h
+++ b/src/ui/toolbar_block.h
@@ -237,7 +237,7 @@ struct LabelToolbarBlock
         this->processScheduledMessages();
         std::ignore                   = this->settings().applyStagedParameters(); // return ignored since there are no tags to be forwarded
         const gr::work::Status status = gr::work::Status::OK;                     // this->invokeWork(); // calls work(...) -> processOne(...) (all in the same thread as this 'draw()'
-        ImGui::Text(message.c_str());
+        ImGui::TextUnformatted(message.c_str());
         return status;
     }
 };


### PR DESCRIPTION
Small followup to #155 and #165.

### UI: toolbar: do not use non-const format strings

Replaces a use of ImGui::Text(<nonconst string>) which complains on
some systems for the use of a non-const format string with
ImGui::TextUnformatted, which is an easy fix since the format string
is not formatting anything here.

### CMake: remove check of defined target

Since the target was defined on subsequent cmake runs, the build
would only work for the first cmake run and not for subsequent runs.
The cmake structure will eventually need to be cleaned up properly,
this is just to get everything working again.
Since the CI only builds once and during testing I also only built once
everything seemed to work initially, sorry for the noise.

Originally the idea was that both subprojects could be built
individually from different ide projects to allow switching to wasm
easily, while the toplevel cmake should be used by non-dev uses like
CI and people who just want to build the state of the repository with
a single command.
This is not possible anymore easily with the additional subprojects
that both depend on.