### PR TITLE
add support for multiple UI axes, axis scales, and UTC time axis

### DIFF
--- a/src/ui/blocks/ImPlotSink.hpp
+++ b/src/ui/blocks/ImPlotSink.hpp
@@ -9,6 +9,7 @@
 #include <gnuradio-4.0/DataSet.hpp>
 #include <gnuradio-4.0/HistoryBuffer.hpp>
 
+#include "../Dashboard.hpp"
 #include "../common/ImguiWrap.hpp"
 
 #include <implot.h>
@@ -21,47 +22,63 @@ struct TagData {
     gr::property_map map;
 };
 
-inline void drawAndPruneTags(std::deque<TagData>& tagValues, double minX, double maxX, const ImVec4& color) {
-    std::erase_if(tagValues, [=](const auto& tag) { return static_cast<double>(tag.timestamp) < std::min(minX, maxX); });
+template<typename T>
+T getValueOrDefault(const gr::property_map& map, const std::string& key, const T& defaultValue) {
+    if (auto it = map.find(key); it != map.end()) {
+        if (auto ptr = std::get_if<T>(&it->second)) {
+            return *ptr;
+        }
+    }
+    return defaultValue;
+}
 
+inline void drawAndPruneTags(std::deque<TagData>& tagValues, double minX, double maxX, DigitizerUi::AxisScale axisScale, const ImVec4& color) {
+    using DigitizerUi::AxisScale;
+    using enum DigitizerUi::AxisScale;
+
+    std::erase_if(tagValues, [=](const auto& tag) { return static_cast<double>(tag.timestamp) < std::min(minX, maxX); });
     if (tagValues.empty()) {
         return;
     }
-
-    auto getStringOrDefault = [](const gr::property_map& map, const std::string& key, const std::string& defaultValue) -> std::string {
-        if (auto it = map.find(key); it != map.end()) {
-            if (auto strPtr = std::get_if<std::string>(&it->second)) {
-                return *strPtr;
-            }
-        }
-        return defaultValue;
-    };
 
     const float  fontHeight = ImGui::GetFontSize();
     const double yMax       = ImPlot::GetPlotLimits(IMPLOT_AUTO, IMPLOT_AUTO).Y.Max;
     ImGui::PushStyleColor(ImGuiCol_Text, color);
     float lastTextPixelX = -std::numeric_limits<float>::infinity();
     for (const auto& tag : tagValues) {
-        const double x         = tag.timestamp;
-        const float  xPixelPos = ImPlot::PlotToPixels(x, 0.0f).x;
+        double xTagPosition = tag.timestamp;
+        switch (axisScale) {
+        case Linear:
+        case Log10:
+        case SymLog: {
+            xTagPosition -= minX;
+        } break;
+        case LinearReverse: {
+            xTagPosition -= maxX;
+        } break;
+        case Time:
+        default: {
+        }
+        }
+        const float xPixelPos = ImPlot::PlotToPixels(xTagPosition, 0.0f).x;
 
         ImPlot::SetNextLineStyle(color);
-        ImPlot::PlotInfLines("TagLines", &x, 1, ImPlotInfLinesFlags_None);
+        ImPlot::PlotInfLines("TagLines", &xTagPosition, 1, ImPlotInfLinesFlags_None);
 
         // suppress tag labels if it is too close to the previous one
         if (xPixelPos - lastTextPixelX > 2.0f * fontHeight || lastTextPixelX == -std::numeric_limits<float>::infinity()) {
-            const std::string triggerLabel     = getStringOrDefault(tag.map, "trigger_name", "TRIGGER");
+            const std::string triggerLabel     = getValueOrDefault<std::string>(tag.map, "trigger_name", "TRIGGER");
             const ImVec2      triggerLabelSize = ImGui::CalcTextSize(triggerLabel.c_str());
 
-            ImPlot::PlotText(triggerLabel.c_str(), x, yMax, {-fontHeight + 2.0f, 1.0f * triggerLabelSize.x}, ImPlotTextFlags_Vertical);
+            ImPlot::PlotText(triggerLabel.c_str(), xTagPosition, yMax, {-fontHeight + 2.0f, 1.0f * triggerLabelSize.x}, ImPlotTextFlags_Vertical);
 
             if (auto metaInfo = tag.map.find("trigger_meta_info"); metaInfo != tag.map.end()) {
                 if (auto mapPtr = std::get_if<gr::property_map>(&metaInfo->second)) {
                     auto              extractCtx = [](const std::string& s) { return s.substr(s.rfind('/') + 1); };
-                    const std::string triggerCtx = extractCtx(getStringOrDefault(*mapPtr, "context", ""));
+                    const std::string triggerCtx = extractCtx(getValueOrDefault<std::string>(*mapPtr, "context", ""));
                     if (!triggerCtx.empty()) {
                         const ImVec2 triggerCtxLabelSize = ImGui::CalcTextSize(triggerCtx.c_str());
-                        ImPlot::PlotText(triggerCtx.c_str(), x, yMax, {5.0f, 1.0f * triggerCtxLabelSize.x}, ImPlotTextFlags_Vertical);
+                        ImPlot::PlotText(triggerCtx.c_str(), xTagPosition, yMax, {5.0f, 1.0f * triggerCtxLabelSize.x}, ImPlotTextFlags_Vertical);
                     }
                 }
             }
@@ -72,11 +89,17 @@ inline void drawAndPruneTags(std::deque<TagData>& tagValues, double minX, double
     ImGui::PopStyleColor();
 }
 
+inline void setYAxisFromConfig(const gr::property_map& config) {
+    static constexpr ImAxis yAxes[] = {ImAxis_Y1, ImAxis_Y2, ImAxis_Y3};
+    ImPlot::SetAxis(yAxes[std::clamp(getValueOrDefault<int>(config, "axisID", 0), 0, 2)]);
+}
+
 struct ImPlotSinkManager {
 private:
     ImPlotSinkManager() {}
 
-    ImPlotSinkManager(const ImPlotSinkManager&)            = delete;
+    ImPlotSinkManager(const ImPlotSinkManager&) = delete;
+
     ImPlotSinkManager& operator=(const ImPlotSinkManager&) = delete;
 
     struct SinkModel {
@@ -123,19 +146,21 @@ using ImPlotSinkBase = gr::Block<TBlock, gr::BlockingIO<false>, gr::SupportedTyp
 template<typename T>
 struct ImPlotSink : public ImPlotSinkBase<ImPlotSink<T>> {
     gr::PortIn<T> in;
-    uint32_t      color = 0xff0000;
-    ///< RGB color for the plot // TODO use better type, support configurable colors for datasets?
-    gr::Size_t  required_size = 2048U; // TODO: make this a multi-consumer/vector property
-    std::string signal_name;
-    std::string signal_quantity;
-    std::string signal_unit;
-    float       signal_min  = std::numeric_limits<float>::lowest();
-    float       signal_max  = std::numeric_limits<float>::max();
-    float       sample_rate = 1000.0f;
+    uint32_t      color         = 0xff0000; ///< RGB color for the plot // TODO use better type, support configurable colors for datasets?
+    gr::Size_t    required_size = 2048U;    // TODO: make this a multi-consumer/vector property
+    std::string   signal_name;
+    std::string   signal_quantity;
+    std::string   signal_unit;
+    float         signal_min  = std::numeric_limits<float>::lowest();
+    float         signal_max  = std::numeric_limits<float>::max();
+    float         sample_rate = 1000.0f;
 
     GR_MAKE_REFLECTABLE(ImPlotSink, in, color, required_size, signal_name, signal_quantity, signal_unit, signal_min, signal_max, sample_rate);
 
+    double                    _xUtcOffset   = 0.;
+    std::uint64_t             _utcOffsetIdx = 0U; // index since last clock update
     gr::HistoryBuffer<double> _xValues{required_size};
+    gr::HistoryBuffer<double> _xUtcValues{required_size};
     gr::HistoryBuffer<double> _yValues{required_size};
     std::deque<TagData>       _tagValues{};
 
@@ -146,6 +171,7 @@ struct ImPlotSink : public ImPlotSinkBase<ImPlotSink<T>> {
     void settingsChanged(const gr::property_map& old_settings, const gr::property_map& /*new_settings*/) {
         if (_xValues.capacity() != required_size) {
             _xValues.resize(required_size);
+            _xUtcValues.resize(required_size);
             _tagValues.clear();
         }
         if (_yValues.capacity() != required_size) {
@@ -156,22 +182,63 @@ struct ImPlotSink : public ImPlotSinkBase<ImPlotSink<T>> {
 
     constexpr void processOne(const T& input) noexcept {
         if constexpr (std::is_arithmetic_v<T>) {
-            in.max_samples  = static_cast<std::size_t>(2.f * sample_rate / 25.f);
-            const double Ts = 1.0 / static_cast<double>(sample_rate);
-            _xValues.push_back(_xValues[_xValues.size() - 1] + 2 * Ts);
+            in.max_samples = static_cast<std::size_t>(2.f * sample_rate / 25.f);
         }
-        _yValues.push_back(input);
+        if (this->inputTagsPresent()) { // received tag
+            const gr::property_map& tag = this->_mergedInputTag.map;
 
-        if (this->inputTagsPresent()) {
-            // received tag
-            _tagValues.push_back({_xValues[0], this->mergedInputTag().map});
+            if (tag.contains("trigger_time")) {
+                const auto offset  = static_cast<double>(getValueOrDefault<float>(tag, "trigger_offset", 0.f));
+                const auto utcTime = static_cast<double>(getValueOrDefault<uint64_t>(tag, "trigger_time", 0U)) + offset;
+                if (utcTime > 0.0 || (utcTime + offset) > 0.0) {
+                    _xUtcOffset   = (utcTime + offset) * 1e-9;
+                    _utcOffsetIdx = 0U;
+                }
+                _tagValues.push_back({.timestamp = _xUtcOffset, .map = this->mergedInputTag().map});
+            }
             this->_mergedInputTag.map.clear(); // TODO: provide proper API for clearing tags
         }
+
+        if (_utcOffsetIdx == 0) {
+            if (_xUtcOffset == 0.0) {
+                using namespace std::chrono;
+                auto now      = system_clock::now().time_since_epoch();
+                _xUtcOffset   = duration<double, std::nano>(now).count() * 1e-9;
+                _utcOffsetIdx = 0U;
+            }
+            _xUtcValues.push_back(_xUtcOffset);
+        } else {
+            if constexpr (std::is_arithmetic_v<T>) {
+                const double Ts = 1.0 / static_cast<double>(sample_rate);
+                _xUtcValues.push_back(_xUtcValues.back() + Ts);
+            }
+        }
+        if constexpr (std::is_arithmetic_v<T>) {
+            const double Ts = 1.0 / static_cast<double>(sample_rate);
+            if (_xValues.size() == 0UZ) {
+                _xValues.push_back(0.0);
+            } else {
+                _xValues.push_back(_xValues.back() + Ts);
+            }
+        }
+        _yValues.push_back(input);
+        _utcOffsetIdx++;
     }
 
     gr::work::Status draw(const gr::property_map& config = {}) noexcept {
+        using DigitizerUi::AxisScale;
+        using enum DigitizerUi::AxisScale;
         [[maybe_unused]] const gr::work::Status status = this->invokeWork();
-        const auto&                             label  = signal_name.empty() ? this->name.value : signal_name;
+
+        setYAxisFromConfig(config);
+        std::string scaleStr = config.contains("scale") ? std::get<std::string>(config.at("scale")) : "Linear";
+        auto        trim     = [](const std::string& str) {
+            auto start = std::ranges::find_if_not(str, [](unsigned char ch) { return std::isspace(ch); });
+            auto end   = std::ranges::find_if_not(str.rbegin(), str.rend(), [](unsigned char ch) { return std::isspace(ch); }).base();
+            return (start < end) ? std::string(start, end) : std::string{};
+        };
+        const AxisScale    axisScale = magic_enum::enum_cast<AxisScale>(trim(scaleStr)).value_or(AxisScale::Linear);
+        const std::string& label     = signal_name.empty() ? this->name.value : signal_name;
         if (_yValues.empty()) {
             // plot one single dummy value so that the sink shows up in the plot legend
             double v = {};
@@ -179,15 +246,36 @@ struct ImPlotSink : public ImPlotSinkBase<ImPlotSink<T>> {
         } else {
             ImVec4 lineColor = ImGui::ColorConvertU32ToFloat4(0xFF000000 | ((color & 0xFF) << 16) | (color & 0xFF00) | ((color & 0xFF0000) >> 16));
             ImPlot::SetNextLineStyle(lineColor);
-            ImPlot::PlotLine(label.c_str(), _xValues.get_span(0).data(), _yValues.get_span(0).data(), static_cast<int>(_xValues.size()));
 
-            if (config.contains("draw_tag")) {
-                const bool* drawTag = std::get_if<bool>(&config.at("draw_tag"));
-                if (!drawTag || !*drawTag) {
-                    return gr::work::Status::OK;
-                }
+            switch (axisScale) {
+            case Time: {
+                ImPlot::PlotLine(label.c_str(), _xUtcValues.get_span(0).data(), _yValues.get_span(0).data(), static_cast<int>(_xValues.size()));
+            } break;
+            case LinearReverse: {
+                // like Linear but normalised to the newest _xValues.back() thus the axis range is [xValues.front() - xValues.back(), 0]
+                ImPlot::PlotLineG(
+                    label.c_str(),
+                    [](int idx, void* user_data) -> ImPlotPoint {
+                        auto   self     = static_cast<ImPlotSink<T>*>(user_data);
+                        double xShifted = self->_xValues[idx] - self->_xValues.back();
+                        double y        = self->_yValues[idx];
+                        return ImPlotPoint(xShifted, y);
+                    },
+                    this,                             // user_data pointer passed to the lambda
+                    static_cast<int>(_xValues.size()) // number of points
+                );
+            } break;
+            case Linear:
+            default: {
+                ImPlot::PlotLine(label.c_str(), _xValues.get_span(0).data(), _yValues.get_span(0).data(), static_cast<int>(_xValues.size()));
+            } break;
+            }
+
+            if (getValueOrDefault<bool>(config, "draw_tag", false)) {
                 lineColor.w *= 0.75f; // semi-transparent tags
-                drawAndPruneTags(_tagValues, _xValues.back(), _xValues.front(), lineColor);
+                drawAndPruneTags(_tagValues, _xUtcValues.front(), _xUtcValues.back(), axisScale, lineColor);
+            } else {
+                return gr::work::Status::OK;
             }
         }
 
@@ -200,12 +288,13 @@ struct ImPlotSinkDataSet : public ImPlotSinkBase<ImPlotSinkDataSet<T>> {
     gr::PortIn<gr::DataSet<T>> in;
     uint32_t                   color = 0xff0000; ///< RGB color for the plot // TODO use better type, support configurable colors for datasets?
     std::string                signal_name;
+    std::string                signal_quantity;
     std::string                signal_unit;
     float                      signal_min    = std::numeric_limits<float>::lowest();
     float                      signal_max    = std::numeric_limits<float>::max();
     gr::Size_t                 dataset_index = std::numeric_limits<gr::Size_t>::max();
 
-    GR_MAKE_REFLECTABLE(ImPlotSinkDataSet, in, color, signal_name, signal_unit, signal_min, signal_max, dataset_index);
+    GR_MAKE_REFLECTABLE(ImPlotSinkDataSet, in, color, signal_name, signal_quantity, signal_unit, signal_min, signal_max, dataset_index);
 
 public:
     ImPlotSinkDataSet(gr::property_map initParameters) : ImPlotSinkBase<ImPlotSinkDataSet<T>>(std::move(initParameters)) { ImPlotSinkManager::instance().registerPlotSink(this); }
@@ -239,7 +328,6 @@ public:
         return gr::work::Status::OK;
     }
 };
-
 } // namespace opendigitizer
 
 inline static auto registerImPlotSink        = gr::registerBlock<opendigitizer::ImPlotSink, float, double>(gr::globalBlockRegistry());

--- a/src/ui/components/Docking.hpp
+++ b/src/ui/components/Docking.hpp
@@ -27,7 +27,7 @@ inline constexpr const char* dockingLayoutName(DockingLayoutType type) {
 
 /// Hosts a group of dock windows
 class DockSpace {
-    DockingLayoutType _layoutType      = DockingLayoutType::Row;
+    DockingLayoutType _layoutType      = DockingLayoutType::Grid;
     bool              _needsRelayout   = true;
     size_t            _lastWindowCount = 0;
 

--- a/src/ui/test/examples/fg_dipole_intensity_ramp.grc
+++ b/src/ui/test/examples/fg_dipole_intensity_ramp.grc
@@ -134,8 +134,8 @@ blocks:
         time: !!uint64 0
         parameters:
           duration: !!float32 0.000000
-          start_value: !!float32 40.000000
-          final_value: !!float32 40.000000
+          start_value: !!float32 40e9f
+          final_value: !!float32 40e9f
           impulse_time0: !!float32 0.000000
           impulse_time1: !!float32 0.000000
           round_off_time: !!float32 0.000000
@@ -145,8 +145,8 @@ blocks:
         time: !!uint64 0
         parameters:
           duration: !!float32 0.500000
-          start_value: !!float32 40.000000
-          final_value: !!float32 38.000000
+          start_value: !!float32 40e9f
+          final_value: !!float32 38e9f
           impulse_time0: !!float32 0.000000
           impulse_time1: !!float32 0.000000
           round_off_time: !!float32 0.000000
@@ -156,8 +156,8 @@ blocks:
         time: !!uint64 0
         parameters:
           duration: !!float32 2.000000
-          start_value: !!float32 38.000000
-          final_value: !!float32 00.000000
+          start_value: !!float32 38e9f
+          final_value: !!float32 00e9f
           impulse_time0: !!float32 0.000000
           impulse_time1: !!float32 0.000000
           round_off_time: !!float32 0.300000

--- a/src/ui/test/examples/fg_dipole_intensity_ramp.yml
+++ b/src/ui/test/examples/fg_dipole_intensity_ramp.yml
@@ -11,16 +11,26 @@ plots:
   - name: Plot 1
     axes:
       - axis: X
-        min: 0.0
+        min: NaN # auto-range min
         max: NaN # auto-range max
+        scale: LinearReverse # options: Linear, LinearReverse, Time, Log10, SymLog
       - axis: Y
-        min: -0.01
-        max: 50.0
+        min: NaN # auto-range min
+        max: NaN # auto-range max
     sources:
-      - DipoleCurrentSink
       - IntensitySink
-    rect:
-      - 8
-      - 0
-      - 8
-      - 8
+      - DipoleCurrentSink
+    rect: [0, 0, 8, 1] # x, y, width, height
+  - name: Plot 2
+    axes:
+      - axis: X
+        min: NaN # auto-range min
+        max: NaN # auto-range max
+        scale: Time # UTC time axis, other options: Linear, LinearReverse, Time, Log10, SymLog
+      - axis: Y
+        min: NaN # auto-range min
+        max: NaN # auto-range max
+    sources:
+      - IntensitySink
+      - DipoleCurrentSink
+    rect: [0, 1, 8, 1] # x, y, width, height


### PR DESCRIPTION
 * axes scale is configured via `scale = []` attribute
 * whether signals are on the same or different axes is controlled by the `signal_quantity` and `signal_unit`
 * auto range is configured whether axis min/max is set to `NaN` have a look at the `fg_dipole_intensity_ramp.yml` for examples.
 * bumped GR4 to latest

![chart_fg_dipole_0001](https://github.com/user-attachments/assets/d022c3c4-57fa-4b4d-80ab-b813e2265106)

