### PR TITLE
Integrate ImGui Test Engine into the build

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -85,7 +85,7 @@ jobs:
       run: |
         $EMSDK_HOME/emsdk activate $EMSDK_VERSION
         source $EMSDK_HOME/emsdk_env.sh
-        cmake -S . -B ../build -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DEMCMAKE_COMMAND=`which emcmake`
+        cmake -S . -B ../build -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DENABLE_IMGUI_TEST_ENGINE=ON -DEMCMAKE_COMMAND=`which emcmake`
 
     - name: Build
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,24 @@ if(USE_DWARF4)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gdwarf-4")
 endif()
 
+option(OPENDIGITIZER_ENABLE_TESTING "Enable unit tests" ON)
+
+# Set proper default for ENABLE_IMGUI_TEST_ENGINE, the idea is:
+
+# * Release people shouldn't enable it by mistake, as it instrumentalizes ImGui
+# * Developers shouldn't skip it by mistake
+# * All other people should explicitly pass -DOPENDIGITIZER_ENABLE_TESTING= with their intention
+if(OPENDIGITIZER_ENABLE_TESTING)
+  enable_testing()
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(DEFAULT_ENABLE_IMGUI_TEST_ENGINE ON)
+  endif()
+else()
+  set(DEFAULT_ENABLE_IMGUI_TEST_ENGINE OFF)
+endif()
+
+option(ENABLE_IMGUI_TEST_ENGINE, "Enable ImGui Test Engine" ${DEFAULT_ENABLE_IMGUI_TEST_ENGINE})
+
 include(cmake/Dependencies.cmake)
 include(cmake/StandardProjectSettings.cmake)
 include(cmake/PreventInSourceBuilds.cmake)
@@ -71,11 +89,6 @@ if(NOT DISABLE_WASM_BUILD)
       ${CMAKE_COMMAND} -E make_directory ${ROOT_BUILD_DIR}/ui-wasm/web && ${CMAKE_COMMAND} -E copy
       ${WASM_BUILD_DIR}/web/index.html ${WASM_BUILD_DIR}/web/index.js ${WASM_BUILD_DIR}/web/index.worker.js
       ${WASM_BUILD_DIR}/web/index.wasm ${ROOT_BUILD_DIR}/ui-wasm/web)
-endif()
-
-option(OPENDIGITIZER_ENABLE_TESTING "Enable unit tests" ON)
-if(OPENDIGITIZER_ENABLE_TESTING)
-  enable_testing()
 endif()
 
 add_subdirectory(src/service)

--- a/src/ui/cmake/Dependencies.cmake
+++ b/src/ui/cmake/Dependencies.cmake
@@ -1,126 +1,104 @@
 include(FetchContent)
 
 FetchContent_Declare(
-    imgui
-    GIT_REPOSITORY  https://github.com/ocornut/imgui.git
-    GIT_TAG         v1.91.0 # latest as of 2024-08-15
-    SYSTEM
-)
+  imgui
+  GIT_REPOSITORY https://github.com/ocornut/imgui.git
+  GIT_TAG v1.91.0 # latest as of 2024-08-15
+  SYSTEM)
 
 # Enables 32 bit vertex indices for ImGui
 add_compile_definitions("ImDrawIdx=unsigned int")
 
 FetchContent_Declare(
-    implot
-    GIT_REPOSITORY  https://github.com/epezent/implot.git
-    GIT_TAG         v0.16 # latest as of 2023-12-19
-    SYSTEM
-)
+  implot
+  GIT_REPOSITORY https://github.com/epezent/implot.git
+  GIT_TAG v0.16 # latest as of 2023-12-19
+  SYSTEM)
 
 FetchContent_Declare(
-    imgui-node-editor
-    # GIT_REPOSITORY  https://github.com/thedmd/imgui-node-editor.git
-    # GIT_TAG         v0.9.3 # latest as of 2023-12-19
-
-    # Temporary until https://github.com/thedmd/imgui-node-editor/pull/291
-    # is merged
-    GIT_REPOSITORY https://github.com/ivan-cukic/wip-fork-imgui-node-editor.git
-    GIT_TAG        2e4740361b7bddb924807f6d5be64818b72bf15e
-    SYSTEM
-)
+  imgui-node-editor
+  # GIT_REPOSITORY  https://github.com/thedmd/imgui-node-editor.git GIT_TAG         v0.9.3 # latest as of 2023-12-19
+  # Temporary until https://github.com/thedmd/imgui-node-editor/pull/291 is merged
+  GIT_REPOSITORY https://github.com/ivan-cukic/wip-fork-imgui-node-editor.git
+  GIT_TAG 2e4740361b7bddb924807f6d5be64818b72bf15e
+  SYSTEM)
 
 FetchContent_Declare(
-    plf_colony
-    GIT_REPOSITORY  https://github.com/mattreecebentley/plf_colony.git
-    GIT_TAG         41e387e281b8323ca5584e79f67d632964b24bbf #v7.11
-    SYSTEM
-)
+  plf_colony
+  GIT_REPOSITORY https://github.com/mattreecebentley/plf_colony.git
+  GIT_TAG 41e387e281b8323ca5584e79f67d632964b24bbf # v7.11
+  SYSTEM)
 
