### PR TITLE
WIP: Compare screen captures when running tests

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -4,8 +4,6 @@ on:
   push:
   pull_request:
     branches: [ main ]
-  release:
-    types: [ created ]
 
 permissions:
   contents: read
@@ -99,6 +97,14 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: ctest --output-on-failure
+
+    - name: compare captures
+      if: ${{ github.event_name == 'pull_request' && matrix.cmake-build-type == 'Debug' }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+      shell: bash
+      run: |
+        ./compare_captures.sh ${{ github.event.pull_request.number }} ${{ github.repository }} ${{ github.workspace }}/reference_captures/ ${{ github.workspace }}/build/captures/
 
     - name: execute tests with coverage
       if: matrix.configurations.compiler == 'gcc-14' && matrix.cmake-build-type == 'Debug'

--- a/.github/workflows/upload-reference-screencaptures.yml
+++ b/.github/workflows/upload-reference-screencaptures.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+
+# When a PR gets merged, this workflow uploads the new reference screen captures
+# If test_screen_captures/PRXXXX-all-captures.tgz does not exist, then it means the PR
+# didn't produce any diff captures
+
+name: Upload reference screen captures
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ closed ]
+
+jobs:
+  upload:
+    runs-on: ubuntu-22.04
+
+    if: github.event.pull_request.merged == true
+    steps:
+    - name: Download reference captures from current PR
+      run: |
+        wget https://github.com/${{ github.repository }}/releases/download/test_screen_captures/${{ github.event.pull_request.number }}-all-captures.tgz || exit 0
+        mkdir captures
+        tar xvf ${{ github.event.pull_request.number }}-all-captures.tgz -C captures --strip-components=1
+
+    - name: Upload reference captures
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        if [ -d captures ]; then
+          # Delete/recreate release, as there's no easy API to just rsync new pngs
+          gh release delete reference_screen_captures-main --repo ${{ github.repository }} -y
+          gh release create reference_screen_captures-main --notes "Reference screen captures" --repo ${{ github.repository }}
+
+          # upload new captures
+          gh release upload reference_screen_captures-main captures/*.png --clobber --repo ${{ github.repository }}
+
+          gh release delete-asset test_screen_captures ${{ github.event.pull_request.number }}-all-captures.tgz --repo ${{ github.repository }}
+        fi

--- a/compare_captures.sh
+++ b/compare_captures.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+# Implements the screen capture comparison (task #213), the algorthm is follows:
+# 1. ctest runs the tests which produce screenshots in the build directory (ran by the build_cmake.yml)
+# 2. This script is called, to compare if the resulting screenshots differ from the reference ones
+#  - The reference images are downloaded
+#  - All PR images are diffed against reference images
+#  - A GitHub PR comment is created listing all different/missing/new images
+# 3. upload-reference-screencaptures.yml is triggered on PR merge, it will refresh the reference images
+#
+# As an implementation detail, we're using "GH releases" as our storage, since "upload/artifacts" has limit
+# of 90 days, 500MB storage limit and isn't available via 'gh' commandline tool.
+# We're using 2 dummy releases to store assets: 'reference_screen_captures-main' and 'test_screen_captures'
+# , the latter stores diffs, so they can be linked from in PR comments.
+
+if [ "$#" -ne 4 ] ; then
+    echo "Usage: compare_captures.sh <PR_NUMBER> <REPO_NAME> <reference_capture_dir> <current_capture_dir>"
+    exit 1
+fi
+
+PR_NUMBER=$1
+REPO_NAME=$2
+REFERENCE_CAPTURES_DIR=$3
+PR_CAPTURES_DIR=$4
+DIFF_DIR=$PR_CAPTURES_DIR/../diffs/
+DIFFS_RELEASE_NAME=test_screen_captures
+REFERENCE_RELEASE_NAME=reference_screen_captures-main # TODO we'll want more than one branch ?
+
+mkdir "$DIFF_DIR" &> /dev/null
+
+# make *.png expand to empty if there's no png file
+
+setopt nullglob  &> /dev/null # zsh
+shopt -s nullglob &> /dev/null # bash
+
+# Download reference captures
+gh release download $REFERENCE_RELEASE_NAME -p "*.png" -D "$REFERENCE_CAPTURES_DIR"
+
+# Let's accumulate the results in these arrays
+# so we can print them in one go in a single PR comment if we want
+
+images_with_differences=()
+new_images_in_pr=()
+images_missing_in_pr=()
+
+for i in ${PR_CAPTURES_DIR}/*.png ; do
+    image_name=$(basename "$i")
+    reference_image=$REFERENCE_CAPTURES_DIR/$image_name
+
+    echo "Testing $image_name"
+
+    if [[ -f $reference_image ]] ; then
+        # 'compare' from GH's old Ubuntu always returns 1 even if files are the same. Guard with 'diff'
+        if ! diff "$PR_CAPTURES_DIR"/"$image_name" "$reference_image" &> /dev/null ; then
+            echo "Found differences for $image_name"
+            compare -compose src "$PR_CAPTURES_DIR"/"$image_name" "$reference_image" "$DIFF_DIR"/"${PR_NUMBER}"-"${image_name}"_diff.png
+            images_with_differences+=($image_name)
+
+            # we'll be uploading it so we can link it from PR, copy to diff dir
+            cp "$PR_CAPTURES_DIR"/"$image_name" "$DIFF_DIR"/"${PR_NUMBER}"-"${image_name}"
+        fi
+    else
+        echo "Found new image $image_name"
+        new_images_in_pr+=($image_name)
+
+        # we'll upload the new image as well, copy to diff dir
+        cp "$PR_CAPTURES_DIR"/"$image_name" "$DIFF_DIR"/"${PR_NUMBER}"-"${image_name}"
+    fi
+done
+
+# check if there's any images missing in PR
+for i in ${REFERENCE_CAPTURES_DIR}/*.png ; do
+    image_name=$(basename "$i")
+    pr_image=$PR_CAPTURES_DIR/$image_name
+
+    if [ ! -f "$pr_image" ] ; then
+        echo "Could not find $image_name in PR"
+        images_missing_in_pr+=$image_name
+    fi
+done
+
+if [[ ${#images_with_differences[@]} -eq 0 && ${#new_images_in_pr[@]} -eq 0 && ${#images_missing_in_pr[@]} -eq 0 ]]; then
+    # Still useful to show a comment on success, in case PR has previous diff comments
+    gh pr comment "$PR_NUMBER" --body "✅ No screencapture diffs to report!"
+
+    # All is good now, when we merge, do not upload anything to reference_screen_captures
+    gh release delete-asset test_screen_captures "${PR_NUMBER}"-all-captures.tgz
+
+    exit 0
+fi
+
+# Make sure the asset releases exist
+
+if ! gh release list | grep -q "$DIFFS_RELEASE_NAME"  ; then
+    echo "No asset release for diffs, creating..."
+    gh release create ${DIFFS_RELEASE_NAME} --notes "Screen captures diffs for faulty pull requests"
+fi
+
+if ! gh release list | grep -q "$REFERENCE_RELEASE_NAME"  ; then
+    echo "No asset release for reference capture, creating..."
+    gh release create ${REFERENCE_RELEASE_NAME} --notes "Reference screen captures"
+fi
+
+if [ -n "$(ls -A "$DIFF_DIR")" ]; then # if not-empty
+    echo "Uploading diffs..."
+    gh release upload ${DIFFS_RELEASE_NAME} "$DIFF_DIR"/*png --clobber || exit 1
+fi
+
+tar cvzf "${PR_NUMBER}"-all-captures.tgz -C "$(dirname "$PR_CAPTURES_DIR")" "$(basename "$PR_CAPTURES_DIR")"
+
+# Once the PR gets merged we need to access this tgz as it will be the new reference
+echo "Uploading all PR captures..."
+gh release upload ${DIFFS_RELEASE_NAME} "${PR_NUMBER}"-all-captures.tgz --clobber || exit 1
+
+pr_text=""
+
+if [[ ${#images_with_differences[@]} -ne 0 ]] ; then
+    pr_text+="# PR produced different images:\n\n"
+    for i in "${images_with_differences[@]}" ; do
+        pr_text+="<details>\n"
+        pr_text+="<summary>$i</summary>\n"
+        pr_text+="\n### Got:\n ![$i](https://github.com/${REPO_NAME}/releases/download/${DIFFS_RELEASE_NAME}/${PR_NUMBER}-${i}) \n"
+        pr_text+="\n### Expected:\n ![$i](https://github.com/${REPO_NAME}/releases/download/${REFERENCE_RELEASE_NAME}/${i}) \n"
+        pr_text+="\n### Diff:\n ![$i](https://github.com/${REPO_NAME}/releases/download/${DIFFS_RELEASE_NAME}/${PR_NUMBER}-${i}_diff.png) \n"
+        pr_text+="</details>\n"
+    done
+fi
+
+if [[ ${#new_images_in_pr[@]} -ne 0 ]] ; then
+    pr_text+="\n# PR has new images:\n\n"
+    for i in "${new_images_in_pr[@]}" ; do
+        pr_text+="<details>\n\n"
+        pr_text+="<summary>$i</summary>\n"
+        pr_text+="<img src=\"https://github.com/${REPO_NAME}/releases/download/${DIFFS_RELEASE_NAME}/${PR_NUMBER}-${i}\" style=\"max-width: 50%; height: auto;\" >"
+        pr_text+="</details>\n"
+    done
+fi
+
+if [[ ${#images_missing_in_pr[@]} -ne 0 ]] ; then
+    pr_text+="\n# PR didn't produce the following images:\n\n"
+    for i in "${images_missing_in_pr[@]}" ; do
+        pr_text+="<details>\n\n"
+        pr_text+="<summary>$i</summary>\n"
+        pr_text+="<img src=\"https://github.com/${REPO_NAME}/releases/download/${REFERENCE_RELEASE_NAME}/${i}\" style=\"max-width: 50%; height: auto;\" >"
+        pr_text+="</details>"
+    done
+fi
+
+if [[ -z "$pr_text" ]]; then
+    # All files are the same
+    rmdir "$DIFF_DIR"
+else
+    formatted_text=$(echo -e "$pr_text") # expand \n
+
+    echo "Creating PR comment with content"
+    echo -e "$formatted_text"
+
+    gh pr comment "$PR_NUMBER" --body "$formatted_text"
+fi

--- a/src/ui/cmake/Dependencies.cmake
+++ b/src/ui/cmake/Dependencies.cmake
@@ -126,7 +126,7 @@ target_include_directories(imgui SYSTEM BEFORE PUBLIC ${imgui_SOURCE_DIR} ${imgu
 
 if(ENABLE_IMGUI_TEST_ENGINE)
   target_compile_definitions(imgui PUBLIC IMGUI_ENABLE_TEST_ENGINE IMGUI_TEST_ENGINE_ENABLE_COROUTINE_STDTHREAD_IMPL=1
-                                          IMGUI_APP_SDL2_GL3)
+                                          IMGUI_APP_SDL2_GL3 IMGUI_TEST_ENGINE_ENABLE_CAPTURE)
 
   target_include_directories(imgui PUBLIC ${imgui_test_engine_SOURCE_DIR})
 endif()

--- a/src/ui/test/ImGuiTestApp.hpp
+++ b/src/ui/test/ImGuiTestApp.hpp
@@ -1,6 +1,7 @@
 #ifndef OPENDIGITIZER_UI_TEST_IMGUI_TEST_APP_HPP_
 #define OPENDIGITIZER_UI_TEST_IMGUI_TEST_APP_HPP_
 
+#include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
 
 class ImGuiApp;
@@ -16,6 +17,9 @@ struct TestOptions {
 
     // If cursor should teleport or move at human speed
     ImGuiTestRunSpeed speedMode = ImGuiTestRunSpeed::ImGuiTestRunSpeed_Fast;
+
+    // Screenshot filenames can be prefixed with something. For instance, your test name
+    const char* screenshotPrefix = "";
 };
 
 /**
@@ -38,6 +42,19 @@ public:
 
     // Runs the gui tests and returns true on success
     bool runTests();
+
+    /**
+      Captures a screenshot.
+
+      Image is saved to disk.
+      This signature is identical to ImGuiTestContext::CaptureScreenshotWindowm but we have our
+      own implementation, so we can control where the images are actually stored.
+
+      @param ctx test context
+      @param ref An ImGuiID or a char* path that identifies the widget to be captured. Captures the window by default
+      @param captureFlags See ImGui's ImGuiCaptureFlags_ enum
+     */
+    static void captureScreenshot(ImGuiTestContext& ctx, ImGuiTestRef ref = "/", int captureFlags = ImGuiCaptureFlags_StitchAll | ImGuiCaptureFlags_HideMouseCursor | ImGuiCaptureFlags_IncludeTooltipsAndPopups | ImGuiCaptureFlags_IncludeOtherWindows);
 
 protected:
     virtual void registerTests() = 0;

--- a/src/ui/test/qa_popup_menu.cpp
+++ b/src/ui/test/qa_popup_menu.cpp
@@ -59,6 +59,8 @@ private:
             ut::test("my test") = [ctx] {
                 ctx->SetRef("Test Window");
                 const ImGuiID popupId = ctx->PopupGetWindowID("MenuPopup_1");
+                captureScreenshot(*ctx);
+
                 ctx->SetRef(popupId);
                 ctx->ItemClick("button");
 
@@ -70,6 +72,6 @@ private:
 };
 
 int main(int, char**) {
-    TestApp app({.useInteractiveMode = false});
+    TestApp app({.useInteractiveMode = false, .screenshotPrefix = "popup_menu"});
     return app.runTests() ? 0 : 1;
 }


### PR DESCRIPTION
Compare screen captures when running tests
    
When a PR is pushed, build_cmake.yml invokes compare_captures.sh,
which creates a PR comment listing all generated images which
are different from their reference image.
    
When the PR is merged, upload-reference-screencaptures.yml uploads
those images as the new reference images.