### PR TITLE
Add +/- buttons to set properties values

### DIFF
--- a/src/ui/common/ImguiWrap.hpp
+++ b/src/ui/common/ImguiWrap.hpp
@@ -19,6 +19,16 @@ inline bool ImGuiBeginDisabled(bool disabled) {
     return disabled;
 }
 
+void setItemTooltip(auto&&... args) {
+    if (ImGui::IsItemHovered()) {
+        if constexpr (sizeof...(args) == 0) {
+            ImGui::SetTooltip("");
+        } else {
+            ImGui::SetTooltip("%s", std::forward<decltype(args)...>(args...));
+        }
+    }
+}
+
 // We use different overloads of BeginChild, we will make separate RAII objects for them
 inline auto ImGuiBeginChild(const char* str_id, const ImVec2& size = ImVec2(0, 0), ImGuiChildFlags child_flags = 0, ImGuiWindowFlags window_flags = 0) { return ImGui::BeginChild(str_id, size, child_flags, window_flags); }
 

--- a/src/ui/components/Block.cpp
+++ b/src/ui/components/Block.cpp
@@ -227,6 +227,8 @@ void BlockSettingsControls(UiGraphBlock* block, bool /*verticalLayout*/, const I
                 return {};
             };
 
+            InputKeypad<>::clearIfNewBlock(block->blockUniqueName);
+
             std::visit(gr::meta::overloaded{[&](float val) {
                                                 ImGui::SetNextItemWidth(editorFieldWidth);
                                                 float temp = val;

--- a/src/ui/components/Block.cpp
+++ b/src/ui/components/Block.cpp
@@ -15,16 +15,6 @@ namespace DigitizerUi::components {
 constexpr const char* addContextPopupId    = "Add Context";
 constexpr const char* removeContextPopupId = "Remove Context";
 
-void setItemTooltip(auto&&... args) {
-    if (ImGui::IsItemHovered()) {
-        if constexpr (sizeof...(args) == 0) {
-            ImGui::SetTooltip("");
-        } else {
-            ImGui::SetTooltip("%s", std::forward<decltype(args)...>(args...));
-        }
-    }
-}
-
 void drawAddContextPopup(UiGraphBlock* block) {
     ImGui::SetNextWindowSize({600, 120}, ImGuiCond_Once);
     if (auto popup = IMW::ModalPopup(addContextPopupId, nullptr, 0)) {
@@ -129,7 +119,7 @@ void BlockControlsPanel(BlockControlsPanelContext& panelContext, const ImVec2& p
                 ImGui::OpenPopup(removeContextPopupId);
             }
         }
-        setItemTooltip("Remove context");
+        IMW::detail::setItemTooltip("Remove context");
 
         {
             ImGui::SameLine();
@@ -138,7 +128,7 @@ void BlockControlsPanel(BlockControlsPanelContext& panelContext, const ImVec2& p
                 ImGui::OpenPopup(addContextPopupId);
             }
         }
-        setItemTooltip("Add new context");
+        IMW::detail::setItemTooltip("Add new context");
 
         drawAddContextPopup(panelContext.block);
         if (drawRemoveContextPopup(activeContext.context)) {
@@ -180,17 +170,14 @@ void BlockControlsPanel(BlockControlsPanelContext& panelContext, const ImVec2& p
 }
 
 void BlockSettingsControls(UiGraphBlock* block, bool /*verticalLayout*/, const ImVec2& /*size*/) {
-    constexpr auto   editorFieldWidth = 100;
-    auto             storage          = ImGui::GetStateStorage();
-    IMW::ChangeStrId mainId("block_controls");
-    const auto&      style = ImGui::GetStyle();
+    constexpr auto editorFieldWidth = 150;
     if (auto table = IMW::Table("settings_table", 2, ImGuiTableFlags_SizingFixedFit, ImVec2(0, 0), 0.0f)) {
         // Setup columns without headers
         ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
         ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthStretch);
 
         int i = 0;
-        for (const auto& p : block->blockSettings) {
+        for (const auto& [key, value] : block->blockSettings) {
             // Do we know how to edit this type?
             if (!std::visit(gr::meta::overloaded{//
                                 [&](float) { return true; },
@@ -203,66 +190,69 @@ void BlockSettingsControls(UiGraphBlock* block, bool /*verticalLayout*/, const I
                                     }
                                     return false;
                                 }},
-                    p.second)) {
+                    value)) {
                 continue;
             };
 
-            auto          id = ImGui::GetID(p.first.c_str());
+            auto          id = ImGui::GetID(key.c_str());
             IMW::ChangeId rowId{int(id)};
-
-            auto* enabled = storage->GetBoolRef(id, true);
 
             ImGui::TableNextRow();
 
-            // Column 1: Checkbox + Label
+            // Column 1: Label
             ImGui::TableSetColumnIndex(0);
-            ImGui::Checkbox("##enabled", enabled);
-            ImGui::SameLine(0, style.ItemSpacing.x);
-            ImGui::TextUnformatted(p.first.c_str());
+            ImGui::TextUnformatted(key.c_str());
 
             // Column 2: Input
             ImGui::TableSetColumnIndex(1);
-            if (*enabled) {
-                char label[64];
-                snprintf(label, sizeof(label), "##parameter_%d", i);
+            char label[64];
+            snprintf(label, sizeof(label), "##parameter_%d", i);
 
-                auto sendSetSettingMessage = [block](auto blockUniqueName, auto key, auto value) {
-                    gr::Message message;
-                    message.serviceName = blockUniqueName;
-                    message.endpoint    = gr::block::property::kSetting;
-                    message.cmd         = gr::message::Command::Set;
-                    message.data        = gr::property_map{{key, value}};
-                    block->ownerGraph->sendMessage(std::move(message));
-                };
+            auto sendSetSettingMessage = [block](auto blockUniqueName, auto keyToUpdate, auto updatedValue) {
+                gr::Message message;
+                message.serviceName = blockUniqueName;
+                message.endpoint    = gr::block::property::kSetting;
+                message.cmd         = gr::message::Command::Set;
+                message.data        = gr::property_map{{keyToUpdate, updatedValue}};
+                block->ownerGraph->sendMessage(std::move(message));
+            };
 
-                std::visit(gr::meta::overloaded{//
-                               [&](float val) {
+            const auto getUnit = [block, key]() -> std::string_view {
+                const auto it = block->blockMetaInformation.find(key + "::unit");
+                if (it != block->blockMetaInformation.end()) {
+                    if (const auto unitPtr = std::get_if<std::string>(&it->second); unitPtr) {
+                        return *unitPtr;
+                    }
+                }
+                return {};
+            };
+
+            std::visit(gr::meta::overloaded{[&](float val) {
+                                                ImGui::SetNextItemWidth(editorFieldWidth);
+                                                float temp = val;
+                                                if (InputKeypad<>::edit(key.c_str(), label, &temp, getUnit())) {
+                                                    sendSetSettingMessage(block->blockUniqueName, key, temp);
+                                                }
+                                            },
+                           [&](auto&& val) {
+                               using T = std::decay_t<decltype(val)>;
+                               if constexpr (std::integral<T>) {
                                    ImGui::SetNextItemWidth(editorFieldWidth);
-                                   float temp = val;
-                                   if (InputKeypad<>::edit(label, &temp)) {
-                                       sendSetSettingMessage(block->blockUniqueName, p.first, temp);
+                                   int temp = int(val);
+                                   if (InputKeypad<>::edit(key.c_str(), label, &temp, getUnit())) {
+                                       sendSetSettingMessage(block->blockUniqueName, key, temp);
                                    }
-                               },
-                               [&](auto&& val) {
-                                   using T = std::decay_t<decltype(val)>;
-                                   if constexpr (std::integral<T>) {
-                                       ImGui::SetNextItemWidth(editorFieldWidth);
-                                       int temp = int(val);
-                                       if (InputKeypad<>::edit(label, &temp)) {
-                                           sendSetSettingMessage(block->blockUniqueName, p.first, temp);
-                                       }
-                                   } else if constexpr (std::same_as<T, std::string> || std::same_as<T, std::string_view>) {
-                                       ImGui::SetNextItemWidth(-FLT_MIN); // Stretch to available width
-                                       std::string temp(val);
-                                       if (ImGui::InputText(label, &temp)) {
-                                           sendSetSettingMessage(block->blockUniqueName, p.first, std::move(temp));
-                                       }
+                               } else if constexpr (std::same_as<T, std::string> || std::same_as<T, std::string_view>) {
+                                   ImGui::SetNextItemWidth(-FLT_MIN); // Stretch to available width
+                                   std::string temp(val);
+                                   if (ImGui::InputText(label, &temp)) {
+                                       sendSetSettingMessage(block->blockUniqueName, key, std::move(temp));
                                    }
-                               }},
-                    p.second);
-            }
+                                   IMW::detail::setItemTooltip(key.c_str());
+                               }
+                           }},
+                value);
 
-            setItemTooltip(p.first.c_str());
             ++i;
         }
     }

--- a/src/ui/components/Keypad.hpp
+++ b/src/ui/components/Keypad.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <unordered_map>
 
 namespace DigitizerUi::components {
 
@@ -298,6 +299,9 @@ template<std::size_t BufferSize = 256>
 class InputKeypad {
     static inline constexpr const char* keypad_name = "KeypadX";
 
+    std::unordered_map<std::string, double> _manualyEditedIncrements;
+    std::unordered_map<std::string, int>    _manualyEditedPrecisions;
+
     //
     bool        _visible     = true;
     bool        _altMode     = false;
@@ -479,24 +483,179 @@ class InputKeypad {
 public:
     template<typename EdTy>
     requires std::integral<EdTy> || std::floating_point<EdTy> || std::same_as<std::string, EdTy>
-    [[nodiscard]] static bool edit(const char* label, EdTy* value) {
+    [[nodiscard]] static bool edit(const std::string& key, const char* label, EdTy* value, std::string_view suffix = {}) {
         if (!label || !value) {
             return false;
         }
 
+        const auto drawChangeButtons = [&]() -> bool {
+            auto& keyPad = getInstance();
+
+            bool result = keyPad.editImpl(label, value);
+            if (result) {
+                const int precision = InputKeypad::getDecimalPrecision(keyPad._editBuffer);
+                keyPad._manualyEditedPrecisions.insert_or_assign(key, precision);
+
+                const double increment = InputKeypad::computeIncrement(keyPad._editBuffer);
+                keyPad._manualyEditedIncrements.insert_or_assign(key, increment);
+            }
+
+            {
+                ImGui::SameLine();
+                IMW::Font _(LookAndFeel::instance().fontIconsSolid);
+                if (ImGui::Button("\uf146")) {
+                    auto it = keyPad._manualyEditedIncrements.find(key);
+                    if (it == keyPad._manualyEditedIncrements.end()) {
+                        const double increment = InputKeypad::computeIncrementNonZero(fmt::format("{:.4f}", static_cast<double>(*value)));
+                        auto         op        = keyPad._manualyEditedIncrements.insert_or_assign(key, increment);
+                        it                     = op.first;
+                    }
+                    *value -= static_cast<EdTy>(it->second);
+
+                    result = true;
+                }
+            }
+            IMW::detail::setItemTooltip("Decrement");
+
+            {
+                ImGui::SameLine();
+                IMW::Font _(LookAndFeel::instance().fontIconsSolid);
+                if (ImGui::Button("\uf0fe")) {
+                    auto it = keyPad._manualyEditedIncrements.find(key);
+                    if (it == keyPad._manualyEditedIncrements.end()) {
+                        const double increment = InputKeypad::computeIncrementNonZero(fmt::format("{:.4f}", static_cast<double>(*value)));
+                        auto         op        = keyPad._manualyEditedIncrements.insert_or_assign(key, increment);
+                        it                     = op.first;
+                    }
+                    *value += static_cast<EdTy>(it->second);
+
+                    result = true;
+                }
+            }
+            IMW::detail::setItemTooltip("Increment");
+
+            return result;
+        };
+
+        auto& keyPad = getInstance();
+
         if constexpr (std::floating_point<EdTy>) {
-            ImGui::DragFloat(label, static_cast<float*>(value), 0.1f);
+            const int precision = [&]() -> int {
+                if (auto it = keyPad._manualyEditedPrecisions.find(key); it != keyPad._manualyEditedPrecisions.end()) {
+                    return it->second;
+                } else {
+                    return InputKeypad::getDecimalPrecisionNonZero(fmt::format("{:.4f}", *value));
+                }
+            }();
+
+            const std::string format = suffix.empty() ? fmt::format("%.{}f", precision) : fmt::format("%.{}f {}", precision, suffix);
+            ImGui::DragFloat(label, static_cast<float*>(value), 0.1f, 0.0f, 0.0f, format.c_str());
+            IMW::detail::setItemTooltip(key.c_str());
+
+            return drawChangeButtons();
         } else if constexpr (std::integral<EdTy>) {
-            ImGui::DragInt(label, static_cast<int*>(value));
+            const std::string format = suffix.empty() ? "%d" : fmt::format("%d {}", suffix);
+            ImGui::DragInt(label, static_cast<int*>(value), 1.0f, 0, 0, format.c_str());
+            IMW::detail::setItemTooltip(key.c_str());
+
+            return drawChangeButtons();
         } else {
             ImGui::InputText(label, value);
-        }
+            IMW::detail::setItemTooltip(key.c_str());
 
-        return getInstance().editImpl(label, value);
+            return keyPad.editImpl(label, value);
+        }
     }
     static bool isVisible() noexcept { return getInstance()._visible; }
 
 private:
+    /**
+     * @return the precision value of digits after the decimal point
+     */
+    [[nodiscard]] static int getDecimalPrecision(const std::string& value) {
+        const size_t dot_pos = value.find('.');
+        if (dot_pos == std::string::npos) {
+            return 0;
+        }
+
+        const size_t frac_length = value.size() - (dot_pos + 1);
+        return static_cast<int>(frac_length);
+    }
+
+    /**
+     * @return the increment for the number of digits after the decimal point
+     */
+    [[nodiscard]] static double computeIncrement(const std::string& value) {
+        if (value.empty()) {
+            return 1.0;
+        }
+
+        const size_t dot_pos = value.find('.');
+        if (dot_pos == std::string::npos) {
+            // Integer case: count significant digits before dot
+            size_t first_non_zero = value.find_first_not_of('0');
+            if (first_non_zero == std::string::npos) {
+                return 1.0; // "0", "00"
+            }
+            int digits = static_cast<int>(value.length() - first_non_zero);
+            return std::pow(10.0, digits - 1);
+        }
+
+        // Decimal case: check if dot is last character
+        if (dot_pos + 1 == value.length()) {
+            return 1.0; // "2."
+        }
+
+        int decimal_places = static_cast<int>(value.length() - dot_pos - 1);
+        return std::pow(10.0, -decimal_places);
+    }
+
+    /**
+     * @return the precision value of non-zero digits after the decimal point
+     */
+    [[nodiscard]] static int getDecimalPrecisionNonZero(const std::string& value) {
+        const size_t dot_pos = value.find('.');
+        if (dot_pos == std::string::npos) {
+            return 0;
+        }
+
+        const size_t last_non_zero = value.find_last_not_of('0');
+        if (last_non_zero == std::string::npos || last_non_zero <= dot_pos) {
+            return 0;
+        }
+
+        return static_cast<int>(last_non_zero - dot_pos);
+    }
+
+    /**
+     * @return the increment for the number of non zero digits after the decimal point
+     */
+    [[nodiscard]] static double computeIncrementNonZero(const std::string& value) {
+        if (value.empty()) {
+            return 1.0;
+        }
+
+        const size_t dot_pos = value.find('.');
+        if (dot_pos == std::string::npos) {
+            // Integer case: count significant digits before dot
+            size_t first_non_zero = value.find_first_not_of('0');
+            if (first_non_zero == std::string::npos) {
+                return 1.0; // "0", "00"
+            }
+            int digits = static_cast<int>(value.length() - first_non_zero);
+            return std::pow(10.0, digits - 1);
+        }
+
+        // Decimal case: check last non zero digit and if it's less or equal to dot
+        const size_t last_non_zero = value.find_last_not_of('0');
+        if (last_non_zero == std::string::npos || last_non_zero <= dot_pos) {
+            return 1.0;
+        }
+
+        int decimal_places = static_cast<int>(last_non_zero - dot_pos);
+        return std::pow(10.0, -decimal_places);
+    }
+
     [[nodiscard]] ReturnState drawKeypadPopup(std::string& valueLabel) noexcept {
         const auto&      mainViewPort     = *ImGui::GetMainViewport();
         const ImVec2     mainViewPortSize = mainViewPort.WorkSize;

--- a/src/ui/components/Keypad.hpp
+++ b/src/ui/components/Keypad.hpp
@@ -299,6 +299,7 @@ template<std::size_t BufferSize = 256>
 class InputKeypad {
     static inline constexpr const char* keypad_name = "KeypadX";
 
+    std::string                             _currentBlockUniqueName;
     std::unordered_map<std::string, double> _manualyEditedIncrements;
     std::unordered_map<std::string, int>    _manualyEditedPrecisions;
 
@@ -481,6 +482,15 @@ class InputKeypad {
     }
 
 public:
+    static void clearIfNewBlock(std::string_view block) {
+        auto& keyPad = getInstance();
+        if (keyPad._currentBlockUniqueName != block) {
+            keyPad._currentBlockUniqueName = block;
+            keyPad._manualyEditedIncrements.clear();
+            keyPad._manualyEditedPrecisions.clear();
+        }
+    }
+
     template<typename EdTy>
     requires std::integral<EdTy> || std::floating_point<EdTy> || std::same_as<std::string, EdTy>
     [[nodiscard]] static bool edit(const std::string& key, const char* label, EdTy* value, std::string_view suffix = {}) {

--- a/src/ui/test/qa_keypad.cpp
+++ b/src/ui/test/qa_keypad.cpp
@@ -26,7 +26,7 @@ private:
             ImGui::SetWindowSize(ImVec2(300, 300));
 
             auto& vars = ctx->GetVars<TestState>();
-            if (DigitizerUi::components::InputKeypad<>::edit("label", &vars.value)) {
+            if (DigitizerUi::components::InputKeypad<>::edit("item_source", "label", &vars.value)) {
                 // do not override with false every frame
                 vars.edited = true;
             }


### PR DESCRIPTION
Compute user input on KeyPad to
get precision value and increment (for +/- buttons).

When no keyPad value was entered, compute
4 or less formatting values to reduce the trailing zeroes.