### PR TITLE
Deployment fixes II: allow loading of default flowgraphs

### DIFF
--- a/src/service/dashboard/defaultDashboards/RemoteDataSet/flowgraph
+++ b/src/service/dashboard/defaultDashboards/RemoteDataSet/flowgraph
@@ -2,15 +2,15 @@ blocks:
   - name: !!str remote stream
     id: !!str opendigitizer::RemoteStreamSource
     parameters:
-      remote_uri: !!str https://localhost:8080/GnuRadio/Acquisition?channelNameFilter=test
+      remote_uri: !!str /GnuRadio/Acquisition?channelNameFilter=test
   - name: !!str remote triggered
     id: !!str opendigitizer::RemoteDataSetSource
     parameters:
-      remote_uri: !!str https://localhost:8080/GnuRadio/Acquisition?channelNameFilter=test&acquisitionModeFilter=triggered&preSamples=500&postSamples=500&triggerNameFilter=CMD_DIAG_TRIGGER1%2FCMD_DIAG_TRIGGER1
+      remote_uri: !!str /GnuRadio/Acquisition?channelNameFilter=test&acquisitionModeFilter=triggered&preSamples=500&postSamples=500&triggerNameFilter=CMD_DIAG_TRIGGER1%2FCMD_DIAG_TRIGGER1
   - name: !!str remote multiplexed
     id: !!str opendigitizer::RemoteDataSetSource
     parameters:
-      remote_uri: !!str https://localhost:8080/GnuRadio/Acquisition?channelNameFilter=test&acquisitionModeFilter=multiplexed&triggerNameFilter=%5BCMD_BP_START%2FFAIR.SELECTOR.C%3D1%3AS%3D1%3AP%3D2%2C%20CMD_BP_START%2FFAIR.SELECTOR.C%3D1%3AS%3D1%3AP%3D6%5D
+      remote_uri: !!str /GnuRadio/Acquisition?channelNameFilter=test&acquisitionModeFilter=multiplexed&triggerNameFilter=%5BCMD_BP_START%2FFAIR.SELECTOR.C%3D1%3AS%3D1%3AP%3D2%2C%20CMD_BP_START%2FFAIR.SELECTOR.C%3D1%3AS%3D1%3AP%3D6%5D
   - name: !!str stream sink
     id: !!str opendigitizer::ImPlotSink
     parameters:

--- a/src/service/dashboard/defaultDashboards/RemoteStream/flowgraph
+++ b/src/service/dashboard/defaultDashboards/RemoteStream/flowgraph
@@ -8,7 +8,7 @@ blocks:
   - name: !!str remote source 1
     id: !!str opendigitizer::RemoteStreamSource
     parameters:
-      remote_uri: !!str https://localhost:8080/GnuRadio/Acquisition?channelNameFilter=test
+      remote_uri: !!str /GnuRadio/Acquisition?channelNameFilter=test
   - name: !!str sink 1
     id: !!str opendigitizer::ImPlotSinkDataSet
     parameters:

--- a/src/service/dashboard/defaultDashboards/RemoteTags/flowgraph
+++ b/src/service/dashboard/defaultDashboards/RemoteTags/flowgraph
@@ -2,7 +2,7 @@ blocks:
   - name: !!str RemoteStreamSource1
     id: !!str opendigitizer::RemoteStreamSource
     parameters:
-      remote_uri: !!str https://localhost:8080/GnuRadio/Acquisition?channelNameFilter=test
+      remote_uri: !!str /GnuRadio/Acquisition?channelNameFilter=test
   - name: !!str TagToSample1
     id: !!str opendigitizer::TagToSample
     parameters:

--- a/src/service/main.cpp
+++ b/src/service/main.cpp
@@ -67,12 +67,12 @@ int main(int argc, char** argv) {
 blocks:
   - name: !!str  source
     id: !!str opendigitizer::TestSource
-    template_args: !!str "float"
+    template_args: !!str "double"
   - name: !!str sink
     id: !!str gr::basic::DataSink
     parameters:
       signal_name: !!str test
-    template_args: !!str "float"
+    template_args: !!str "double"
 connections:
   - [source, 0, sink, 0]
 )";

