### PR TITLE
tests: make initImGui public

### DIFF
--- a/src/ui/test/ImGuiTestApp.cpp
+++ b/src/ui/test/ImGuiTestApp.cpp
@@ -78,7 +78,9 @@ void ImGuiTestApp::initImGui() {
 }
 
 bool ImGuiTestApp::runTests() {
-    initImGui();
+    if (!_app) {
+        initImGui();
+    }
 
     bool aborted = false;
 

--- a/src/ui/test/ImGuiTestApp.hpp
+++ b/src/ui/test/ImGuiTestApp.hpp
@@ -53,6 +53,14 @@ public:
     ImGuiTestContext* testContext() const;
 
     /**
+      Initializes ImGui context and graphics
+
+      Calling this is optional, as it's implicitly called by runTests().
+      It's public in case you need to initialize ImGui earlier.
+     */
+    void initImGui();
+
+    /**
       Captures a screenshot.
 
       Image is saved to disk.
@@ -74,8 +82,6 @@ protected:
     ImGuiTestEngine* engine() const;
 
 private:
-    void initImGui();
-
     ImGuiTestApp(const ImGuiTestApp&)            = delete;
     ImGuiTestApp& operator=(const ImGuiTestApp&) = delete;
 };


### PR DESCRIPTION
Some tests need to initialize ImGui very early, for example, any test using Dashboard will access ImGui early due to styling code.