### PR TITLE
Fix compare_captures.sh not being able to create reference folder

### DIFF
--- a/.github/compare_captures.sh
+++ b/.github/compare_captures.sh
@@ -31,6 +31,7 @@ DIFF_DIR=$PR_CAPTURES_DIR/../diffs/
 DIFFS_RELEASE_NAME=test_screen_captures
 REFERENCE_RELEASE_NAME=reference_screen_captures-main
 
+echo "Creating directory ${DIFF_DIR}"
 mkdir "$DIFF_DIR" &> /dev/null
 
 # make *.png expand to empty if there's no png file
@@ -39,6 +40,7 @@ setopt nullglob  &> /dev/null # zsh
 shopt -s nullglob &> /dev/null # bash
 
 # Download reference captures
+echo "Downloading release to ${REFERENCE_CAPTURES_DIR}"
 gh release download $REFERENCE_RELEASE_NAME -p "*.png" -D "$REFERENCE_CAPTURES_DIR"
 
 # Let's accumulate the results in these arrays

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -113,7 +113,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       shell: bash
       run: |
-        ./.github/compare_captures.sh ${{ github.event.pull_request.number }} ${{ github.repository }} ${{ github.workspace }}/reference_captures/ /__w/opendigitizer/build/captures
+        ./.github/compare_captures.sh ${{ github.event.pull_request.number }} ${{ github.repository }} /__w/opendigitizer/build/reference_captures /__w/opendigitizer/build/captures
 
     - name: Setup Pages
       if: matrix.cmake-build-type == 'Release'


### PR DESCRIPTION
The problems seems specific to our setup, or rather, specific to
running workflows inside containers. The container can't write to
`${{ github.workspace }}` as it points to a host path and not a container
path.