### PR TITLE
Fix CMake subprojects

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -2,6 +2,7 @@ name: CMake
 
 on:
   push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,6 @@ set(ROOT_BUILD_DIR ${CMAKE_BINARY_DIR})
 set(PREFIX_DIR ${CMAKE_BINARY_DIR}/CMakeExternals/Prefix)
 set(BUILD_DIR ${CMAKE_BINARY_DIR}/CMakeExternals/Build)
 set(INSTALL_DIR ${CMAKE_BINARY_DIR}/CMakeExternals/Install)
-set(WASM_BUILD_DIR ${BUILD_DIR}/ui-wasm)
-set(SERVING_DIR ${ROOT_BUILD_DIR}/ui-wasm)
-
-configure_file(build_configuration.hpp.in ${CMAKE_BINARY_DIR}/build_configuration.hpp @ONLY)
-include_directories(${CMAKE_BINARY_DIR})
 
 option(USE_DWARF4 "Use DWARF-4 instead of DWARF-5 for better LLDB compatibility" OFF)
 if(USE_DWARF4)

--- a/build_configuration.hpp.in
+++ b/build_configuration.hpp.in
@@ -1,2 +1,0 @@
-#cmakedefine ROOT_BUILD_DIR "@ROOT_BUILD_DIR@"
-#cmakedefine SERVING_DIR "@SERVING_DIR@"

--- a/src/acquisition/CMakeLists.txt
+++ b/src/acquisition/CMakeLists.txt
@@ -3,5 +3,4 @@ add_library(od_acquisition INTERFACE)
 target_include_directories(od_acquisition INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                                                     $<INSTALL_INTERFACE:include/>)
 
-target_link_libraries(od_acquisition INTERFACE project_options project_warnings)
 set_target_properties(od_acquisition PROPERTIES PUBLIC_HEADER daq_api.hpp)

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -4,14 +4,30 @@ set(CMAKE_CXX_STANDARD 23)
 # Mainly for FMT
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
-include(cmake/Dependencies.cmake)
-
 project(opendigitizer-service CXX)
 include(GNUInstallDirs)
+
+include(cmake/Dependencies.cmake)
+
+if(NOT TARGET od_acquisition)
+  add_subdirectory(../acquisition acquisition)
+endif()
+if(NOT TARGET digitizer_settings)
+  add_subdirectory(../utils utils)
+endif()
 
 option(WASM_BUILD_DIR
        "The directory containing the build output of the emscripten ui build to be bundled into the assets"
        ${CMAKE_CURRENT_SOURCE_DIR}/../ui/build-wasm)
+
+if(NOT WASM_BUILD_DIR)
+  set(SERVING_DIR ${ROOT_BUILD_DIR}/ui-wasm)
+else()
+  set(SERVING_DIR ${CMAKE_BINARY_DIR}/${WASM_BUILD_DIR})
+endif()
+
+configure_file(build_configuration.hpp.in ${CMAKE_BINARY_DIR}/build_configuration.hpp @ONLY)
+include_directories(${CMAKE_BINARY_DIR})
 
 # Check for supported compiler versions
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
@@ -111,7 +127,6 @@ target_link_libraries(
           services
           client
           project_options
-          project_warnings
           assets::rest
           digitizer_settings)
 if(NOT EMSCRIPTEN)

--- a/src/service/build_configuration.hpp.in
+++ b/src/service/build_configuration.hpp.in
@@ -1,0 +1,1 @@
+#cmakedefine SERVING_DIR "@SERVING_DIR@"

--- a/src/service/cmake/Dependencies.cmake
+++ b/src/service/cmake/Dependencies.cmake
@@ -1,7 +1,17 @@
 include(FetchContent)
 