--- a/src/service/main.cpp
+++ b/src/service/main.cpp
@@ -80,7 +80,7 @@ connections:
         std::ifstream     in(argv[1]);
         std::stringstream grcBuffer;
         if (!(grcBuffer << in.rdbuf())) {
-            fmt::println(std::cerr, "Could not read GRC file: {}", strerror(errno));
+            fmt::println(stderr, "Could not read GRC file: {}", strerror(errno));
             return 1;
         }
         grc = grcBuffer.str();
@@ -117,7 +117,7 @@ connections:
     gr::BlockRegistry registry;
     registerTestBlocks(registry);
     gr::PluginLoader pluginLoader(registry, {});
-    GrAcqWorker      grAcqWorker(broker, &pluginLoader, std::chrono::milliseconds(50));
+    GrAcqWorker      grAcqWorker(broker, &pluginLoader, 50ms);
     GrFgWorker       grFgWorker(broker, &pluginLoader, {grc, {}}, grAcqWorker);
 
     const opencmw::zmq::Context                               zctx{};

--- a/src/service/main.cpp
+++ b/src/service/main.cpp
@@ -86,7 +86,7 @@ connections:
         grc = grcBuffer.str();
     }
 
-    Digitizer::Settings settings;
+    Digitizer::Settings& settings = Digitizer::Settings::instance();
     fmt::print("Settings: host/port: {}:{}, {} {}\nwasmServeDir: {}\n", settings.hostname, settings.port, settings.disableHttps ? "(http disabled), " : "", settings.checkCertificates ? "(cert check disabled), " : "", settings.wasmServeDir);
     Broker broker("/PrimaryBroker");
     // REST backend

--- a/src/service/rest/fileserverRestBackend.hpp
+++ b/src/service/rest/fileserverRestBackend.hpp
@@ -68,12 +68,14 @@ public:
                 response.set_content("Not found", "text/plain");
             }
         };
-
         _svr.Get("/assets/.*", cmrcHandler);
         _svr.Get("/web/.*", cmrcHandler);
-        // catch nonexistent base files. probably this should just redirect to the main site
-        _svr.Get("/", cmrcHandler);
-        _svr.Get("/index.html", cmrcHandler);
+
+        auto redirectHandler = [this](const httplib::Request& request, httplib::Response& response) {
+            response.set_redirect("/web/index.html#dashboard=RemoteStream"); // TODO: make default dashboard configurable
+        };
+        _svr.Get("/", redirectHandler);
+        _svr.Get("/index.html", redirectHandler);
 
         // Register default handlers
         super_t::registerHandlers();

--- a/src/service/rest/fileserverRestBackend.hpp
+++ b/src/service/rest/fileserverRestBackend.hpp
@@ -1,5 +1,6 @@
 #include <majordomo/RestBackend.hpp>
 #include <majordomo/base64pp.hpp>
+#include <settings.hpp>
 
 using namespace opencmw::majordomo;
 
@@ -72,7 +73,8 @@ public:
         _svr.Get("/web/.*", cmrcHandler);
 
         auto redirectHandler = [this](const httplib::Request& request, httplib::Response& response) {
-            response.set_redirect("/web/index.html#dashboard=RemoteStream"); // TODO: make default dashboard configurable
+            auto& settings = Digitizer::Settings::instance();
+            response.set_redirect(fmt::format("/web/index.html#dashboard={}{}", settings.defaultDashboard, settings.darkMode ? "&darkMode=true" : ""));
         };
         _svr.Get("/", redirectHandler);
         _svr.Get("/index.html", redirectHandler);

