### PR TITLE
Compile gnuradio4 targets with Release flags

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -24,6 +24,43 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(opencmw-cpp gnuradio4 ut)
 
+# Compile gnuradio4 targets with Release flags to keep the resulting binaries small.
+# 1. find all targets in all subdirectories
+# 2. select only gnuradio non-interface targets
+# 3. set compiler options using target_compile_options
+function(_get_all_targets_impl dir)
+    get_property(ts DIRECTORY "${dir}" PROPERTY BUILDSYSTEM_TARGETS)
+    if(ts)
+        foreach(t IN LISTS ts)
+            set_property(GLOBAL APPEND PROPERTY _ALL_COLLECTED_TARGETS "${t}")
+        endforeach()
+    endif()
+
+    get_property(subs DIRECTORY "${dir}" PROPERTY SUBDIRECTORIES)
+    foreach(s IN LISTS subs)
+        _get_all_targets_impl("${s}")
+    endforeach()
+endfunction()
+
+function(get_all_targets dir out_var)
+    set_property(GLOBAL PROPERTY _ALL_COLLECTED_TARGETS "")
+    _get_all_targets_impl("${dir}")
+    get_property(_res GLOBAL PROPERTY _ALL_COLLECTED_TARGETS)
+    set(${out_var} "${_res}" PARENT_SCOPE)
+endfunction()
+
+
+get_all_targets("${gnuradio4_SOURCE_DIR}" GNURADIO4_ALL_TARGETS)
+foreach(t IN LISTS GNURADIO4_ALL_TARGETS)
+    if(t MATCHES "^gnuradio-" OR t MATCHES "^gr-" OR t MATCHES "^Gr")
+        get_target_property(_type ${t} TYPE)
+
+        if(NOT _type STREQUAL "INTERFACE_LIBRARY")
+            target_compile_options(${t} PRIVATE -O2 -g0 -DNDEBUG -ffunction-sections -fdata-sections)
+        endif()
+    endif()
+endforeach()
+
 set_target_properties(exprtk_example0 PROPERTIES EXCLUDE_FROM_ALL ON)
 set_target_properties(exprtk_example1 PROPERTIES EXCLUDE_FROM_ALL ON)
 set_target_properties(exprtk_example2 PROPERTIES EXCLUDE_FROM_ALL ON)


### PR DESCRIPTION
### What this PR does
Compiles every `gnuradio4` target with Release‑style flags (`-O2 ‑g0 ‑DNDEBUG ‑ffunction‑sections ‑fdata‑sections`) so that the produced binaries are small in size.

### Why we need the workaround
`FetchContent` brings the dependency into the same build tree via `add_subdirectory()`.  
That means we can’t request `Debug` mode for gnuradio4 code, `Release` for the rest, using, for example (`CMAKE_BUILD_TYPE`). The whole project shares one build mode.

### How the workaround works
1. **Discover targets** Recursively collect every target created inside the gnuradio4 source tree.  
2. **Filter** Ignore interface libraries.  
3. **Patch** Call `target_compile_options()` on each remaining gnuradio* / gr‑* target to inject the Release flags.

### Alternative considered
We could migrate to **ExternalProject_Add**, which builds a dependency in a separate configure–build–install step and therefore supports its own build type.  
To switch, gnuradio4 would first need a proper `install()` layout so we can stage its libraries and headers in a predictable location.