-# TODO this should be a gnuradio4 dependency only, as gr-digitizer blocks
-# (e.g. PicoScope) would be loaded via plugins, at runtime
+FetchContent_Declare(
+        opencmw-cpp
+        GIT_REPOSITORY https://github.com/fair-acc/opencmw-cpp.git
+        GIT_TAG bb8996babab2000a4ae3612ea146a551a96e59c4 # main as of 2024-10-18
+        SYSTEM)
+
+FetchContent_Declare(
+        gnuradio4
+        GIT_REPOSITORY https://github.com/fair-acc/gnuradio4.git
+        GIT_TAG 5e7ecc561dfb35a6a8fd357f50d12efd09303c4f # main as of 2024-10-18
+        SYSTEM)
+
 FetchContent_Declare(
         gr-digitizers
         GIT_REPOSITORY https://github.com/fair-acc/gr-digitizers.git
@@ -9,4 +19,4 @@ FetchContent_Declare(
         SYSTEM
 )
 
-FetchContent_MakeAvailable(gr-digitizers)
+FetchContent_MakeAvailable(opencmw-cpp gr-digitizers gnuradio4)

--- a/src/service/dashboard/CMakeLists.txt
+++ b/src/service/dashboard/CMakeLists.txt
@@ -15,5 +15,4 @@ target_link_libraries(
   INTERFACE majordomo
             core
             project_options
-            project_warnings
             assets::dashboard)

--- a/src/service/dashboard/defaultDashboard.dashboard
+++ b/src/service/dashboard/defaultDashboard.dashboard
@@ -11,10 +11,6 @@ sources:
     block: sink 2
     port: 0
     color: 4284318450
-  - name: sink 4
-    block: sink 4
-    port: 0
-    color: 4293501622
 plots:
   - name: Plot 1
     axes:

--- a/src/service/gnuradio/CMakeLists.txt
+++ b/src/service/gnuradio/CMakeLists.txt
@@ -7,7 +7,6 @@ target_link_libraries(
             disruptor
             gr-basic
             yaml-cpp::yaml-cpp
-            project_options
-            project_warnings)
+            project_options)
 
 add_subdirectory(test)

--- a/src/service/gnuradio/examples/picoscope4000a-streaming.grc
+++ b/src/service/gnuradio/examples/picoscope4000a-streaming.grc
@@ -1,15 +1,15 @@
 blocks:
-  - name: fair::picoscope::Picoscope4000a<float>
+  - name: picoscope
     id: fair::picoscope::Picoscope4000a
     template_args: "float,fair::picoscope::AcquisitionMode::Streaming"
     parameters:
       acquisition_mode: Streaming
       auto_arm: true
       channel_couplings:
-        - AC_1M
-        - AC_1M
-        - AC_1M
-        - AC_1M
+        - DC_1M
+        - DC_1M
+        - DC_1M
+        - DC_1M
       channel_ids:
         - A
         - B
@@ -30,23 +30,38 @@ blocks:
         - Test unit B
         - Test unit C
         - Test unit D
-      name: fair::picoscope::Picoscope4000a<float>
-      sample_rate: 80000
+      sample_rate: 10000
       streaming_mode_poll_rate: 0.000010
+  - name: convertA
+    id: gr::blocks::type::converter::Convert
+    template_args: "float,double"
+  - name: convertB
+    id: gr::blocks::type::converter::Convert
+    template_args: "float,double"
+  - name: convertC
+    id: gr::blocks::type::converter::Convert
+    template_args: "float,double"
+  - name: convertD
+    id: gr::blocks::type::converter::Convert
+    template_args: "float,double"
   - name: sinkA
     id: gr::basic::DataSink
-    template_args: float
+    template_args: double
   - name: sinkB
     id: gr::basic::DataSink
-    template_args: float
+    template_args: double
   - name: sinkC
     id: gr::basic::DataSink
-    template_args: float
+    template_args: double
   - name: sinkD
     id: gr::basic::DataSink
-    template_args: float
+    template_args: double
 connections:
-  - [fair::picoscope::Picoscope4000a<float>, [0, 0], sinkA, 0]
-  - [fair::picoscope::Picoscope4000a<float>, [0, 1], sinkB, 0]
-  - [fair::picoscope::Picoscope4000a<float>, [0, 2], sinkC, 0]
-  - [fair::picoscope::Picoscope4000a<float>, [0, 3], sinkD, 0]
+  - [picoscope,  [0, 0], convertA, 0]
+  - [convertA, 0, sinkA, 0]
+  - [picoscope,  [0, 1], convertB, 0]
+  - [convertB, 0, sinkB, 0]
+  - [picoscope,  [0, 2], convertC, 0]
+  - [convertC, 0, sinkC, 0]
+  - [picoscope,  [0, 3], convertD, 0]
+  - [convertD, 0, sinkD, 0]

--- a/src/service/main.cpp
+++ b/src/service/main.cpp
@@ -15,6 +15,7 @@
 
 // TODO instead of including and registering blocks manually here, rely on the plugin system
 #include <Picoscope4000a.hpp>
+#include <gnuradio-4.0/basic/ConverterBlocks.hpp>
 #include <gnuradio-4.0/basic/Selector.hpp>
 #include <gnuradio-4.0/basic/common_blocks.hpp>
 #include <gnuradio-4.0/basic/function_generator.hpp>
