### PR TITLE
GnuRadioAcquisitionWorker: limit scheduler threads to 2

### DIFF
--- a/src/service/gnuradio/GnuRadioAcquisitionWorker.hpp
+++ b/src/service/gnuradio/GnuRadioAcquisitionWorker.hpp
@@ -197,6 +197,7 @@ class GnuRadioAcquisitionWorker : public Worker<serviceName, TimeDomainContext, 
     std::unique_ptr<gr::Graph>                                                    _pendingFlowGraph;
     std::unique_ptr<scheduler::Simple<scheduler::ExecutionPolicy::multiThreaded>> _scheduler;
     std::mutex                                                                    _graphChangeMutex;
+    std::shared_ptr<thread_pool::BasicThreadPool>                                 _threadPool = std::make_shared<thread_pool::BasicThreadPool>("scheduler_Pool", gr::thread_pool::CPU_BOUND, 2, 2);
 
 public:
     using super_t = Worker<serviceName, TimeDomainContext, Empty, Acquisition, Meta...>;
@@ -364,7 +365,7 @@ private:
                         auto entries = signalEntryBySink | std::views::values;
                         _updateSignalEntriesCallback(std::vector(entries.begin(), entries.end()));
                     }
-                    _scheduler             = std::make_unique<scheduler::Simple<scheduler::ExecutionPolicy::multiThreaded>>(std::move(*pendingFlowGraph));
+                    _scheduler             = std::make_unique<scheduler::Simple<scheduler::ExecutionPolicy::multiThreaded>>(std::move(*pendingFlowGraph), _threadPool);
                     _messagesToScheduler   = std::make_unique<MsgPortOut>();
                     _messagesFromScheduler = std::make_unique<MsgPortIn>();
                     std::ignore            = _messagesToScheduler->connect(_scheduler->msgIn);


### PR DESCRIPTION
Since the current scheduler will spin on all cores by default, limit the scheduler to run with a fixed 2 core pool. This is also more in line with what is available on the target systems.