### PR TITLE
Smaller client fixes

### DIFF
--- a/src/ui/Dashboard.cpp
+++ b/src/ui/Dashboard.cpp
@@ -103,7 +103,7 @@ auto fetch(const std::shared_ptr<DashboardSource>& source, const std::string& na
                     std::string_view sv(s, e);
                     auto             p = sv.find(';');
                     assert(p != sv.npos);
-                    std::size_t size = std::stoul(s);
+                    std::size_t size = std::stoul(std::string(s, p));
                     s += p + 1; // the +1 is for the ';'
 
                     reply[i].resize(size);

--- a/src/utils/include/settings.hpp
+++ b/src/utils/include/settings.hpp
@@ -51,7 +51,7 @@ struct Settings {
     bool        checkCertificates{true};
     bool        darkMode{false};
     std::string wasmServeDir{""};
-    std::string defaultDashboard{"RemoteStreaming"};
+    std::string defaultDashboard{"RemoteStream"};
 
 private:
     Settings() {


### PR DESCRIPTION
Fixes a memory issue in the Opendigitizer UI and also suppresses the subscription errors at startup by only subscribing once the base host url has been set by the scheduler.