### PR TITLE
App.hpp: remove scheduleMessages call from main thread

### DIFF
--- a/src/ui/App.hpp
+++ b/src/ui/App.hpp
@@ -105,7 +105,6 @@ public:
                         // TODO: handle error return message
                     }
                     while (!stopRequested && _scheduler.isProcessing()) {
-                        _scheduler.processScheduledMessages();
                         std::this_thread::sleep_for(std::chrono::milliseconds(100));
                     }
                     if (auto e = _scheduler.changeStateTo(gr::lifecycle::State::REQUESTED_STOP); !e) {


### PR DESCRIPTION
This fixes an assertion that is triggered irregularly in the opendigitizer-ui.

ScheduleMessages is already called from from the scheduler's thread pool threads while the flowgraph is running, running it here additionally leads to multiple invocations of the blocks' message port buffer's reserve function via the same writer, triggering an assertion that will terminate the program.