-FetchContent_Declare( # needed to load images in ImGui
-    stb
-    GIT_REPOSITORY https://github.com/nothings/stb.git
-    GIT_TAG 8b5f1f37b5b75829fc72d38e7b5d4bcbf8a26d55 # master from Sep 2022
-    SYSTEM
-)
+FetchContent_Declare(
+  # needed to load images in ImGui
+  stb
+  GIT_REPOSITORY https://github.com/nothings/stb.git
+  GIT_TAG 8b5f1f37b5b75829fc72d38e7b5d4bcbf8a26d55 # master from Sep 2022
+  SYSTEM)
 
 # TODO use proper release once available
 FetchContent_Declare(
-    opencmw-cpp
-    GIT_REPOSITORY https://github.com/fair-acc/opencmw-cpp.git
-    GIT_TAG b10bf280023775a6a65cd9f6138ed004e8140dc6 # main as of 2024-10-02
-    SYSTEM
-)
+  opencmw-cpp
+  GIT_REPOSITORY https://github.com/fair-acc/opencmw-cpp.git
+  GIT_TAG b10bf280023775a6a65cd9f6138ed004e8140dc6 # main as of 2024-10-02
+  SYSTEM)
 
 FetchContent_Declare(
-    gnuradio4
-    GIT_REPOSITORY https://github.com/fair-acc/gnuradio4.git
-    GIT_TAG d2584d0afe2b9f4f952513a28a60576ed5bd6416 # main as of 2024-10-04
-    SYSTEM
-)
+  gnuradio4
+  GIT_REPOSITORY https://github.com/fair-acc/gnuradio4.git
+  GIT_TAG d2584d0afe2b9f4f952513a28a60576ed5bd6416 # main as of 2024-10-04
+  SYSTEM)
 
-FetchContent_MakeAvailable(imgui implot imgui-node-editor stb opencmw-cpp plf_colony gnuradio4)
+FetchContent_MakeAvailable(
+  imgui
+  implot
+  imgui-node-editor
+  stb
+  opencmw-cpp
+  plf_colony
+  gnuradio4)
 
