### PR TITLE
Add automatically generated version of the program from Git hash

### DIFF
--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -116,12 +116,14 @@ file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/demo_sslcert/demo_private.key" DESTINATIO
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/demo_sslcert/demo_public.crt" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
 
 add_executable(opendigitizer main.cpp)
+
 # TODO fair-picoscope is a run-time dependencies only, should be loaded as plugin
 target_link_libraries(
   opendigitizer
   PRIVATE od_dashboard_worker
           od_gnuradio_worker
           od_rest
+          opendigitizer_version
           majordomo
           services
           client

--- a/src/service/main.cpp
+++ b/src/service/main.cpp
@@ -27,6 +27,8 @@
 #include "gnuradio/GnuRadioFlowgraphWorker.hpp"
 #include "rest/fileserverRestBackend.hpp"
 
+#include <version.hpp>
+
 // TODO instead of including and registering blocks manually here, rely on the plugin system
 #include "build_configuration.hpp"
 #include "settings.hpp"
@@ -72,7 +74,9 @@ int main(int argc, char** argv) {
         std::println("opendigitizer [<path to flowgraph>]");
         std::println("    launch opendigitizer with the provided flow graph or a default flowgraph if omitted");
         std::println("opendigitizer --list-registered-blocks");
-        std::println("    List all blocks that are registered in the service");
+        std::println("    list all blocks that are registered in the service");
+        std::println("opendigitizer --version");
+        std::println("    print version of the opendigitizer");
         std::println("opendigitizer --help");
         std::println("    show this help message");
         return 0;
@@ -84,6 +88,11 @@ int main(int argc, char** argv) {
         for (auto& blockName : registry.keys()) {
             std::print("  - {}\n", blockName);
         }
+        return 0;
+    }
+
+    if (argc > 1 && strcmp(argv[1], "--version") == 0) {
+        std::println("{}", kOpendigitizerVersion);
         return 0;
     }
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -159,6 +159,7 @@ target_link_libraries(
          imgui-node-editor
          od_acquisition
          services
+         opendigitizer_version
          plf_colony
          ui_assets
          core

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -50,6 +50,8 @@
 #include "blocks/SineSource.hpp"
 #include "blocks/TagToSample.hpp"
 
+#include <version.hpp>
+
 namespace DigitizerUi {
 
 struct SDLState {
@@ -87,6 +89,21 @@ void setWindowMode(SDL_Window* window, const WindowMode& state) {
 }
 
 int main(int argc, char** argv) {
+#ifndef EMSCRIPTEN
+    if (argc > 1 && strcmp(argv[1], "--help") == 0) {
+        std::println("opendigitizer --version");
+        std::println("    print version of the opendigitizer-ui");
+        std::println("opendigitizer --help");
+        std::println("    show this help message");
+        return 0;
+    }
+
+    if (argc > 1 && strcmp(argv[1], "--version") == 0) {
+        std::println("{}", kOpendigitizerVersion);
+        return 0;
+    }
+#endif
+
     // Setup SDL
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) != 0) {
         printf("Error: %s\n", SDL_GetError());

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -19,3 +19,24 @@ set_target_properties(digitizer_common_utils PROPERTIES PUBLIC_HEADER include/co
 if(OPENDIGITIZER_ENABLE_TESTING)
   add_subdirectory(test)
 endif()
+
+# Automatically generate current version of opendigitizer
+set(OPENDIGITIZER_GIT_DESCRIBE "unknown")
+find_package(Git)
+if(Git_FOUND)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --tags --long --always --dirty #
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE OPENDIGITIZER_GIT_DESCRIBE
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version/version.cpp.in ${CMAKE_BINARY_DIR}/generated_version/version.cpp
+               @ONLY)
+if(Git_FOUND)
+  set_property(
+    DIRECTORY
+    APPEND
+    PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../../.git/HEAD")
+endif()
+add_library(opendigitizer_version STATIC ${CMAKE_BINARY_DIR}/generated_version/version.cpp)
+target_include_directories(opendigitizer_version PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/version/include)

--- a/src/utils/version/include/version.hpp
+++ b/src/utils/version/include/version.hpp
@@ -1,0 +1,8 @@
+#ifndef OPENDIGITIZER_VERSION_HPP_IN
+#define OPENDIGITIZER_VERSION_HPP_IN
+
+#include <string_view>
+
+extern const std::string_view kOpendigitizerVersion;
+
+#endif // OPENDIGITIZER_VERSION_HPP_IN

--- a/src/utils/version/version.cpp.in
+++ b/src/utils/version/version.cpp.in
@@ -1,0 +1,3 @@
+#include "version.hpp"
+
+const std::string_view kOpendigitizerVersion{"@OPENDIGITIZER_GIT_DESCRIBE@"};


### PR DESCRIPTION
This PR resolves the issue we encountered during deployment, where it was necessary to determine the exact version of OpenDigitizer in use.

Add automatically generated version of the program using `git describe --dirty --always --long --tags`

Usage: 
`opendigitizer --version` or `opendigitizer-ui --version`
Output example: `reference_screen_captures-main-186-g275215f-dirty`

Note: Consider to add version somewhere in the UI