--- a/src/service/rest/fileserverRestBackend.hpp
+++ b/src/service/rest/fileserverRestBackend.hpp
@@ -48,7 +48,7 @@ public:
 
             if (super_t::_vfs.is_file(path)) { // file embedded with cmakerc
                 // headers required for using the SharedArrayBuffer
-                response.set_header("Cache-Control", "public, max-age=36000"); // cache all artefacts for 10h
+                response.set_header("Cache-Control", "public, max-age=3600"); // cache all artefacts for 1h
                 // webworkers and wasm can only be executed if they have the correct mimetype
                 auto file = super_t::_vfs.open(path);
                 response.set_content(std::string(file.begin(), file.end()), contentType);
@@ -60,7 +60,7 @@ public:
                 data.resize(static_cast<unsigned long>(filesize));
                 file.seekg(0, std::ios::beg);
                 file.read(data.data(), filesize);
-                response.set_header("Cache-Control", "public, max-age=36000"); // cache all artefacts for 10h
+                response.set_header("Cache-Control", "public, max-age=3600"); // cache all artefacts for 1h
                 response.set_content(std::move(data), contentType);
             } else {
                 std::cerr << "File not found: " << _serverRoot / request.path << std::endl;

--- a/src/ui/App.hpp
+++ b/src/ui/App.hpp
@@ -29,8 +29,6 @@ namespace DigitizerUi {
 
 struct SDLState;
 
-static constexpr LookAndFeel::Style kDefaultStyle = LookAndFeel::Style::Dark;
-
 class App {
 public:
     std::string                       executable;
@@ -144,7 +142,7 @@ public:
 public:
     App() {
         BlockRegistry::instance().addBlockDefinitionsFromPluginLoader(*pluginLoader);
-        setStyle(kDefaultStyle);
+        setStyle(Digitizer::Settings::instance().darkMode ? LookAndFeel::Style::Dark : LookAndFeel::Style::Light);
     }
 
     static App& instance() {

--- a/src/ui/App.hpp
+++ b/src/ui/App.hpp
@@ -96,6 +96,9 @@ public:
                 gr::sendMessage<gr::message::Command::Subscribe>(_toScheduler, _scheduler.unique_name, gr::block::property::kLifeCycleState, {}, "UI");
                 gr::sendMessage<gr::message::Command::Subscribe>(_toScheduler, "", gr::block::property::kSetting, {}, "UI");
                 gr::sendMessage<gr::message::Command::Get>(_toScheduler, "", gr::block::property::kSetting, {}, "UI");
+                // set block settings for the remote sources to know the address of the service
+                // fmt::print("setting service address to all blocks (which implement the settings): {}://{}:{}\n", (Digitizer::Settings::instance().disableHttps ? "http" : "https"), Digitizer::Settings::instance().hostname, static_cast<int>(Digitizer::Settings::instance().port));
+                // gr::sendMessage<gr::message::Command::Set>(_toScheduler, "", gr::block::property::kSetting, {{"hostname", Digitizer::Settings::instance().hostname}, {"port", static_cast<int>(Digitizer::Settings::instance().port)}, {"scheme", Digitizer::Settings::instance().disableHttps ? "http" : "https"}}, "UI");
 
                 _thread = std::thread([this]() {
                     if (auto e = _scheduler.changeStateTo(gr::lifecycle::State::INITIALISED); !e) {

--- a/src/ui/Dashboard.cpp
+++ b/src/ui/Dashboard.cpp
@@ -565,22 +565,13 @@ void Dashboard::loadPlotSources() {
     }
 }
 
-void Dashboard::registerRemoteService(std::string_view blockName, std::string_view uri_) {
-    const auto uri = [&] -> std::optional<opencmw::URI<>> {
-        try {
-            return opencmw::URI<>(std::string(uri_));
-        } catch (const std::exception& e) {
-            auto msg = fmt::format("remote_source of '{}' is not a valid URI '{}': {}", blockName, uri_, e.what());
-            components::Notification::error(msg);
-            return {};
-        }
-    }();
-
+void Dashboard::registerRemoteService(std::string_view blockName, std::optional<opencmw::URI<>> uri) {
     if (!uri) {
         return;
     }
 
     const auto flowgraphUri = opencmw::URI<>::UriFactory(*uri).path("/flowgraph").setQuery({}).build().str();
+    fmt::print("block {} adds subscription to remote flowgraph service: {} -> {}\n", blockName, uri->str(), flowgraphUri);
     m_flowgraphUriByRemoteSource.insert({std::string{blockName}, flowgraphUri});
 
     const auto it = std::ranges::find_if(m_services, [&](const auto& s) { return s.uri == flowgraphUri; });

--- a/src/ui/Dashboard.hpp
+++ b/src/ui/Dashboard.hpp
@@ -124,7 +124,7 @@ public:
         void execute();
         void emplaceBlock(std::string type, std::string params);
     };
-    void registerRemoteService(std::string_view blockName, std::string_view uri);
+    void registerRemoteService(std::string_view blockName, std::optional<opencmw::URI<>> uri);
     void unregisterRemoteService(std::string_view blockName);
     void removeUnusedRemoteServices();
 

--- a/src/ui/Flowgraph.cpp
+++ b/src/ui/Flowgraph.cpp
@@ -155,6 +155,7 @@ void Block::setSetting(const std::string& settingName, const pmtv::pmt& p) {
     m_settings[settingName] = p;
 
     gr::Message msg;
+    msg.cmd         = gr::message::Command::Set;
     msg.serviceName = m_uniqueName;
     msg.endpoint    = gr::block::property::kStagedSetting;
     msg.data        = gr::property_map{{settingName, p}};

--- a/src/ui/RemoteSignalSources.hpp
+++ b/src/ui/RemoteSignalSources.hpp
@@ -73,7 +73,7 @@ protected:
 };
 
 class SignalList {
-    Digitizer::Settings            settings;
+    Digitizer::Settings&           settings      = Digitizer::Settings::instance();
     opencmw::client::ClientContext clientContext = []() {
         std::vector<std::unique_ptr<opencmw::client::ClientBase>> clients;
         clients.emplace_back(std::make_unique<opencmw::client::RestClient>(opencmw::client::DefaultContentTypeHeader(opencmw::MIME::BINARY)));

--- a/src/ui/components/ImGuiNotify.hpp
+++ b/src/ui/components/ImGuiNotify.hpp
@@ -349,7 +349,10 @@ inline std::vector<ImGuiToast> notifications;
  * Inserts a new notification into the notification queue.
  * @param toast The notification to be inserted.
  */
-inline void InsertNotification(const ImGuiToast& toast) { notifications.push_back(toast); }
+inline void InsertNotification(const ImGuiToast& toast) {
+    fmt::print("{} - {}\n", toast.getTitle(), toast.getContent());
+    notifications.push_back(toast);
+}
 
 /**
  * @brief Removes a notification from the list of notifications.

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -300,6 +300,9 @@ int main(int argc, char** argv) {
             fmt::print("Loading dashboard from '{}'\n", url);
             app.loadDashboard(url);
         }
+    } else if (!settings.defaultDashboard.empty()) {
+        // TODO: add subscription to remote dashboard worker if needed
+        app.loadDashboard(settings.defaultDashboard);
     }
     if (auto first_dashboard = app.openDashboardPage.get(0); app.dashboard == nullptr && first_dashboard != nullptr) { // load first dashboard if there is a dashboard available
         app.loadDashboard(first_dashboard);

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -177,7 +177,7 @@ int main(int argc, char** argv) {
         return -1;
     }
 
-    Digitizer::Settings settings;
+    Digitizer::Settings& settings = Digitizer::Settings::instance();
 
 #if defined(IMGUI_IMPL_OPENGL_ES2)
     // GL ES 2.0 + GLSL 100

--- a/src/ui/test/ImGuiTestApp.cpp
+++ b/src/ui/test/ImGuiTestApp.cpp
@@ -89,7 +89,7 @@ void ImGuiTestApp::initImGui() {
     ImGuiTestEngine_Start(_engine, ImGui::GetCurrentContext());
     ImGuiTestEngine_InstallDefaultCrashHandler();
 
-    App::setImGuiStyle(kDefaultStyle);
+    App::setImGuiStyle(LookAndFeel::Style::Dark);
 
     registerTests();
 }


### PR DESCRIPTION
This PR contains different small changes for the rollout of the opendigitizer application:

- reduce cache time for assets served from opendigitizer service (future improvement: use hash based etag)
- redirect from document root to the wasm client with the default dashboard
  - The default dashboard to redirect to can be configured by setting the environment variable `DIGITIZER_DASHBOARD` before launching the service.
- Darkmode: default to light, allow to preset using Environment variable `DIGITIZER_DARK_MODE=[true,True,1,yes]` for native or the url fragment `.../index.html#[dashboard=<...>&]darkMode=true` for emscripten.
- allow relative paths in Remote source urls. This is implemented by an additional block setting `host`, which is set to the base url at flowgraph initialization.
  - note that at the moment absolute paths are only working if they point to the same service, subscribing to sources on different servers (or even just different hostnames/ports) is not possible due to same origin policy. We need to investigate which headers we can use to allow subscriptions to other services.