### PR TITLE
Fix flowgraph capture file name

### DIFF
--- a/src/ui/test/qa_flowgraph.cpp
+++ b/src/ui/test/qa_flowgraph.cpp
@@ -126,7 +126,7 @@ void registerTestBlocks(Registry& registry) {
 
 int main(int argc, char* argv[]) {
     auto options             = DigitizerUi::test::TestOptions::fromArgs(argc, argv);
-    options.screenshotPrefix = "chart";
+    options.screenshotPrefix = "flowgraph";
 
     // This is not a globalBlockRegistry, but a copy of it
     gr::BlockRegistry& registry = gr::globalBlockRegistry();


### PR DESCRIPTION
flowgraph filename was "graph"
which caused the qa_graph test to
overwrite it.

Documentation says that if not in use it would use the test name, but that didn't work. IMO it would be better to use the test name to avoid issues like this one.