### PR TITLE
qa_chart_fgdipole: lazy eval for unexpected value

### DIFF
--- a/src/ui/test/qa_chart_fgdipole.cpp
+++ b/src/ui/test/qa_chart_fgdipole.cpp
@@ -50,7 +50,7 @@ struct TestState {
         schedulerThread = std::thread([&] {
             scheduler = std::make_unique<TestScheduler<gr::profiling::null::Profiler>>(std::move(graph));
             auto ret  = scheduler->runAndWait();
-            expect(ret.has_value()) << std::format("TestScheduler returned with: {} in {}:{}", ret.error().message, ret.error().srcLoc(), ret.error().methodName());
+            expect(ret.has_value()) << [&ret]() { return std::format("TestScheduler returned with: {} in {}:{}", ret.error().message, ret.error().srcLoc(), ret.error().methodName()); };
         });
     }
 


### PR DESCRIPTION
Fixes test segfault by only evaluating the unexpected value in the failure case.