### PR TITLE
Set proper layout on load, check if dashboard is initialised.

### DIFF
--- a/src/ui/App.hpp
+++ b/src/ui/App.hpp
@@ -196,7 +196,7 @@ public:
             }
 
             if (dashboard != nullptr) {
-                if (loadedDashboard != dashboard.get()) {
+                if (loadedDashboard != dashboard.get() && dashboard->isInitialised()) {
                     // Are we in the process of changing the dashboard?
                     loadedDashboard = dashboard.get();
                     dashboardPage   = std::make_unique<DashboardPage>();
@@ -207,11 +207,11 @@ public:
             }
 
             if (mainViewMode == ViewMode::VIEW || mainViewMode == ViewMode::LAYOUT) {
-                if (dashboard != nullptr) {
+                if (dashboard != nullptr && dashboard->isInitialised()) {
                     dashboardPage->draw(mainViewMode == ViewMode::VIEW ? DashboardPage::Mode::View : DashboardPage::Mode::Layout);
                 }
             } else if (mainViewMode == ViewMode::FLOWGRAPH) {
-                if (dashboard != nullptr) {
+                if (dashboard != nullptr && dashboard->isInitialised()) {
                     if (previousViewMode != ViewMode::FLOWGRAPH) {
                         dashboard->graphModel().requestGraphUpdate();
                         dashboard->graphModel().requestAvailableBlocksTypesUpdate();

--- a/src/ui/Dashboard.cpp
+++ b/src/ui/Dashboard.cpp
@@ -224,6 +224,7 @@ void Dashboard::setNewDescription(const std::shared_ptr<DashboardDescription>& d
 
 void Dashboard::load() {
     if (!m_desc->storageInfo->isInMemoryDashboardStorage()) {
+        m_isInitialised.store(false, std::memory_order_release);
         isInUse = true;
         fetch(
             m_desc->storageInfo, m_desc->filename, {What::Flowgraph, What::Dashboard}, //
@@ -271,6 +272,7 @@ void Dashboard::loadAndThen(const std::string& grcData, const std::string& dashb
 
         // Load is called after parsing the flowgraph so that we already have the list of sources
         doLoad(dashboardData);
+        m_isInitialised.store(true, std::memory_order_release);
     } catch (const gr::exception& e) {
 #ifndef NDEBUG
         fmt::println(stderr, "Dashboard::load(const std::string& grcData,const std::string& dashboardData): error: {}", e);

--- a/src/ui/Dashboard.hpp
+++ b/src/ui/Dashboard.hpp
@@ -199,12 +199,15 @@ public:
 
     void handleMessages() { m_scheduler.handleMessages(m_graphModel); }
 
+    [[nodiscard]] bool isInitialised() const noexcept { return m_isInitialised.load(std::memory_order_acquire); }
+
 private:
-    std::shared_ptr<DashboardDescription>        m_desc;
+    std::shared_ptr<DashboardDescription>        m_desc = nullptr;
     std::vector<Plot>                            m_plots;
     DockingLayoutType                            m_layout;
     std::unordered_map<std::string, std::string> m_flowgraphUriByRemoteSource;
     plf::colony<Service>                         m_services;
+    std::atomic<bool>                            m_isInitialised = false;
 
     Scheduler m_scheduler;
 

--- a/src/ui/OpenDashboardPage.cpp
+++ b/src/ui/OpenDashboardPage.cpp
@@ -113,7 +113,7 @@ static constexpr float indent = 20;
 void OpenDashboardPage::dashboardControls(Dashboard* optionalDashboard) {
     IMW::Font titleFont(LookAndFeel::instance().fontBigger[LookAndFeel::instance().prototypeMode]);
 
-    if (optionalDashboard) {
+    if (optionalDashboard != nullptr && optionalDashboard->isInitialised()) {
         auto desc = optionalDashboard->description();
         ImGui::Text("%s (%s)", desc->name.c_str(), desc->storageInfo->path.c_str());
     } else {
@@ -122,7 +122,7 @@ void OpenDashboardPage::dashboardControls(Dashboard* optionalDashboard) {
 
     ImGui::Dummy({indent, 20});
     ImGui::SameLine();
-    const bool dashboardLoaded = optionalDashboard != nullptr;
+    const bool dashboardLoaded = optionalDashboard != nullptr && optionalDashboard->isInitialised();
 
     IMW::Disabled disabled(!dashboardLoaded);
 
@@ -153,10 +153,10 @@ void OpenDashboardPage::draw(Dashboard* optionalDashboard) {
         ImGui::AlignTextToFramePadding();
         ImGui::Text("Name:");
         ImGui::SameLine();
-        auto                                         desc = optionalDashboard ? optionalDashboard->description() : nullptr;
+        auto                                         desc = optionalDashboard != nullptr && optionalDashboard->isInitialised() ? optionalDashboard->description() : nullptr;
         static std::string                           name;
         static std::shared_ptr<DashboardStorageInfo> storageInfo;
-        if (ImGui::IsWindowAppearing()) {
+        if (ImGui::IsWindowAppearing() && desc != nullptr) {
             name        = desc->name;
             storageInfo = !desc->storageInfo->isInMemoryDashboardStorage() || m_storageInfos.empty() ? desc->storageInfo : m_storageInfos.front();
         }
@@ -181,13 +181,13 @@ void OpenDashboardPage::draw(Dashboard* optionalDashboard) {
         drawAddSourcePopup();
 
         bool okEnabled = !name.empty() && !storageInfo->isInMemoryDashboardStorage();
-        if (components::DialogButtons(okEnabled) == components::DialogButton::Ok) {
+        if (components::DialogButtons(okEnabled) == components::DialogButton::Ok && desc != nullptr) {
             auto newDesc         = std::make_shared<DashboardDescription>(*desc);
             newDesc->name        = name;
             newDesc->storageInfo = storageInfo;
             m_dashboards.push_back(newDesc);
 
-            if (optionalDashboard) {
+            if (optionalDashboard != nullptr && optionalDashboard->isInitialised()) {
                 optionalDashboard->setNewDescription(newDesc);
                 optionalDashboard->save();
             }
@@ -291,7 +291,7 @@ void OpenDashboardPage::draw(Dashboard* optionalDashboard) {
 
             const auto& name              = item.first->name;
             const auto& storageInfo       = item.first->storageInfo;
-            bool        isDashboardActive = optionalDashboard && optionalDashboard->description() && name == optionalDashboard->description()->name && storageInfo == optionalDashboard->description()->storageInfo;
+            bool        isDashboardActive = optionalDashboard != nullptr && optionalDashboard->isInitialised() && optionalDashboard->description() && name == optionalDashboard->description()->name && storageInfo == optionalDashboard->description()->storageInfo;
 
             {
                 IMW::Font font(isDashboardActive ? LookAndFeel::instance().fontIconsSolid : LookAndFeel::instance().fontIcons);


### PR DESCRIPTION
**Temporary workaround to ensure the `Free` layout works after reload:**  
Avoid setting a custom layout — always use the default `Free` layout.

The underlying issue needs to be properly addressed in future PRs.  
Currently, `App::loadDashboard()` and `dashboard->load()` do not wait for the dashboard to fully load. As a result, `dashboardPage->setDashboard()` and `dashboardPage->setLayout()` are called before the dashboard is ready.
