### PR TITLE
Fix online demo for mobile chrome

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -107,26 +107,29 @@ jobs:
       run: cmake --build . --target opendigitizer_coverage
 
     - name: Setup Pages
-      uses: actions/configure-pages@v3
+      if: matrix.cmake-build-type == 'Release'
+      uses: actions/configure-pages@v5
     - name: "Fetch cors header workaround" # we're unable to set custom headers on github pages, workaround according to: https://stackoverflow.com/a/68675301
+      if: matrix.cmake-build-type == 'Release'
       run: |
         npm i --save coi-serviceworker
         cp node_modules/coi-serviceworker/coi-serviceworker.js ../build/CMakeExternals/Build/ui-wasm/web/
         sed -e "s%</style>%</style><script src=\"coi-serviceworker.js\"></script>%" -i ../build/CMakeExternals/Build/ui-wasm/web/index.html
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v1
+      if: matrix.cmake-build-type == 'Release'
+      uses: actions/upload-pages-artifact@v3
       with:
         path: '../build/CMakeExternals/Build/ui-wasm/web/'
 
   deploy_pages:
     name: Deploy to GitHub Pages
-    if: ${{ github.ref_name == 'main' && github.event_name == 'push' }}
+    if: ${{ (github.ref_name == 'main' || github.ref_name == 'fixOnlineDemo') && github.event_name == 'push' }}
     environment: github-pages
     runs-on: ubuntu-latest
     needs: build
     steps:
     - name: "Setup Pages"
-      uses: actions/configure-pages@v3
+      uses: actions/configure-pages@v5
     - name: "Deploy to pages"
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
I was looking into why opendigitizer was not working on android chrome. I've enabled remote debugging and the error is `WebGL: INVALID_VALUE: texImage2D: width or height out of range _glTexImage2D` so it seems that some part of the code tries to allocate texture memory too big for mobile devices. Interestingly it works with firefox on the same device.
https://github.com/mrdoob/three.js/issues/22873 describes the same symptoms, but we already have the meta tag suggested there.

## Further investigation showed

- glTexImage2D is called 3 times during the initialisation regardless of browser choice, twice with a 120x100 texture (probably the fair logo in light and dark) and once with a 4096x16384 texture
- The big texture is allocated by imgui's font atlas, which is quite huge since we render 2 different fonts in 4 sizes each, plus a handful of fontawesome gylphs in the same sizes. Additionally we use x4 font oversampling (leading to a x16 bigger font atlas) as the fonts have to be (fractionally) scaled by the flowgraph view.
- on my pc `GLctx.getParameter(GLctx.MAX_TEXTURE_SIZE)` returns 32k, on my phone it returns only 4k. This number seems to be the maximum supported texture dimension, so the height of the second one would violate that. (also that corresponds to ~270Mb ). (for comparison: the browser window is actually 432\*834, so this texture fits the whole screen more than 200 times)
- ImGUI has hardcoded limits for the font atlas size, [4k for the width](https://github.com/ocornut/imgui/blob/67cd4ead6505b3386d4ef9c713c98546e86e26ca/imgui_draw.cpp#L2931) and [23k for the height](https://github.com/ocornut/imgui/blob/67cd4ead6505b3386d4ef9c713c98546e86e26ca/imgui_draw.cpp#L2935). It then packs the glyph rectangles into the texture to determine the actual height for the texture which will be the lowest power of two which will fit all requested glyphs
- Still don't know why this is not a problem on mobile firefox, since this is only a warning maybe it's just that firefox uses only the valid parts of the returned texture or handles this case differently.

## The Solution/fix

This PR changes the oversampling to 2, which was the easiest way to significantly reduce the font-atlas size. This has the drawback of making the fonts in the flowgraph view appear a bit blurry, depending on the zoom level, which can be improved in a later change by using the biggest font there.

Testing on 2 different android devices showed that this allows chrome on android to display the wasm app again.
The font atlas with oversampling = 1 uses a 2kx2k texture, so it was even possible to stay with x2 oversampling.

## Further Work

- use the biggest available font-size for the flowgraph view
- In general the font handling could be improved to lower the memory footprint:
  - factor of 2 reduction by rebuilding the font atlas when switching between the 2 different themes, so it always contains only the used font
  - using a more sophisticated font caching system, which dynamically builds the font atlas for all used glyphs (or wait for ImGui to implement this themselves as they plan to, but this is not currently worked on)

## Janitorial

This PR also bumps the versions of various github pages related actions, which were causing deprecation warnings and depended on an old nodejs version which will probably at some point be removed from the runners.