### PR TITLE
Improvements for ImguiTestApp

### DIFF
--- a/src/ui/test/ImGuiTestApp.cpp
+++ b/src/ui/test/ImGuiTestApp.cpp
@@ -8,7 +8,6 @@
 #include <algorithm>
 #include <fmt/core.h>
 #include <fmt/format.h>
-#include <iostream>
 #include <span>
 #include <string_view>
 
@@ -161,4 +160,28 @@ TestOptions TestOptions::fromArgs(int argc, char* argv[]) {
     options.useInteractiveMode = hasArgument("--interactive");
 
     return options;
+}
+
+void ImGuiTestApp::printWindows() {
+    ImGuiContext& g = *GImGui;
+    fmt::println("printWindows:");
+    fmt::println("    popupLevel={}", g.BeginPopupStack.size());
+    fmt::println("    openPopups={}", g.OpenPopupStack.size());
+
+    auto flagsString = [](ImGuiWindowFlags flags) -> std::string {
+        return fmt::format("ChildWindow={}, ToolTip={}, Popup={}, Modal={}, ChildMenu={}", //
+            flags & ImGuiWindowFlags_ChildWindow,                                          //
+            flags & ImGuiWindowFlags_Tooltip,                                              //
+            flags & ImGuiWindowFlags_Popup,                                                //
+            flags & ImGuiWindowFlags_Modal,                                                //
+            flags & ImGuiWindowFlags_ChildMenu);
+    };
+
+    for (const ImGuiWindowStackData& data : g.CurrentWindowStack) {
+        fmt::println("    window name={}; flags={}", data.Window->Name, flagsString(data.Window->Flags));
+    }
+
+    for (const ImGuiPopupData& data : g.OpenPopupStack) {
+        fmt::println("    popup name={}; flags={}", data.Window->Name, flagsString(data.Window->Flags));
+    }
 }

--- a/src/ui/test/ImGuiTestApp.cpp
+++ b/src/ui/test/ImGuiTestApp.cpp
@@ -5,6 +5,13 @@
 #include "imgui_test_engine/imgui_te_ui.h"
 #include "shared/imgui_app.h"
 
+#include <algorithm>
+#include <fmt/core.h>
+#include <fmt/format.h>
+#include <iostream>
+#include <span>
+#include <string_view>
+
 using namespace DigitizerUi::test;
 
 namespace {
@@ -55,6 +62,7 @@ void ImGuiTestApp::initImGui() {
     test_io.ConfigVerboseLevel        = ImGuiTestVerboseLevel_Info;
     test_io.ConfigVerboseLevelOnError = ImGuiTestVerboseLevel_Debug;
     test_io.ConfigRunSpeed            = _options.speedMode;
+    test_io.ConfigKeepGuiFunc         = _options.keepGui;
     test_io.ScreenCaptureFunc         = ImGuiApp_ScreenCaptureFunc;
     test_io.ScreenCaptureUserData     = _app;
     test_io.ConfigCaptureOnError      = true;
@@ -138,4 +146,19 @@ void ImGuiTestApp::captureScreenshot(ImGuiTestContext& ctx, ImGuiTestRef ref, in
 
     ctx.CaptureAddWindow(ref);
     ctx.CaptureScreenshot(captureFlags);
+}
+
+TestOptions TestOptions::fromArgs(int argc, char* argv[]) {
+    std::span args(argv + 1, argc - 1);
+    auto      hasArgument = [args](std::string_view arg) { return std::any_of(args.cbegin(), args.cend(), [arg](const char* v) { return arg == v; }); };
+
+    if (hasArgument("--help") || hasArgument("-h")) {
+        fmt::println(stdout, "Usage: {} [--keep-gui][--interactive]", argv[0]);
+    }
+
+    TestOptions options;
+    options.keepGui            = hasArgument("--keep-gui");
+    options.useInteractiveMode = hasArgument("--interactive");
+
+    return options;
 }

--- a/src/ui/test/ImGuiTestApp.cpp
+++ b/src/ui/test/ImGuiTestApp.cpp
@@ -185,3 +185,5 @@ void ImGuiTestApp::printWindows() {
         fmt::println("    popup name={}; flags={}", data.Window->Name, flagsString(data.Window->Flags));
     }
 }
+
+ImGuiTestContext* ImGuiTestApp::testContext() const { return _engine ? _engine->TestContext : nullptr; }

--- a/src/ui/test/ImGuiTestApp.hpp
+++ b/src/ui/test/ImGuiTestApp.hpp
@@ -15,11 +15,18 @@ struct TestOptions {
     // mostly used for debugging a test
     bool useInteractiveMode = false;
 
+    // Runs GuiFunc in a loop instead of quiting the application
+    // Use this for visually debug your test.
+    bool keepGui = false;
+
     // If cursor should teleport or move at human speed
     ImGuiTestRunSpeed speedMode = ImGuiTestRunSpeed::ImGuiTestRunSpeed_Fast;
 
     // Screenshot filenames can be prefixed with something. For instance, your test name
     const char* screenshotPrefix = "";
+
+    // Returns a good default for TestOptions but influenced by program arguments
+    static TestOptions fromArgs(int argc, char** argv);
 };
 
 /**

--- a/src/ui/test/ImGuiTestApp.hpp
+++ b/src/ui/test/ImGuiTestApp.hpp
@@ -63,7 +63,7 @@ public:
       @param ref An ImGuiID or a char* path that identifies the widget to be captured. Captures the window by default
       @param captureFlags See ImGui's ImGuiCaptureFlags_ enum
      */
-    static void captureScreenshot(ImGuiTestContext& ctx, ImGuiTestRef ref = "/", int captureFlags = ImGuiCaptureFlags_StitchAll | ImGuiCaptureFlags_HideMouseCursor | ImGuiCaptureFlags_IncludeTooltipsAndPopups | ImGuiCaptureFlags_IncludeOtherWindows);
+    static void captureScreenshot(ImGuiTestContext& ctx, ImGuiTestRef ref = "/", int captureFlags = ImGuiCaptureFlags_HideMouseCursor | ImGuiCaptureFlags_IncludeTooltipsAndPopups | ImGuiCaptureFlags_IncludeOtherWindows);
 
     // Prints the existing window ids, for debugging purposes
     static void printWindows();

--- a/src/ui/test/ImGuiTestApp.hpp
+++ b/src/ui/test/ImGuiTestApp.hpp
@@ -50,6 +50,8 @@ public:
     // Runs the gui tests and returns true on success
     bool runTests();
 
+    ImGuiTestContext* testContext() const;
+
     /**
       Captures a screenshot.
 

--- a/src/ui/test/ImGuiTestApp.hpp
+++ b/src/ui/test/ImGuiTestApp.hpp
@@ -63,6 +63,9 @@ public:
      */
     static void captureScreenshot(ImGuiTestContext& ctx, ImGuiTestRef ref = "/", int captureFlags = ImGuiCaptureFlags_StitchAll | ImGuiCaptureFlags_HideMouseCursor | ImGuiCaptureFlags_IncludeTooltipsAndPopups | ImGuiCaptureFlags_IncludeOtherWindows);
 
+    // Prints the existing window ids, for debugging purposes
+    static void printWindows();
+
 protected:
     virtual void registerTests() = 0;
 


### PR DESCRIPTION
Some fixes and convenience for debugging tests.

- Fix popup screen captures
- Add ImGuiTestApp::testContext()
- Add ImGuiTestApp::printWindows()
- Allow to pass --keep-gui and --interactive

Although it's related to #207 , it's atomic and can go in already. Will rebase Ralph's qa_Chart tests over it.