-if (NOT EMSCRIPTEN)
-    find_package(SDL2 REQUIRED)
-    find_package(OpenGL REQUIRED COMPONENTS OpenGL)
-    FetchContent_Declare(
-        sdl2
-        OVERRIDE_FIND_PACKAGE
-        GIT_REPOSITORY "https://github.com/libsdl-org/SDL"
-        GIT_TAG        release-2.28.2
-        SYSTEM
-    )
-    FetchContent_MakeAvailable(sdl2)
+if(NOT EMSCRIPTEN)
+  find_package(SDL2 REQUIRED)
+  find_package(OpenGL REQUIRED COMPONENTS OpenGL)
+  FetchContent_Declare(
+    sdl2
+    OVERRIDE_FIND_PACKAGE
+    GIT_REPOSITORY "https://github.com/libsdl-org/SDL"
+    GIT_TAG release-2.28.2
+    SYSTEM)
+  FetchContent_MakeAvailable(sdl2)
 endif()
 
 # imgui and implot are not CMake Projects, so we have to define their targets manually here
 add_library(
-    imgui
-    OBJECT
-        ${imgui_SOURCE_DIR}/imgui_demo.cpp
-        ${imgui_SOURCE_DIR}/imgui_draw.cpp
-        ${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
-        ${imgui_SOURCE_DIR}/backends/imgui_impl_sdl2.cpp
-        ${imgui_SOURCE_DIR}/imgui_tables.cpp
-        ${imgui_SOURCE_DIR}/imgui_widgets.cpp
-        ${imgui_SOURCE_DIR}/imgui.cpp
-        ${imgui_SOURCE_DIR}/misc/cpp/imgui_stdlib.cpp
-)
+  imgui OBJECT
+  ${imgui_SOURCE_DIR}/imgui_demo.cpp
+  ${imgui_SOURCE_DIR}/imgui_draw.cpp
+  ${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
+  ${imgui_SOURCE_DIR}/backends/imgui_impl_sdl2.cpp
+  ${imgui_SOURCE_DIR}/imgui_tables.cpp
+  ${imgui_SOURCE_DIR}/imgui_widgets.cpp
+  ${imgui_SOURCE_DIR}/imgui.cpp
+  ${imgui_SOURCE_DIR}/misc/cpp/imgui_stdlib.cpp)
 if(NOT EMSCRIPTEN) # emscripten comes with its own sdl, for native we have to specify the dependency
-    target_link_libraries(imgui PUBLIC SDL2::SDL2  OpenGL::GL)
+  target_link_libraries(imgui PUBLIC SDL2::SDL2 OpenGL::GL)
 endif()
 
-target_include_directories(
-    imgui SYSTEM BEFORE
-    PUBLIC
-        ${imgui_SOURCE_DIR}
-        ${imgui_SOURCE_DIR}/backends
-)
+target_include_directories(imgui SYSTEM BEFORE PUBLIC ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/backends)
 
-add_library(
-    implot
-    OBJECT ${implot_SOURCE_DIR}/implot_demo.cpp ${implot_SOURCE_DIR}/implot_items.cpp ${implot_SOURCE_DIR}/implot.cpp
-)
-target_include_directories(
-    implot SYSTEM BEFORE
-    PUBLIC
-        ${implot_SOURCE_DIR}
-)
+add_library(implot OBJECT ${implot_SOURCE_DIR}/implot_demo.cpp ${implot_SOURCE_DIR}/implot_items.cpp
+                          ${implot_SOURCE_DIR}/implot.cpp)
+target_include_directories(implot SYSTEM BEFORE PUBLIC ${implot_SOURCE_DIR})
 target_link_libraries(implot PUBLIC imgui $<TARGET_OBJECTS:imgui>)
 
 add_library(
-    imgui-node-editor
-    OBJECT
-        ${imgui-node-editor_SOURCE_DIR}/imgui_node_editor.cpp
-        ${imgui-node-editor_SOURCE_DIR}/imgui_canvas.cpp
-        ${imgui-node-editor_SOURCE_DIR}/imgui_node_editor_api.cpp
-        ${imgui-node-editor_SOURCE_DIR}/crude_json.cpp
-)
-target_include_directories(
-    imgui-node-editor SYSTEM BEFORE
-    PUBLIC
-        ${imgui-node-editor_SOURCE_DIR}
-)
+  imgui-node-editor OBJECT
+  ${imgui-node-editor_SOURCE_DIR}/imgui_node_editor.cpp
+  ${imgui-node-editor_SOURCE_DIR}/imgui_canvas.cpp
+  ${imgui-node-editor_SOURCE_DIR}/imgui_node_editor_api.cpp
+  ${imgui-node-editor_SOURCE_DIR}/crude_json.cpp)
+target_include_directories(imgui-node-editor SYSTEM BEFORE PUBLIC ${imgui-node-editor_SOURCE_DIR})
 target_link_libraries(imgui-node-editor PUBLIC imgui $<TARGET_OBJECTS:imgui>)
 
 add_library(stb INTERFACE)