@@ -79,6 +80,7 @@ void registerTestBlocks(Registry& registry) {
 #pragma GCC diagnostic ignored "-Wunused-variable"
     gr::registerBlock<TestSource, double, float>(registry);
     gr::registerBlock<gr::basic::DataSink, double, float, std::int16_t>(registry);
+    gr::registerBlock<gr::blocks::type::converter::Convert, gr::BlockParameters<double, float>, gr::BlockParameters<float, double>>(registry);
     gr::registerBlock<fair::picoscope::Picoscope4000a, fair::picoscope::AcquisitionMode::Streaming, float, std::int16_t>(registry); // ommitting gr::UncertainValue<float> for now, which would also be supported by picoscope block
     fmt::print("providedBlocks:\n");
     for (auto& blockName : registry.providedBlocks()) {

--- a/src/service/rest/CMakeLists.txt
+++ b/src/service/rest/CMakeLists.txt
@@ -17,9 +17,4 @@ cmrc_add_resource_library(
 
 add_library(od_rest INTERFACE fileserverRestBackend.hpp)
 target_include_directories(od_rest INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/.)
-target_link_libraries(
-  od_rest
-  INTERFACE majordomo
-            project_options
-            project_warnings
-            assets::rest)
+target_link_libraries(od_rest INTERFACE majordomo project_options assets::rest)

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -12,44 +12,12 @@ set(CMAKE_VERBOSE_MAKEFILE OFF)
 # Mainly for FMT
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
-set(DIGITIZER_UI_SRCS
-    main.cpp
-    Flowgraph.cpp
-    Flowgraph.hpp
-    FlowgraphItem.cpp
-    FlowgraphItem.hpp
-    Dashboard.cpp
-    Dashboard.hpp
-    DashboardPage.cpp
-    DashboardPage.hpp
-    OpenDashboardPage.cpp
-    OpenDashboardPage.hpp
-    RemoteSignalSources.cpp
-    RemoteSignalSources.hpp
-    components/AppHeader.hpp
-    components/Block.cpp
-    components/Block.hpp
-    components/Dialog.hpp
-    components/FilterComboBoxes.hpp
-    components/Keypad.hpp
-    components/ListBox.hpp
-    components/ImGuiNotify.hpp
-    components/PopupMenu.hpp
-    components/SelectedLabelsView.hpp
-    components/SignalSelector.hpp
-    components/Splitter.cpp
-    components/Splitter.hpp
-    components/Toolbar.hpp
-    utils/stb_impl.cpp # STB is a library with linking issues -- impl instantiated only here
-)
-
-set(GNURADIO_PREFIX
-    "/usr/"
-    CACHE FILEPATH "Prefix of the GNURadio installation")
-
 if(EMSCRIPTEN)
-  message(STATUS "Detected emscripten webassembly build")
-
+  # locate the "executable" output in the build/web directory
+  set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/web)
+  # necessary to tell CMake (with emscripten) to extend the standard .js and .wasm output with .html output (so that we
+  # can execute it with the webserver)
+  set(CMAKE_EXECUTABLE_SUFFIX ".html")
   # CAUTION: The "SHELL:" before some compile/link options has to be used to explicitly tell CMake to not sum up options
   # (e.g. -option A -option B => -option A B)(CMake default behaviour), but instead keep them separated (needed for
   # proper operation of emscripten)
@@ -62,7 +30,6 @@ if(EMSCRIPTEN)
     -fwasm-exceptions
     "SHELL:-s USE_SDL=2"
     -pthread)
-
   add_link_options(
     "SHELL:-s WASM=1"
     "SHELL:-s ALLOW_MEMORY_GROWTH=1"
@@ -81,6 +48,13 @@ endif()
 # dependencies
 include(../../cmake/CMakeRC.cmake)
 include(cmake/Dependencies.cmake)
+
+if(NOT TARGET od_acquisition)
+  add_subdirectory(../acquisition acquisition)
+endif()
+if(NOT TARGET raii_wrapper)
+  add_subdirectory(../utils utils)
+endif()
 
 cmrc_add_resource_library(
   ui_assets
@@ -109,87 +83,19 @@ cmrc_add_resource_library(
   assets/sampleDashboards/DemoDashboard.yml)
 
 if(EMSCRIPTEN)
-  # locate the "executable" output in the build/web directory
-  set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/web)
-
-  # necessary to tell CMake (with emscripten) to extend the standard .js and .wasm output with .html output (so that we
-  # can execute it with the webserver)
-  set(CMAKE_EXECUTABLE_SUFFIX ".html")
-
-  set(outputFileName "index")
-  add_executable(${outputFileName})
-
-  target_sources(index PRIVATE ${DIGITIZER_UI_SRCS})
+  message(STATUS "Detected emscripten webassembly build")
   set(target_name "index")
-
-  # link the executable
-  target_link_libraries(
-    ${outputFileName}
-    PRIVATE implot
-            plf_colony
-            ui_assets
-            sample_dashboards
-            stb
-            fonts
-            core
-            client
-            services
-            imgui-node-editor
-            yaml-cpp::yaml-cpp)
+  add_executable(${target_name})
 
   add_custom_target(
     serve
-    python3
-    -m
-    http.server
-    -d
-    ${EXECUTABLE_OUTPUT_PATH}
-    8000
-    COMMENT start
-    a
-    python
-    server
-    serving
-    the
-    webassembly
-    app
-    DEPENDS ${outputFileName})
-
-  # TODO should be pulled via linking the targets, but they're outside the source folder (src/ui) for the ui-wasm build
-  target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../acquisition) # for daq_api.hpp
-  target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include)
-
+    "python3 -m http.server -d ${EXECUTABLE_OUTPUT_PATH} 8000"
+    COMMENT "start a python server serving the webassembly app"
+    DEPENDS ${target_name})
 else() # native build
