### PR TITLE
CMake: fix path to wasm subbuild

### DIFF
--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -16,16 +16,14 @@ if(NOT TARGET digitizer_settings)
   add_subdirectory(../utils utils)
 endif()
 
-option(WASM_BUILD_DIR
-       "The directory containing the build output of the emscripten ui build to be bundled into the assets"
-       ${CMAKE_CURRENT_SOURCE_DIR}/../ui/build-wasm)
-
 if(NOT WASM_BUILD_DIR)
-  set(SERVING_DIR ${ROOT_BUILD_DIR}/ui-wasm)
-else()
-  set(SERVING_DIR ${CMAKE_BINARY_DIR}/${WASM_BUILD_DIR})
+  option(
+    WASM_BUILD_DIR
+    "The absolute path to a directory containing the build output of the emscripten ui build to be bundled into the assets"
+    ${CMAKE_CURRENT_SOURCE_DIR}/../ui/build-wasm)
 endif()
 
+set(SERVING_DIR ${WASM_BUILD_DIR})
 configure_file(build_configuration.hpp.in ${CMAKE_BINARY_DIR}/build_configuration.hpp @ONLY)
 include_directories(${CMAKE_BINARY_DIR})
 

--- a/src/service/README.md
+++ b/src/service/README.md
@@ -7,7 +7,7 @@ as a HTTP interface to these properties and a WebAssembly based visualisation cl
 ## Building
 
 ```shell
-cmake -S . -B build -DWASM_BUILD_DIR=../ui/build-wasm && cmake --build build
+cmake -S . -B build -DWASM_BUILD_DIR=`pwd`/../ui/build-wasm && cmake --build build
 ```
 
 See the top-level README on how to use the resulting binary.

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -9,13 +9,13 @@ This is the UI part of the opendigitizer project.
 Install the emscripten compiler according to the documentation and build this subproject part of the repository like so
 
 ```shell
-emcmake cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Debug && (cd build-wasm && EM_CACHE="$TMP" emmake make -j)
+emcmake cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Debug && cmake --build build-wasm -j
 ```
-Note: `cmake --build` is broken with em(c)make, hence the cd + make call.
 
 To test, launch a python http server and navigate your browser to http://localhost:8000;
+
 ```shell
-(cd build-wasm/ && make serve)
+cmake --build build-wasm --target serve
 ```
 
 ## Building for native
@@ -28,6 +28,7 @@ cmake -S . -B build-native -DCMAKE_BUILD_TYPE=Debug && cmake --build build-nativ
 ```
 
 The application can then be launched via
+
 ```shell
 ./build-native/opendigitizer-ui
 ```


### PR DESCRIPTION
Followup fix of #223 where I broke the path to where the wasm assets are loaded from.