--- a/src/ui/components/PopupMenu.hpp
+++ b/src/ui/components/PopupMenu.hpp
@@ -11,7 +11,7 @@
 namespace DigitizerUi {
 
 namespace detail {
-inline ImVec4 lightenColor(const ImVec4 &color, float percent) {
+inline ImVec4 lightenColor(const ImVec4& color, float percent) {
     float h;
     float s;
     float v;
@@ -21,10 +21,10 @@ inline ImVec4 lightenColor(const ImVec4 &color, float percent) {
     float g;
     float b;
     ImGui::ColorConvertHSVtoRGB(h, s, v, r, g, b);
-    return { r, g, b, color.w };
+    return {r, g, b, color.w};
 }
 
-inline ImVec4 darkenColor(const ImVec4 &color, float percent) {
+inline ImVec4 darkenColor(const ImVec4& color, float percent) {
     float h;
     float s;
     float v;
@@ -34,22 +34,22 @@ inline ImVec4 darkenColor(const ImVec4 &color, float percent) {
     float g;
     float b;
     ImGui::ColorConvertHSVtoRGB(h, s, v, r, g, b);
-    return { r, g, b, color.w };
+    return {r, g, b, color.w};
 }
 } // namespace detail
 
 struct MenuButton {
-    using CallbackFun = std::variant<std::function<void()>, std::function<void(MenuButton &)>>;
-    std::string         label;
-    std::string         optionalLabel;
-    mutable float       _size;
-    CallbackFun         onClick;
-    ImFont             *font = nullptr;
-    std::string         toolTip;
-    bool                isTransparent = false;
-    bool                isNewRow      = false;
-    float               padding       = std::max(ImGui::GetStyle().FramePadding.x, ImGui::GetStyle().FramePadding.y);
-    ImVec4              buttonColor   = ImGui::GetStyleColorVec4(ImGuiCol_Button);
+    using CallbackFun = std::variant<std::function<void()>, std::function<void(MenuButton&)>>;
+    std::string   label;
+    std::string   optionalLabel;
+    mutable float _size;
+    CallbackFun   onClick;
+    ImFont*       font = nullptr;
+    std::string   toolTip;
+    bool          isTransparent = false;
+    bool          isNewRow      = false;
+    float         padding       = std::max(ImGui::GetStyle().FramePadding.x, ImGui::GetStyle().FramePadding.y);
+    ImVec4        buttonColor   = ImGui::GetStyleColorVec4(ImGuiCol_Button);
 
     [[nodiscard]] float size() const {
         IMW::Font    _(font);
@@ -71,10 +71,7 @@ struct MenuButton {
             struct ButtonStyle {
                 IMW::StyleColor normal, hover, active;
 
-                ButtonStyle(ImVec4 _normal, ImVec4 _hover, ImVec4 _active)
-                    : normal(ImGuiCol_Button, std::move(_normal))
-                    , hover(ImGuiCol_ButtonHovered, std::move(_hover))
-                    , active(ImGuiCol_ButtonActive, std::move(_active)) {}
+                ButtonStyle(ImVec4 _normal, ImVec4 _hover, ImVec4 _active) : normal(ImGuiCol_Button, std::move(_normal)), hover(ImGuiCol_ButtonHovered, std::move(_hover)), active(ImGuiCol_ButtonActive, std::move(_active)) {}
             };
 
             auto styles = [&]() -> std::optional<ButtonStyle> {
@@ -86,11 +83,12 @@ struct MenuButton {
                     buttonColorActive.w      = 1.0;
 
                     return std::make_optional<ButtonStyle>(buttonColor, buttonColorHover, buttonColorActive);
-                } else
+                } else {
                     return std::nullopt;
+                }
             }();
 
-            if (ImGui::Button(label.c_str(), ImVec2{ actualButtonSize, actualButtonSize })) {
+            if (ImGui::Button(label.c_str(), ImVec2{actualButtonSize, actualButtonSize})) {
                 isClicked = true;
             }
         }
@@ -103,11 +101,7 @@ struct MenuButton {
     }
 };
 
-enum class MenuType {
-    Radial,
-    Vertical,
-    Horizontal
-};
+enum class MenuType { Radial, Vertical, Horizontal };
 
 template<std::size_t unique_id, MenuType menuType>
 class PopupMenu {
@@ -144,7 +138,7 @@ class PopupMenu {
         float       maxButtonSize    = .0f;
         float       cumulativeLength = .0f;
         for (auto i = firstButtonIndex; i < _buttons.size(); ++i) {
-            const auto &button     = _buttons[i];
+            const auto& button     = _buttons[i];
             const float buttonSize = button.size();
             if ((cumulativeLength + buttonSize + _padding) > arcLength || (button.isNewRow && i > firstButtonIndex)) {
                 break;
@@ -153,7 +147,7 @@ class PopupMenu {
             maxButtonSize = std::max(buttonSize, maxButtonSize);
             cumulativeLength += buttonSize + _padding;
         }
-        return { buttonCount, maxButtonSize };
+        return {buttonCount, maxButtonSize};
     }
 
     void updateElementCoordinate() {
@@ -165,10 +159,7 @@ class PopupMenu {
 public:
     float frameRounding = 6.f;
 
-    explicit PopupMenu(ImVec2 menuSize = { 100, 100 }, float startAngle = 0.f, float stopAngle = 360.f, float extraRadius = 0.f, float animationSpeed = .25f, float timeOut = 0.5f)
-        : _menuSize(menuSize), _startAngle(startAngle), _stopAngle(stopAngle), _extraRadius(extraRadius), _animationSpeed(animationSpeed), _timeOut(timeOut) {
-        updateAndDraw();
-    }
+    explicit PopupMenu(ImVec2 menuSize = {100, 100}, float startAngle = 0.f, float stopAngle = 360.f, float extraRadius = 0.f, float animationSpeed = .25f, float timeOut = 0.5f) : _menuSize(menuSize), _startAngle(startAngle), _stopAngle(stopAngle), _extraRadius(extraRadius), _animationSpeed(animationSpeed), _timeOut(timeOut) { updateAndDraw(); }
 
     template<bool transparent = false, bool newRow = false>
     void addButton(std::string label, auto onClick, float buttonSize = -1.f, std::string toolTip = "") {
@@ -181,7 +172,7 @@ public:
     }
 
     template<bool transparent = false, bool newRow = false>
-    void addButton(std::string label, auto onClick, ImFont *font, std::string toolTip = "") {
+    void addButton(std::string label, auto onClick, ImFont* font, std::string toolTip = "") {
         if (_animationProgress > 0.f) { // we do not allow to add buttons when the popup is already open or animating
             return;
         }
@@ -196,9 +187,7 @@ public:
         _isOpen = true;
     }
 
-    [[nodiscard]] bool isOpen() const noexcept {
-        return _isOpen;
-    }
+    [[nodiscard]] bool isOpen() const noexcept { return _isOpen; }
 
     void forceClose() {
         _isOpen            = false;
@@ -210,22 +199,22 @@ public:
     void updateAndDraw() {
         static float timeOutOfRadius = 0.0f;
 
-        const float  deltaTime       = ImGui::GetIO().DeltaTime;
-        _animationProgress           = _isOpen ? std::min(1.0f, _animationProgress + deltaTime / _animationSpeed) : std::max(0.0f, _animationProgress - deltaTime / _animationSpeed);
+        const float deltaTime = ImGui::GetIO().DeltaTime;
+        _animationProgress    = _isOpen ? std::min(1.0f, _animationProgress + deltaTime / _animationSpeed) : std::max(0.0f, _animationProgress - deltaTime / _animationSpeed);
 
         if (!_isOpen && _animationProgress <= 0.f) {
-            _itemBoundaryBox = { { -1.f, -1.f }, { -1.f, -1.f } };
+            _itemBoundaryBox = {{-1.f, -1.f}, {-1.f, -1.f}};
             if (!_buttons.empty()) {
                 _buttons.clear();
             }
             return;
         } else if (_isOpen && (_itemBoundaryBox.Min.x <= 0.f || _itemBoundaryBox.Min.y <= 0.f || _itemBoundaryBox.Max.x <= 0.f || _itemBoundaryBox.Max.y <= 0.f)) {
-            _itemBoundaryBox = { ImGui::GetMousePos(), ImGui::GetMousePos() };
+            _itemBoundaryBox = {ImGui::GetMousePos(), ImGui::GetMousePos()};
         }
-        const ImVec2 centre      = _itemBoundaryBox.GetCenter();
+        const ImVec2 centre = _itemBoundaryBox.GetCenter();
 
-        std::size_t  nButtonRows = 1UL;
-        const float  buttonSize  = maxButtonSize();
+        std::size_t nButtonRows = 1UL;
+        const float buttonSize  = maxButtonSize();
         if (_animationProgress >= 0.0f) {
             const ImVec2 oldPos            = ImGui::GetCursorPos();
             float        requiredPopupSize = 2.f * (_extraRadius + (buttonSize + 2.f * _padding) * static_cast<float>(_buttons.size()));
@@ -268,32 +257,33 @@ public:
     }
 
 private:
-    void drawButton(MenuButton &button) {
+    void drawButton(MenuButton& button) {
         if (button.create(menuType == MenuType::Radial ? -1.f : frameRounding)) {
-            std::visit([&]<typename Arg>(Arg &&onClick) {
-                using T = std::decay_t<decltype(onClick)>;
-                if constexpr (std::is_same_v<T, std::function<void()>>) {
-                    onClick();
-                } else if constexpr (std::is_same_v<T, std::function<void(MenuButton &)>>) {
-                    onClick(button);
-                }
-            },
-                    button.onClick);
+            std::visit(
+                [&]<typename Arg>(Arg&& onClick) {
+                    using T = std::decay_t<decltype(onClick)>;
+                    if constexpr (std::is_same_v<T, std::function<void()>>) {
+                        onClick();
+                    } else if constexpr (std::is_same_v<T, std::function<void(MenuButton&)>>) {
+                        onClick(button);
+                    }
+                },
+                button.onClick);
         }
     }
 
-    [[nodiscard]] std::size_t drawButtonsOnArc(const ImVec2 &centre, float arcRadius) {
+    [[nodiscard]] std::size_t drawButtonsOnArc(const ImVec2& centre, float arcRadius) {
         std::size_t currentRow = 0UL;
         for (std::size_t buttonIndex = 0UL; buttonIndex < _buttons.size();) {
             // get the maximum number of buttons and button size for the current arc row
             const auto [maxButtonsInRow, maxButtonSizeInRow] = maxButtonNumberAndSizeForArc(arcRadius, buttonIndex);
 
-            float cumulativeAngle                            = _startAngle;
+            float cumulativeAngle = _startAngle;
             for (std::size_t buttonsInRow = 0UL; buttonIndex < _buttons.size() && buttonsInRow < maxButtonsInRow; ++buttonIndex) {
-                auto       &button     = _buttons[buttonIndex];
+                auto&       button     = _buttons[buttonIndex];
                 const float buttonSize = button.size();
                 // centre button if there is only one in the arc segment
-                const float angle    = cumulativeAngle + ((maxButtonsInRow == 1) ? 0.5f * (_stopAngle - _startAngle) : 0.5f * ((buttonSize + _padding) / arcRadius) * (180.0f / std::numbers::pi_v<float>) );
+                const float angle = cumulativeAngle + ((maxButtonsInRow == 1) ? 0.5f * (_stopAngle - _startAngle) : 0.5f * ((buttonSize + _padding) / arcRadius) * (180.0f / std::numbers::pi_v<float>));
 
                 const float angleRad = angle * _animationProgress * (std::numbers::pi_v<float> / 180.0f);
                 ImGui::SetCursorScreenPos(ImVec2(centre.x + arcRadius * std::cos(angleRad) - 0.5f * buttonSize, centre.y + arcRadius * std::sin(angleRad) - 0.5f * buttonSize));
@@ -313,10 +303,10 @@ private:
         }
 
         const float maxSize = maxButtonSize();
-        ImVec2      posBeneathMenu{ _itemBoundaryBox.Min.x, _itemBoundaryBox.Max.y + _padding };
+        ImVec2      posBeneathMenu{_itemBoundaryBox.Min.x, _itemBoundaryBox.Max.y + _padding};
 
         std::size_t nRows = 0UL;
-        for (MenuButton &button : _buttons) {
+        for (MenuButton& button : _buttons) {
             const float buttonSize = button.size();
             posBeneathMenu.x       = _itemBoundaryBox.Min.x + .5f * maxSize - .5f * buttonSize;
             ImGui::SetCursorScreenPos(posBeneathMenu);
@@ -330,7 +320,7 @@ private:
 
     float mouseInactivity() {
         static float timeSinceLastIoActivity = 0.0;
-        if (const ImGuiIO &io = ImGui::GetIO(); !_isOpen || io.MouseDelta.x != 0.0f || io.MouseDelta.y != 0.0f || ImGui::IsMouseClicked(0) || ImGui::IsMouseClicked(1)) {
+        if (const ImGuiIO& io = ImGui::GetIO(); !_isOpen || io.MouseDelta.x != 0.0f || io.MouseDelta.y != 0.0f || ImGui::IsMouseClicked(0) || ImGui::IsMouseClicked(1)) {
             timeSinceLastIoActivity = 0.f;
         } else {
             timeSinceLastIoActivity += io.DeltaTime;
@@ -343,7 +333,7 @@ bool PopupMenu<unique_id, menuType>::_isOpen = false;
 template<std::size_t unique_id, MenuType menuType>
 const std::string PopupMenu<unique_id, menuType>::_popupId = fmt::format("MenuPopup_{}", unique_id);
 template<std::size_t unique_id, MenuType menuType>
-ImRect PopupMenu<unique_id, menuType>::_itemBoundaryBox = { { -1.f, -1.f }, { -1.f, -1.f } };
+ImRect PopupMenu<unique_id, menuType>::_itemBoundaryBox = {{-1.f, -1.f}, {-1.f, -1.f}};
 template<std::size_t unique_id, MenuType menuType>
 float PopupMenu<unique_id, menuType>::_animationProgress = 0.f;
 template<std::size_t unique_id, MenuType menuType>

--- a/src/ui/components/PopupMenu.hpp
+++ b/src/ui/components/PopupMenu.hpp
@@ -2,8 +2,11 @@
 #define OPENDIGITIZER_UI_COMPONENTS_POPUP_MENU_HPP_
 
 #include <cmath>
+#include <fmt/format.h>
 #include <functional>
+#include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "../common/ImguiWrap.hpp"

--- a/src/ui/test/CMakeLists.txt
+++ b/src/ui/test/CMakeLists.txt
@@ -27,3 +27,25 @@ target_include_directories(qa_play_stop_bar PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/
 target_include_directories(qa_play_stop_bar PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/include)
 
 add_test(NAME qa_play_stop_bar COMMAND qa_play_stop_bar)
+
+if(ENABLE_IMGUI_TEST_ENGINE)
+
+  # Code shared between all tests
+  add_library(imgui_tests_common STATIC ImGuiTestApp.cpp)
+  target_link_libraries(imgui_tests_common PUBLIC fmt ut imgui-node-editor)
+
+  function(add_imgui_test NAME)
+    add_executable(${NAME} ${NAME}.cpp)
+    target_link_libraries(
+      ${NAME}
+      PRIVATE fmt
+              ut
+              imgui-node-editor
+              imgui_tests_common)
+    add_test(NAME ${NAME} COMMAND ${NAME})
+  endfunction()
+
+  add_imgui_test(qa_popup_menu)
+  target_include_directories(qa_popup_menu PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..
+                                                   ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/include)
+endif()

--- a/src/ui/test/ImGuiTestApp.cpp
+++ b/src/ui/test/ImGuiTestApp.cpp
@@ -1,0 +1,108 @@
+#include "ImGuiTestApp.hpp"
+
+#include "imgui_test_engine/imgui_te_exporters.h"
+#include "imgui_test_engine/imgui_te_internal.h"
+#include "imgui_test_engine/imgui_te_ui.h"
+#include "shared/imgui_app.h"
+
+using namespace DigitizerUi::test;
+
+ImGuiTestApp::ImGuiTestApp(const TestOptions& options) : _options(options) {}
+
+ImGuiTestApp::~ImGuiTestApp() {
+    ImGuiTestEngine_Stop(_engine);
+    _app->ShutdownBackends(_app);
+    _app->ShutdownCloseWindow(_app);
+    ImGui::DestroyContext();
+
+    ImGuiTestEngine_DestroyContext(_engine);
+
+    _app->Destroy(_app);
+}
+
+void ImGuiTestApp::initImGui() {
+    _app = ImGuiApp_ImplSdlGL3_Create();
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+
+    // Setup application. Values copied from upstream examples.
+    // If some are interesting to change, consider adding them to our TestOptions struct
+    _app->DpiAware        = false;
+    _app->SrgbFramebuffer = false;
+    _app->ClearColor      = ImVec4(0.120f, 0.120f, 0.120f, 1.000f);
+    _app->InitCreateWindow(_app, "Test", ImVec2(1600, 1000));
+    _app->InitBackends(_app);
+
+    // Setup test engine
+    _engine                           = ImGuiTestEngine_CreateContext();
+    ImGuiTestEngineIO& test_io        = ImGuiTestEngine_GetIO(_engine);
+    test_io.ConfigVerboseLevel        = ImGuiTestVerboseLevel_Info;
+    test_io.ConfigVerboseLevelOnError = ImGuiTestVerboseLevel_Debug;
+    test_io.ConfigRunSpeed            = _options.speedMode;
+    test_io.ScreenCaptureFunc         = ImGuiApp_ScreenCaptureFunc;
+    test_io.ScreenCaptureUserData     = _app;
+    test_io.ConfigLogToTTY            = true;
+    // Optional: save test output in junit-compatible XML format.
+    // test_io.ExportResultsFile = "./results.xml";
+    // test_io.ExportResultsFormat = ImGuiTestEngineExportFormat_JUnitXml;
+
+    // Start test engine
+    ImGuiTestEngine_Start(_engine, ImGui::GetCurrentContext());
+    ImGuiTestEngine_InstallDefaultCrashHandler();
+
+    registerTests();
+}
+
+bool ImGuiTestApp::runTests() {
+    initImGui();
+
+    bool aborted = false;
+
+    if (!_options.useInteractiveMode) {
+        // In non-interactive mode we queue the tests immediately, while in interactive mode
+        // the user will click the "run" button
+        ImGuiTestEngine_QueueTests(engine(), ImGuiTestGroup_Tests);
+    }
+
+    while (!aborted) {
+        if (!_app->NewFrame(_app)) {
+            aborted = true;
+        }
+
+        if (_app->Quit) {
+            aborted = true;
+        }
+
+        if (!_options.useInteractiveMode && ImGuiTestEngine_IsTestQueueEmpty(engine())) {
+            // All tests ran
+            aborted = true;
+        }
+
+        if (aborted && ImGuiTestEngine_TryAbortEngine(_engine)) {
+            break;
+        }
+
+        ImGui::NewFrame();
+
+        if (_options.useInteractiveMode) {
+            // Shows pretty dialog with list of test and results
+            ImGuiTestEngine_ShowTestEngineWindows(_engine, nullptr);
+        }
+
+        // Render and swap
+        _app->Vsync = !ImGuiTestEngine_GetIO(_engine).IsRequestingMaxAppSpeed;
+        ImGui::Render();
+        _app->Render(_app);
+
+        // Post-swap handler is REQUIRED in order to support screen capture
+        ImGuiTestEngine_PostSwap(_engine);
+    }
+
+    int count_tested  = 0;
+    int count_success = 0;
+    ImGuiTestEngine_GetResult(engine(), count_tested, count_success);
+
+    return count_tested == count_success;
+}
+
+ImGuiTestEngine* ImGuiTestApp::engine() const { return _engine; }

--- a/src/ui/test/ImGuiTestApp.hpp
+++ b/src/ui/test/ImGuiTestApp.hpp
@@ -1,0 +1,56 @@
+#ifndef OPENDIGITIZER_UI_TEST_IMGUI_TEST_APP_HPP_
+#define OPENDIGITIZER_UI_TEST_IMGUI_TEST_APP_HPP_
+
+#include "imgui_test_engine/imgui_te_engine.h"
+
+class ImGuiApp;
+class ImGuiTestEngine;
+class ImGuiTestEngineIO;
+
+namespace DigitizerUi::test {
+
+struct TestOptions {
+    // If true, tests are started manually by the user, via a dialog
+    // mostly used for debugging a test
+    bool useInteractiveMode = false;
+
+    // If cursor should teleport or move at human speed
+    ImGuiTestRunSpeed speedMode = ImGuiTestRunSpeed::ImGuiTestRunSpeed_Fast;
+};
+
+/**
+   Helper to share ImGui, ImGuiTestEngine and SDL setup code through all tests
+
+   It's responsible for setup, cleanup and main loop. All you need to do is write your
+   tests in registerTests() and then call runTests().
+ */
+class ImGuiTestApp {
+    ImGuiApp*          _app      = nullptr;
+    ImGuiTestEngine*   _engine   = nullptr;
+    ImGuiTestEngineIO* _engineIO = nullptr;
+    const TestOptions  _options  = {};
+
+public:
+    explicit ImGuiTestApp(const TestOptions& = {});
+
+    // Frees ImGui and SDL resources
+    virtual ~ImGuiTestApp();
+
+    // Runs the gui tests and returns true on success
+    bool runTests();
+
+protected:
+    virtual void registerTests() = 0;
+
+    ImGuiTestEngine* engine() const;
+
+private:
+    void initImGui();
+
+    ImGuiTestApp(const ImGuiTestApp&)            = delete;
+    ImGuiTestApp& operator=(const ImGuiTestApp&) = delete;
+};
+
+} // namespace DigitizerUi::test
+
+#endif

--- a/src/ui/test/qa_popup_menu.cpp
+++ b/src/ui/test/qa_popup_menu.cpp
@@ -1,0 +1,75 @@
+#include "imgui.h"
+#include "imgui_test_engine/imgui_te_context.h"
+
+#include "components/PopupMenu.hpp"
+#include <boost/ut.hpp>
+
+#include "ImGuiTestApp.hpp"
+
+using namespace boost;
+
+/**
+  Tests opening a PopupMenu and clicking on its button
+
+  Very simple as it's a proof of concept for ImGui Test Engine.
+
+  boost::ut vs ImGuiTest
+      We're using boost::ut as the unit-test framework. ImGuiTest is
+      an implementation detail, required by the test engine.
+
+      Use boost::ut for asserts and reporting results instead of
+      ImGuiTest's equivalents.
+
+      Feel free to add several boost::ut tests under the same ImGuiTest.
+      While for pure unit-tests the relation is 1:1, for end-to-end tests
+      well have 1:N, that is, 1 ImGuiTest doing several UI interactions,
+      so N boost:ut::test grouping testable functionallity.
+ */
+
+class TestApp : public DigitizerUi::test::ImGuiTestApp {
+private:
+    using DigitizerUi::test::ImGuiTestApp::ImGuiTestApp;
+
+    void registerTests() override {
+        struct TestState {
+            bool pressed = false;
+        };
+
+        ImGuiTest* t = IM_REGISTER_TEST(engine(), "popup_menu", "test1");
+        t->SetVarsDataType<TestState>();
+
+        t->GuiFunc = [](ImGuiTestContext* ctx) {
+            ImGui::Begin("Test Window", NULL, ImGuiWindowFlags_NoSavedSettings);
+            ImGui::SetWindowPos({0, 0});
+            ImGui::SetWindowSize(ImVec2(500, 500));
+
+            DigitizerUi::VerticalPopupMenu<1> menu;
+
+            if (!menu.isOpen()) {
+                menu.addButton("button", [ctx] {
+                    auto& vars   = ctx->GetVars<TestState>();
+                    vars.pressed = true;
+                });
+            }
+
+            ImGui::End();
+        };
+
+        t->TestFunc = [](ImGuiTestContext* ctx) {
+            ut::test("my test") = [ctx] {
+                ctx->SetRef("Test Window");
+                const ImGuiID popupId = ctx->PopupGetWindowID("MenuPopup_1");
+                ctx->SetRef(popupId);
+                ctx->ItemClick("button");
+
+                auto& vars = ctx->GetVars<TestState>();
+                ut::expect(vars.pressed);
+            };
+        };
+    }
+};
+
+int main(int, char**) {
+    TestApp app({.useInteractiveMode = false});
+    return app.runTests() ? 0 : 1;
+}


### PR DESCRIPTION
Integrates ImGui Test Engine and has a minimal example, for task #208.

Read the individual commit messages for more info.

 To be decided:
 
 - Coding style: ImGuiTestApp is not header-only and is polymorphic.
    Since it's not part of the production build I don't think it needs
    to be micro-optimized and also since we'll have dozens of test
    exacutables eventually.
 
 - Offscreen rendering (no window) would be a nice to have,
  so developers don't get spammed with windows when running 'ctest -j12'
    
- We're reporting test results both with ImGui Test Engine and with
    boost/ut.h. Maybe remove boost/ut.h since it involves another "register
    tests" step as well.
    
- Lot's of settings to tune later as we gain experience. For example,
    mouse teleportation can speed up tests, but might not be great if
    the component being tested uses timeouts internally (popup menus for
    example).
   
