### PR TITLE
Auto arrange nodes layout for new nodes

### DIFF
--- a/.github/compare_captures.sh
+++ b/.github/compare_captures.sh
@@ -55,6 +55,8 @@ for i in ${PR_CAPTURES_DIR}/*.png ; do
     reference_image=$REFERENCE_CAPTURES_DIR/$image_name
 
     echo "Testing $image_name"
+    ls -l "$PR_CAPTURES_DIR"/"$image_name"
+    md5sum "$PR_CAPTURES_DIR"/"$image_name"
 
     if [[ -f $reference_image ]] ; then
         # 'compare' from GH's old Ubuntu always returns 1 even if files are the same. Guard with 'diff'

--- a/src/ui/FlowgraphPage.hpp
+++ b/src/ui/FlowgraphPage.hpp
@@ -39,7 +39,6 @@ private:
     ax::NodeEditor::Config         m_editorConfig;
     ax::NodeEditor::EditorContext* m_editor = nullptr;
 
-    bool   m_layoutGraph = true;
     ImVec2 m_contextMenuPosition;
 
     std::unique_ptr<SignalSelector> m_remoteSignalSelector;
@@ -47,7 +46,7 @@ private:
 
     components::BlockControlsPanelContext m_editPaneContext;
 
-    void sortNodes();
+    void sortNodes(bool all);
 
     void drawNodeEditor(const ImVec2& size);
 

--- a/src/ui/GraphModel.cpp
+++ b/src/ui/GraphModel.cpp
@@ -153,6 +153,10 @@ UiGraphBlock* UiGraphModel::findBlockByUniqueName(const std::string& uniqueName)
     }
 }
 
+bool UiGraphModel::rearrangeBlocks() const { return _rearrangeBlocks; }
+
+void UiGraphModel::setRearrangedBlocks() { _rearrangeBlocks = false; }
+
 auto UiGraphModel::findPortIteratorByName(auto& ports, const std::string& portName) {
     auto it = std::ranges::find_if(ports, [&](const auto& port) { return port.portName == portName; });
     return std::make_pair(it, it != ports.end());
@@ -168,6 +172,7 @@ bool UiGraphModel::handleBlockRemoved(const std::string& uniqueName) {
     // Delete edges for the removed block
     removeEdgesForBlock(*blockIt);
     _blocks.erase(blockIt);
+    _rearrangeBlocks = true;
     return true;
 }
 
@@ -204,6 +209,7 @@ void UiGraphModel::handleBlockSettingsChanged(const std::string& uniqueName, con
             blockIt->updateBlockSettingsMetaInformation();
         }
     }
+    _rearrangeBlocks = true;
 }
 
 void UiGraphModel::handleBlockSettingsStaged(const std::string& uniqueName, const gr::property_map& data) { handleBlockSettingsChanged(uniqueName, data); }
@@ -222,6 +228,8 @@ void UiGraphModel::handleBlockActiveContext(const std::string& uniqueName, const
         .context = ctx,
         .time    = time,
     };
+
+    _rearrangeBlocks = true;
 }
 
 void UiGraphModel::handleBlockAllContexts(const std::string& uniqueName, const gr::property_map& data) {
@@ -242,6 +250,8 @@ void UiGraphModel::handleBlockAllContexts(const std::string& uniqueName, const g
         });
     }
     blockIt->contexts = contextAndTimes;
+
+    _rearrangeBlocks = true;
 }
 
 void UiGraphModel::handleBlockAddOrRemoveContext(const std::string& uniqueName, const gr::property_map& /* data */) {
@@ -253,6 +263,8 @@ void UiGraphModel::handleBlockAddOrRemoveContext(const std::string& uniqueName, 
 
     blockIt->getAllContexts();
     blockIt->getActiveContext();
+
+    _rearrangeBlocks = true;
 }
 
 void UiGraphModel::handleEdgeEmplaced(const gr::property_map& data) {
@@ -312,6 +324,7 @@ void UiGraphModel::handleGraphRedefined(const gr::property_map& data) {
             components::Notification::error("Invalid edge ignored");
         }
     }
+    _rearrangeBlocks = true;
 }
 
 void UiGraphModel::handleAvailableGraphBlockTypes(const gr::property_map& data) {
@@ -378,6 +391,8 @@ void UiGraphModel::setBlockData(auto& block, const gr::property_map& blockData) 
 
         block.getAllContexts();
         block.getActiveContext();
+
+        _rearrangeBlocks = true;
     }
 
     // TODO: When adding support for nested graphs, need to process

--- a/src/ui/GraphModel.hpp
+++ b/src/ui/GraphModel.hpp
@@ -125,6 +125,7 @@ private:
     std::vector<UiGraphBlock> _blocks;
     std::vector<UiGraphEdge>  _edges;
     bool                      _newGraphDataBeingSet = false;
+    bool                      _rearrangeBlocks      = false;
 
 public:
     UiGraphModel() {}
@@ -170,6 +171,13 @@ public:
     AvailableParametrizationsResult availableParametrizationsFor(const std::string& fullBlockType) const;
 
     UiGraphBlock* findBlockByUniqueName(const std::string& uniqueName);
+
+    /**
+     * @return true when new blocks were added or removed so UI can rearrange them
+     */
+    bool rearrangeBlocks() const;
+
+    void setRearrangedBlocks();
 
 private:
     auto findBlockIteratorByUniqueName(const std::string& uniqueName);

--- a/src/ui/cmake/Dependencies.cmake
+++ b/src/ui/cmake/Dependencies.cmake
@@ -23,8 +23,11 @@ FetchContent_Declare(
   imgui-node-editor
   # GIT_REPOSITORY  https://github.com/thedmd/imgui-node-editor.git GIT_TAG         v0.9.3 # latest as of 2023-12-19
   # Temporary until https://github.com/thedmd/imgui-node-editor/pull/291 is merged
-  GIT_REPOSITORY https://github.com/ivan-cukic/wip-fork-imgui-node-editor.git
-  GIT_TAG 2e4740361b7bddb924807f6d5be64818b72bf15e
+  # GIT_REPOSITORY https://github.com/ivan-cukic/wip-fork-imgui-node-editor.git
+  # GIT_TAG 2e4740361b7bddb924807f6d5be64818b72bf15e
+  # Temporary until https://github.com/ivan-cukic/wip-fork-imgui-node-editor/pull/1 is merged
+  GIT_REPOSITORY https://github.com/dantti/wip-fork-imgui-node-editor.git
+  GIT_TAG e1a4cf22a73a6ca8e15b2ab4602ac5870afb7b5d
   SYSTEM)
 
 FetchContent_Declare(

--- a/src/ui/test/qa_flowgraph.cpp
+++ b/src/ui/test/qa_flowgraph.cpp
@@ -46,7 +46,7 @@ struct TestState {
     void drawGraph() {
         // draw it here since we can't make FlowgraphPage a friend of the GuiFunc lambda
         if (hasBlocks()) {
-            flowgraphPage.sortNodes();
+            flowgraphPage.sortNodes(false);
             DigitizerUi::FlowgraphPage::drawGraph(dashboard->graphModel(), ImGui::GetContentRegionAvail(), flowgraphPage.m_filterBlock);
         }
     }


### PR DESCRIPTION
Once the user manually moves a node we ignore
it's position and position the others as if
it still in it's automatic position.