### PR TITLE
Reenable picoscope

### DIFF
--- a/src/service/cmake/Dependencies.cmake
+++ b/src/service/cmake/Dependencies.cmake
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
         gr-digitizers
         GIT_REPOSITORY https://github.com/fair-acc/gr-digitizers.git
-        GIT_TAG 0ad25d0d2947aac288cf76b1626816a5044b753e # dev-prototype as of 2024-04-25
+        GIT_TAG ba28ef2be685b84d917843b8c790e9156ca5e5e6 # dev-prototype as of 2024-10-09
         SYSTEM
 )
 

--- a/src/service/gnuradio/examples/picoscope4000a-streaming.grc
+++ b/src/service/gnuradio/examples/picoscope4000a-streaming.grc
@@ -1,5 +1,5 @@
 blocks:
-  - name: fair::picoscope::Picoscope4000a<double>
+  - name: fair::picoscope::Picoscope4000a<float>
     id: fair::picoscope::Picoscope4000a
     parameters:
       acquisition_mode: Streaming
@@ -29,7 +29,7 @@ blocks:
         - Test unit B
         - Test unit C
         - Test unit D
-      name: fair::picoscope::Picoscope4000a<double>
+      name: fair::picoscope::Picoscope4000a<float>
       sample_rate: 80000
       streaming_mode_poll_rate: 0.000010
   - name: sinkA
@@ -41,7 +41,7 @@ blocks:
   - name: sinkD
     id: gr::basic::DataSink
 connections:
-  - [fair::picoscope::Picoscope4000a<double>, [0, 0], sinkA, 0]
-  - [fair::picoscope::Picoscope4000a<double>, [0, 1], sinkB, 0]
-  - [fair::picoscope::Picoscope4000a<double>, [0, 2], sinkC, 0]
-  - [fair::picoscope::Picoscope4000a<double>, [0, 3], sinkD, 0]
+  - [fair::picoscope::Picoscope4000a<float>, [0, 0], sinkA, 0]
+  - [fair::picoscope::Picoscope4000a<float>, [0, 1], sinkB, 0]
+  - [fair::picoscope::Picoscope4000a<float>, [0, 2], sinkC, 0]
+  - [fair::picoscope::Picoscope4000a<float>, [0, 3], sinkD, 0]

--- a/src/service/main.cpp
+++ b/src/service/main.cpp
@@ -17,10 +17,7 @@
 #include <gnuradio-4.0/basic/Selector.hpp>
 #include <gnuradio-4.0/basic/common_blocks.hpp>
 #include <gnuradio-4.0/basic/function_generator.hpp>
-
-#ifndef __EMSCRIPTEN__
 #include <Picoscope4000a.hpp>
-#endif
 
 #include "build_configuration.hpp"
 #include "settings.hpp"
@@ -82,10 +79,11 @@ void registerTestBlocks(Registry& registry) {
 #pragma GCC diagnostic ignored "-Wunused-variable"
     gr::registerBlock<TestSource, double, float>(registry);
     gr::registerBlock<gr::basic::DataSink, double, float, std::int16_t>(registry);
-#ifndef __EMSCRIPTEN__
-    // TODO: Current implementation of Picoscope4000a does not satisfy the new block API
-    // gr::registerBlock<fair::picoscope::Picoscope4000a, double, float, std::int16_t>(registry);
-#endif
+    gr::registerBlock<fair::picoscope::Picoscope4000a, fair::picoscope::AcquisitionMode::Streaming, float, std::int16_t>(registry); // ommitting gr::UncertainValue<float> for now, which would also be supported by picoscope block
+    fmt::print("providedBlocks:\n");
+    for (auto& blockName : registry.providedBlocks()) {
+        fmt::print("  - {}: {}\n", blockName, registry.knownBlockParameterizations(blockName));
+    }
 #pragma GCC diagnostic pop
 }
 } // namespace

--- a/src/ui/components/SignalSelector.hpp
+++ b/src/ui/components/SignalSelector.hpp
@@ -305,7 +305,7 @@ public:
 
     void drawRemoteSignalsInput(FlowGraph* fg) {
         ImGui::AlignTextToFramePadding();
-        ImGui::Text("URI:");
+        ImGui::TextUnformatted("URI:");
         ImGui::SameLine();
         if (m_addRemoteSignalDialogOpened) {
             ImGui::SetKeyboardFocusHere();
@@ -359,7 +359,7 @@ public:
         ImGui::TableNextColumn();
         ImGui::TextUnformatted(entry.frontend.c_str());
         ImGui::TableNextColumn();
-        ImGui::Text(entry.comment.c_str());
+        ImGui::TextUnformatted(entry.comment.c_str());
     }
 
     void drawSignalSelector(FlowGraph* fg) {


### PR DESCRIPTION
The digitizer block was disabled due to gr-digitizers not following some
of the changes in gnuradio4. This was fixed in gr-digitizers#147 which
refactored the picoscope blocks to the current block API but was never
followed up in opendigitizer.

I had to change the data type for all blocks to float because the
picoscope block does not support double anymore. It should be possible
to follow up these changes and add a converter block to use double in
the rest of the flowgraph.

I also removed some emscripten guards since the opendigitizer-service
part is not supposed to build on emscripten anyway.

This changes depend on reading the template parameters for the blocks
from the yaml.

With these changes it is possible to run with the picoscope again, I
still cannot get data via the subscription, probably due to some channel
name missmatches which i still try to resolve.

small unrelated fix:
Passing non-const strings to ImGui::Text's format-string argument may
cause build errors on some platforms due to security hardening compiler
parameters. Change to the non-formatting variant.