-
   set(target_name "opendigitizer-ui")
-  add_executable(
-    ${target_name}
-    common/AppDefinitions.hpp
-    common/Events.hpp
-    common/ImguiWrap.hpp
-    common/LookAndFeel.hpp
-    common/TouchHandler.hpp)
-
-  target_sources(${target_name} PRIVATE ${DIGITIZER_UI_SRCS})
-
-  # link the executable
-  target_link_libraries(
-    ${target_name}
-    PRIVATE od_acquisition
-            SDL2
-            implot
-            imgui-node-editor
-            plf_colony
-            yaml-cpp::yaml-cpp
-            core
-            client
-            services
-            stb
-            ui_assets
-            sample_dashboards
-            digitizer_settings
-            fonts)
-  target_compile_definitions(${target_name} PRIVATE BLOCKS_DIR="${GNURADIO_PREFIX}/share/gnuradio/grc/blocks/")
+  add_executable(${target_name})
+  target_link_libraries(${target_name} PRIVATE SDL2) # for emscripten SDL is already included in the build
 
   if(OPENDIGITIZER_ENABLE_ASAN)
     target_compile_options(${target_name} PRIVATE -fsanitize=address)
@@ -197,18 +103,67 @@ else() # native build
   endif()
 endif()
 
+target_sources(
+  ${target_name}
+  PRIVATE main.cpp
+          Flowgraph.cpp
+          Flowgraph.hpp
+          FlowgraphItem.cpp
+          FlowgraphItem.hpp
+          Dashboard.cpp
+          Dashboard.hpp
+          DashboardPage.cpp
+          DashboardPage.hpp
+          OpenDashboardPage.cpp
+          OpenDashboardPage.hpp
+          RemoteSignalSources.cpp
+          RemoteSignalSources.hpp
+          components/AppHeader.hpp
+          components/Block.cpp
+          components/Block.hpp
+          components/Dialog.hpp
+          components/FilterComboBoxes.hpp
+          components/Keypad.hpp
+          components/ListBox.hpp
+          components/ImGuiNotify.hpp
+          components/PopupMenu.hpp
+          components/SelectedLabelsView.hpp
+          components/SignalSelector.hpp
+          components/Splitter.cpp
+          components/Splitter.hpp
+          components/Toolbar.hpp
+          utils/stb_impl.cpp # STB is a library with linking issues -- impl instantiated only here
+          common/AppDefinitions.hpp
+          common/Events.hpp
+          common/ImguiWrap.hpp
+          common/LookAndFeel.hpp
+          common/TouchHandler.hpp)
+
 target_link_libraries(
   ${target_name}
-  PRIVATE gnuradio-core
+  PRIVATE implot
+          imgui-node-editor
+          od_acquisition
+          services
+          plf_colony
+          ui_assets
+          yaml-cpp::yaml-cpp
+          core
+          client
+          stb
+          sample_dashboards
+          fonts
+          digitizer_settings
+          gnuradio-core
           gnuradio-meta
           gnuradio-algorithm
           gr-basic
           gr-fourier
+          raii_wrapper
           gr-testing
           fftw
           vir
           pmtv)
-target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../service/acquisition) # for daq_api.hpp
 target_compile_options(${target_name} PRIVATE "-Wfatal-errors")
 
 if(OPENDIGITIZER_ENABLE_TESTING)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,8 +1,7 @@
 add_library(raii_wrapper INTERFACE)
 
-target_include_directories(raii_wrapper INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+target_include_directories(raii_wrapper INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                                                   $<INSTALL_INTERFACE:include/>)
-target_link_libraries(raii_wrapper INTERFACE project_options project_warnings)
 set_target_properties(raii_wrapper PROPERTIES PUBLIC_HEADER /include/c_resource.hpp)
 
 add_library(digitizer_settings INTERFACE)


### PR DESCRIPTION
Makes it possible the build opendigitizer-service and opendigitizer-ui
separately as individual projects.
This makes managing different compile and run configurations in an IDE a
lot easier.

Also some smaller fixes, see individual commit messages.