### PR TITLE
migrate to SDL3 with automatic fallback, unified backend setup

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -77,19 +77,38 @@ jobs:
         source $EMSDK_HOME/emsdk_env.sh
         cmake --build ../build
 
+    - name: Install Xvfb
+      run: ( sudo apt-get update && sudo apt-get install -y xvfb || true )
+
     - name: execute tests
       if: matrix.configurations.compiler != 'gcc-14' || matrix.cmake-build-type != 'Debug'
       timeout-minutes: 10
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: ctest --output-on-failure
+      env:
+        XDG_RUNTIME_DIR: /tmp/runtime-dir
+        SDL_VIDEODRIVER: x11
+        SDL_AUDIODRIVER: dummy
+      run: |
+        mkdir -p /tmp/runtime-dir
+        Xvfb :99 -screen 0 1600x1200x24 &
+        export DISPLAY=:99
+        ctest --output-on-failure
 
     - name: execute tests with coverage
       if: matrix.configurations.compiler == 'gcc-14' && matrix.cmake-build-type == 'Debug'
       timeout-minutes: 10
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: cmake --build . --target opendigitizer_coverage
+      env:
+        XDG_RUNTIME_DIR: /tmp/runtime-dir
+        SDL_VIDEODRIVER: x11
+        SDL_AUDIODRIVER: dummy
+      run: |
+        mkdir -p /tmp/runtime-dir
+        Xvfb :99 -screen 0 1600x1200x24 &
+        export DISPLAY=:99
+        cmake --build . --target opendigitizer_coverage
 
     # only for Release, as this might generate PR comments (which we don't want to duplicate)
     - name: compare captures

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.27)
 
 project(opendigitizer LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 23)

--- a/src/ui/App.hpp
+++ b/src/ui/App.hpp
@@ -43,10 +43,9 @@ public:
     FlowgraphPage     flowgraphPage;
     OpenDashboardPage openDashboardPage;
 
-    SDLState* sdlState         = nullptr;
-    bool      isRunning        = true;
-    ViewMode  mainViewMode     = ViewMode::VIEW;
-    ViewMode  previousViewMode = ViewMode::VIEW;
+    std::atomic<bool> isRunning        = true;
+    ViewMode          mainViewMode     = ViewMode::VIEW;
+    ViewMode          previousViewMode = ViewMode::VIEW;
 
     std::vector<gr::BlockModel*> toolbarBlocks;
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -25,10 +25,13 @@ if(EMSCRIPTEN)
     -Wformat
     -Os
     -fwasm-exceptions
-    "SHELL:-s USE_SDL=2"
+    "SHELL:-s USE_SDL=3"
     -pthread)
   add_link_options(
     "SHELL:-s WASM=1"
+    "SHELL:-sFULL_ES2=1"
+    "SHELL:-sMAX_WEBGL_VERSION=2"
+    "SHELL:-sMIN_WEBGL_VERSION=2"
     "SHELL:-s ALLOW_MEMORY_GROWTH=1"
     "SHELL:-s NO_EXIT_RUNTIME=0"
     "SHELL:-s ASSERTIONS=1"
@@ -38,10 +41,12 @@ if(EMSCRIPTEN)
     --shell-file
     ${CMAKE_CURRENT_SOURCE_DIR}/shell_minimal.html
     "SHELL:-s PTHREAD_POOL_SIZE=30"
-    "SHELL:-s USE_SDL=2"
+    "SHELL:-s USE_SDL=3"
     -fwasm-exceptions
     -pthread
-    -sFETCH)
+    "-sFETCH=1" # needed for file_io
+    "--bind" # needed for Clipboard
+  )
 endif()
 
 # dependencies
@@ -97,7 +102,7 @@ if(EMSCRIPTEN)
 else() # native build
   set(target_name "opendigitizer-ui")
   add_executable(${target_name})
-  target_link_libraries(${target_name} PRIVATE SDL2) # for emscripten SDL is already included in the build
+  target_link_libraries(${target_name} PRIVATE SDL3::SDL3) # for emscripten SDL is already included in the build
 
   if(OPENDIGITIZER_ENABLE_ASAN)
     target_compile_options(${target_name} PRIVATE -fsanitize=address)

--- a/src/ui/Dashboard.cpp
+++ b/src/ui/Dashboard.cpp
@@ -414,10 +414,10 @@ void Dashboard::doLoad(const std::string& desc) {
         }
 
         std::transform(plotSources.begin(), plotSources.end(), std::back_inserter(plot.sourceNames), [](const auto& elem) { return std::get<std::string>(elem); });
-        plot.window->x      = pmtv::cast<int>(rect[0]);
-        plot.window->y      = pmtv::cast<int>(rect[1]);
-        plot.window->width  = pmtv::cast<int>(rect[2]);
-        plot.window->height = pmtv::cast<int>(rect[3]);
+        plot.window->x      = pmtv::cast<std::size_t>(rect[0]);
+        plot.window->y      = pmtv::cast<std::size_t>(rect[1]);
+        plot.window->width  = pmtv::cast<std::size_t>(rect[2]);
+        plot.window->height = pmtv::cast<std::size_t>(rect[3]);
     }
 
     // if (m_fgItem) {

--- a/src/ui/GraphModel.cpp
+++ b/src/ui/GraphModel.cpp
@@ -361,8 +361,6 @@ void UiGraphModel::handleAvailableGraphBlockTypes(const gr::property_map& data) 
             knownBlockTypes[std::string(type)].emplace();
         }
     }
-
-    std::print("Known block types: {}\n", knownBlockTypes);
 }
 
 UiGraphModel::AvailableParametrizationsResult UiGraphModel::availableParametrizationsFor(const std::string& fullBlockType) const {

--- a/src/ui/common/ImGuiHelperSDL.hpp
+++ b/src/ui/common/ImGuiHelperSDL.hpp
@@ -1,0 +1,247 @@
+#ifndef IMGUIHELPERSDL_HPP
+#define IMGUIHELPERSDL_HPP
+
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_opengl.h>
+#include <SDL3/SDL_video.h>
+
+#include <backends/imgui_impl_opengl3.h>
+#include <backends/imgui_impl_sdl3.h>
+#include <implot.h>
+#include <misc/cpp/imgui_stdlib.h>
+
+#include "LookAndFeel.hpp"
+
+#include "Events.hpp"
+#include "TouchHandler.hpp"
+
+#include <format>
+#include <print>
+
+namespace imgui_helper {
+inline static SDL_Window*   g_Window               = nullptr;
+inline static SDL_GLContext g_GLContext            = nullptr;
+inline static bool          g_ImGuiSDL3Initialised = false;
+
+inline bool requestGLContext(std::string_view windowTitle, ImVec2 windowSize, int major, int minor, std::string& glslVersionOut) {
+    std::println("[Main] Requesting OpenGL context {}.{}", major, minor);
+
+#ifdef __EMSCRIPTEN__
+    // WebGL2 via GLES 3.0 + GLSL ES 300
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+    // glslVersionOut = "#version 300 es"; //TODO: check compatibility of this
+    glslVersionOut = "#version 100";
+#else
+#ifdef __APPLE__
+    // macOS requires forward-compatible core context ≥ 3.2
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+    glslVersionOut = "#version 150";
+#else
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, 0);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, major);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, minor);
+    glslVersionOut = "#version 330 core";
+#endif
+#endif
+
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+    SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
+
+#ifdef __APPLE__
+    constexpr SDL_WindowFlags windowFlags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY | SDL_WINDOW_ALLOW_HIGHDPI;
+#else
+    constexpr SDL_WindowFlags windowFlags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY;
+#endif
+    if (g_Window != nullptr) {
+        SDL_DestroyWindow(g_Window);
+        g_Window = nullptr;
+    }
+    g_Window = SDL_CreateWindow(windowTitle.data(), static_cast<int>(windowSize.x), static_cast<int>(windowSize.y), windowFlags);
+    if (!g_Window) {
+        std::println(stderr, "[Main] SDL_CreateWindow failed: '{}'", SDL_GetError());
+        return false;
+    }
+
+    g_GLContext = SDL_GL_CreateContext(g_Window);
+    if (!g_GLContext) {
+        std::println(stderr, "[Main] SDL_GL_CreateContext({}.{}) failed: '{}'", major, minor, SDL_GetError());
+        SDL_DestroyWindow(g_Window);
+        g_Window = nullptr;
+        return false;
+    }
+    std::println("[Main] GL_VERSION:   {}", reinterpret_cast<const char*>(glGetString(GL_VERSION)));
+    std::println("[Main] GL_RENDERER:  {}", reinterpret_cast<const char*>(glGetString(GL_RENDERER)));
+    std::println("[Main] GLSL_VERSION: {}", reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION)));
+
+    std::println("[Main] OpenGL context successfully created using shader '{}'", glslVersionOut);
+    return true;
+}
+
+inline bool initSDL(std::string& glslVersion, std::string_view windowTitle = "OpenDigitizer UI", ImVec2 windowSize = {1280.f, 720.f}) {
+    if (!SDL_Init(SDL_INIT_VIDEO)) {
+        std::println("[Main] SDL_Init failed: '{}'", SDL_GetError());
+        return false;
+    }
+
+    if (!requestGLContext(windowTitle, windowSize, 3, 3, glslVersion) && !requestGLContext(windowTitle, windowSize, 2, 0, glslVersion)) {
+        std::println("[Main] Could not create any GL context!");
+        SDL_Quit();
+        return false;
+    }
+
+    SDL_GL_SetSwapInterval(1);
+    return true;
+}
+
+inline bool initImGui(const std::string& glslVersion) {
+    if (g_ImGuiSDL3Initialised) {
+        return true; // already initialised
+    }
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGui::StyleColorsDark();
+    ImPlot::CreateContext();
+
+    ImGui_ImplSDL3_InitForOpenGL(g_Window, g_GLContext);
+
+    ImGuiIO& io                  = ImGui::GetIO();
+    ImPlot::GetInputMap().Select = ImGuiPopupFlags_MouseButtonLeft;
+    ImPlot::GetInputMap().Pan    = ImGuiPopupFlags_MouseButtonMiddle;
+
+    // For an Emscripten build we are disabling file-system access, so let's not
+    // attempt to do a fopen() of the imgui.ini file. You may manually call
+    // LoadIniSettingsFromMemory() to load settings from your own storage.
+    io.IniFilename = nullptr;
+
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+    io.ConfigWindowsMoveFromTitleBarOnly = true;
+
+    if (bool ret = ImGui_ImplOpenGL3_Init(glslVersion.c_str()); !ret) {
+        SDL_GL_DestroyContext(g_GLContext);
+        SDL_DestroyWindow(g_Window);
+        SDL_Quit();
+        return false;
+    }
+    g_ImGuiSDL3Initialised = true;
+    return true;
+}
+
+inline void setWindowMode(SDL_Window* window, const WindowMode& state) {
+    using enum WindowMode;
+    const SDL_WindowFlags flags        = SDL_GetWindowFlags(window);
+    const bool            isMaximised  = (flags & SDL_WINDOW_MAXIMIZED) != 0;
+    const bool            isMinimised  = (flags & SDL_WINDOW_MINIMIZED) != 0;
+    const bool            isFullscreen = (flags & SDL_WINDOW_FULLSCREEN) != 0;
+    if ((isMaximised && state == MAXIMISED) || (isMinimised && state == MINIMISED) || (isFullscreen && state == FULLSCREEN)) {
+        return;
+    }
+    switch (state) {
+    case FULLSCREEN: SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN); return;
+    case MAXIMISED:
+        SDL_SetWindowFullscreen(window, false);
+        SDL_MaximizeWindow(window);
+        return;
+    case MINIMISED:
+        SDL_SetWindowFullscreen(window, false);
+        SDL_MinimizeWindow(window);
+        return;
+    case RESTORED: SDL_SetWindowFullscreen(window, false); SDL_RestoreWindow(window);
+    }
+}
+
+[[maybe_unused]] inline bool processEvents() {
+    SDL_Event event;
+    while (SDL_PollEvent(&event)) {
+        ImGui_ImplSDL3_ProcessEvent(&event);
+        // filter to the current window
+        if (event.window.windowID && event.window.windowID != SDL_GetWindowID(imgui_helper::g_Window)) {
+            continue;
+        }
+
+        switch (event.type) {
+        case SDL_EVENT_QUIT:
+        case SDL_EVENT_WINDOW_CLOSE_REQUESTED: return false; break;
+        case SDL_EVENT_WINDOW_RESTORED: DigitizerUi::LookAndFeel::mutableInstance().windowMode = WindowMode::RESTORED; break;
+        case SDL_EVENT_WINDOW_MINIMIZED: DigitizerUi::LookAndFeel::mutableInstance().windowMode = WindowMode::MINIMISED; break;
+        case SDL_EVENT_WINDOW_MAXIMIZED: DigitizerUi::LookAndFeel::mutableInstance().windowMode = WindowMode::MAXIMISED; break;
+        case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+        case SDL_EVENT_WINDOW_RESIZED: { // SDL3 recommends this one for logical size changes
+            const int width            = event.window.data1;
+            const int height           = event.window.data2;
+            ImGui::GetIO().DisplaySize = ImVec2(float(width), float(height));
+            glViewport(0, 0, width, height);
+            ImGui::SetNextWindowPos(ImVec2(0, 0));
+            ImGui::SetNextWindowSize(ImVec2(float(width), float(height)));
+            break;
+        }
+        default: break;
+        }
+        DigitizerUi::TouchHandler<>::processSDLEvent(event);
+    }
+
+    DigitizerUi::EventLoop::instance().fireCallbacks();
+    DigitizerUi::TouchHandler<>::updateGestures();
+
+    return true;
+}
+
+[[maybe_unused]] inline bool newFrame() {
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplSDL3_NewFrame();
+    ImGui::NewFrame();
+
+    ImGui::SetNextWindowPos({0, 0});
+    int  width  = -1;
+    int  height = -1;
+    bool ret    = SDL_GetWindowSize(g_Window, &width, &height);
+    ImGui::SetNextWindowSize(ImVec2{static_cast<float>(width), static_cast<float>(height)});
+    return ret;
+}
+
+[[maybe_unused]] inline bool renderFrame() {
+    ImGui::Render();
+    if (!SDL_GL_MakeCurrent(g_Window, g_GLContext)) {
+        std::println("[Main] SDL_GL_MakeCurrent failed: '{}'", SDL_GetError());
+        return false;
+    }
+    const ImGuiIO& io = ImGui::GetIO();
+    glViewport(0, 0, int(io.DisplaySize.x), int(io.DisplaySize.y));
+    glClearColor(1, 1, 1, 1);
+    glClear(GL_COLOR_BUFFER_BIT);
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+    SDL_GL_SwapWindow(g_Window);
+    setWindowMode(g_Window, DigitizerUi::LookAndFeel::instance().windowMode);
+    return true;
+}
+
+inline bool teardownSDL() {
+    if (g_Window == nullptr) {
+        return false;
+    }
+    if (g_GLContext == nullptr) {
+        return false;
+    }
+    // IMGUI & SDL Cleanup
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplSDL3_Shutdown();
+    ImGui::DestroyContext();
+    if (bool state = SDL_GL_DestroyContext(g_GLContext); !state) {
+        std::println("[Main] teardownSDL failed: '{}'", SDL_GetError());
+        return false;
+    }
+    SDL_DestroyWindow(g_Window);
+    SDL_Quit();
+    g_Window    = nullptr;
+    g_GLContext = nullptr;
+    return true;
+}
+} // namespace imgui_helper
+
+#endif // IMGUIHELPERSDL_HPP

--- a/src/ui/common/LookAndFeel.hpp
+++ b/src/ui/common/LookAndFeel.hpp
@@ -4,11 +4,11 @@
 #include <array>
 #include <chrono>
 
+enum class WindowMode { FULLSCREEN, MAXIMISED, MINIMISED, RESTORED };
+
 struct ImFont;
 
 namespace DigitizerUi {
-
-enum class WindowMode { FULLSCREEN, MAXIMISED, MINIMISED, RESTORED };
 
 struct LookAndFeel {
     enum class Style { Light, Dark };

--- a/src/ui/common/TouchHandler.hpp
+++ b/src/ui/common/TouchHandler.hpp
@@ -5,15 +5,17 @@
 #include <cassert>
 #include <chrono>
 #include <cmath>
+#include <format>
+#include <map>
+#include <numbers>
+#include <print>
 #include <stack>
 #include <unordered_map>
-
-#include <format>
 
 #include "ImguiWrap.hpp"
 #include <implot_internal.h>
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 
 #include "../common/LookAndFeel.hpp"
 #include "conversion.hpp"
@@ -159,8 +161,8 @@ struct TouchHandler {
         const auto  now         = ClockSourceType::now();
 
         switch (event.type) {
-        case SDL_FINGERDOWN: {
-            const std::size_t fingerIndex    = getOrAssignIndex(event.tfinger.fingerId);
+        case SDL_EVENT_FINGER_DOWN: {
+            const std::size_t fingerIndex    = getOrAssignIndex(event.tfinger.fingerID);
             touchActive                      = true;
             fingerDown                       = true;
             fingerTimeStamp[fingerIndex]     = now;
@@ -197,8 +199,8 @@ struct TouchHandler {
                 std::print("touch: finger down: {} fingerID: {} p:{} @({},{})\n", nFingers, fingerIndex, event.tfinger.pressure, event.tfinger.x, event.tfinger.y);
             }
         } break;
-        case SDL_FINGERUP: {
-            const std::size_t fingerIndex  = getOrAssignIndex(event.tfinger.fingerId);
+        case SDL_EVENT_FINGER_UP: {
+            const std::size_t fingerIndex  = getOrAssignIndex(event.tfinger.fingerID);
             touchActive                    = true;
             fingerUp                       = true;
             fingerTimeStamp[fingerIndex]   = now;
@@ -212,7 +214,7 @@ struct TouchHandler {
             fingerWindowID[fingerIndex]    = event.tfinger.windowID;
             assert(nFingers > 0);
             --nFingers;
-            releaseIndex(event.tfinger.fingerId);
+            releaseIndex(event.tfinger.fingerID);
             if (nFingers == 0 && !gestureActive && !gestureDragActive && !gestureZoomActive) {
                 if (getFingerPressedDuration(fingerIndex) < std::chrono::milliseconds(500)) { // short click -> process as left click
                     ImGui::GetIO().AddMouseButtonEvent(ImGuiPopupFlags_MouseButtonLeft, true);
@@ -239,8 +241,8 @@ struct TouchHandler {
                 std::print("touch: finger up: {} fingerID: {} p:{} @({},{})\n", nFingers, fingerIndex, event.tfinger.pressure, event.tfinger.x, event.tfinger.y);
             }
         } break;
-        case SDL_FINGERMOTION: {
-            std::size_t fingerIndex      = getOrAssignIndex(event.tfinger.fingerId);
+        case SDL_EVENT_FINGER_MOTION: {
+            std::size_t fingerIndex      = getOrAssignIndex(event.tfinger.fingerID);
             touchActive                  = true;
             fingerTimeStamp[fingerIndex] = now;
             fingerPressed[fingerIndex]   = true;
@@ -276,7 +278,7 @@ struct TouchHandler {
                 fingerUp            = true;
                 singleFingerClicked = false;
                 releaseFingerIndex(fingerIndex);
-                std::print("WARNING: probably lost SDL_FINGERUP event -> reset inactive fingerID {} out of {} - timeSinceLifted {}\n", fingerIndex, nFingers, timeSinceLastActive);
+                std::print("WARNING: probably lost SDL_FINGER_UP event -> reset inactive fingerID {} out of {} - timeSinceLifted {}\n", fingerIndex, nFingers, timeSinceLastActive);
             }
         }
 

--- a/src/ui/components/AppHeader.hpp
+++ b/src/ui/components/AppHeader.hpp
@@ -12,7 +12,7 @@
 #include "../common/ImguiWrap.hpp"
 #include "../components/ImGuiNotify.hpp"
 
-#include <SDL_opengl.h>
+#include <SDL3/SDL_opengl.h>
 #include <stb_image.h>
 
 #include "PopupMenu.hpp"
@@ -190,7 +190,7 @@ public:
         }();
 
         if ((devMenuButtonPushed || ImGui::IsItemHovered()) && settings.editableMode) {
-            using enum DigitizerUi::WindowMode;
+            using enum WindowMode;
 
             {
                 IMW::StyleColor buttonStyle(ImGuiCol_Button, ImVec4{.3f, .3f, 1.0f, 1.f}); // blue

--- a/src/ui/components/Docking.cpp
+++ b/src/ui/components/Docking.cpp
@@ -171,12 +171,12 @@ void DockSpace::layoutInFree(const Windows& windows) {
     bool isOverlapDetected = false;
     for (std::size_t i = 0; i < windows.size(); i++) {
         const auto& w = windows[i];
-        for (int x = w->x; x < w->x + w->width; x++) {
-            for (int y = w->y; y < w->y + w->height; y++) {
+        for (std::size_t x = w->x; x < w->x + w->width; x++) {
+            for (std::size_t y = w->y; y < w->y + w->height; y++) {
                 if (grid[x][y] != -1) {
                     isOverlapDetected = true;
                 }
-                grid[x][y] = i;
+                grid[x][y] = static_cast<int>(i);
             }
         }
     }
@@ -198,8 +198,9 @@ void DockSpace::layoutInFree(const Windows& windows) {
 void DockSpace::layoutInFreeRegion(const std::vector<std::vector<int>>& grid, const Windows& windows, std::size_t x0, std::size_t x1, std::size_t y0, std::size_t y1, ImGuiID nodeId) {
 
     // Check if entire region belongs to exactly one window ID
-    const int  firstId = grid[x0][y0];
-    const bool allSame = std::ranges::all_of( // x in [x0, x1)
+    assert(grid[x0][y0] >= 0);
+    const std::size_t firstId = static_cast<std::size_t>(grid[x0][y0]);
+    const bool        allSame = std::ranges::all_of( // x in [x0, x1)
         std::views::iota(x0, x1), [&](std::size_t x) {
             return std::ranges::all_of( // y in [y0, y1)
                 std::views::iota(y0, y1), [&](std::size_t y) { return grid[x][y] == firstId; });

--- a/src/ui/components/Docking.hpp
+++ b/src/ui/components/Docking.hpp
@@ -75,19 +75,19 @@ struct DockSpace::Window {
     explicit Window(const std::string& n) : name(n) {}
 
     std::string           name;
-    int                   x      = 0;
-    int                   y      = 0;
-    int                   width  = 0;
-    int                   height = 0;
+    std::size_t           x      = 0UZ;
+    std::size_t           y      = 0UZ;
+    std::size_t           width  = 0UZ;
+    std::size_t           height = 0UZ;
     std::function<void()> renderFunc;
 
     void clearGeometry() { setGeometry({}, {}); }
 
     void setGeometry(ImVec2 pos, ImVec2 size) {
-        x      = static_cast<int>(pos.x);
-        y      = static_cast<int>(pos.y);
-        width  = static_cast<int>(size.x);
-        height = static_cast<int>(size.y);
+        x      = static_cast<std::size_t>(pos.x);
+        y      = static_cast<std::size_t>(pos.y);
+        width  = static_cast<std::size_t>(size.x);
+        height = static_cast<std::size_t>(size.y);
     }
 
     [[nodiscard]] bool hasSize() const { return width > 0 && height > 0; }

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -1,12 +1,21 @@
-#ifdef __EMSCRIPTEN__
-#include <emscripten.h>
-#endif
+#include "common/ImGuiHelperSDL.hpp"
+
+#include "utils/EmscriptenHelper.hpp"
 
 #include <algorithm>
 #include <array>
 #include <cstdio>
-
+#include <cstdlib>
 #include <format>
+#include <string>
+
+#include "App.hpp"
+#include "common/AppDefinitions.hpp"
+#include "common/Events.hpp"
+#include "common/ImguiWrap.hpp"
+#include "common/LookAndFeel.hpp"
+#include "common/TouchHandler.hpp"
+#include "components/ImGuiNotify.hpp"
 
 #include <gnuradio-4.0/BlockRegistry.hpp>
 #include <gnuradio-4.0/Scheduler.hpp>
@@ -19,30 +28,10 @@
 #include <GrHttpBlocks.hpp>
 #include <GrMathBlocks.hpp>
 #include <GrTestingBlocks.hpp>
-
-#include "common/Events.hpp"
-#include "common/ImguiWrap.hpp"
-#include "common/LookAndFeel.hpp"
-#include "components/ImGuiNotify.hpp"
-
-#include "utils/EmscriptenHelper.hpp"
-
-#include <imgui_impl_opengl3.h>
-#include <imgui_impl_sdl2.h>
-#include <implot.h>
-#include <misc/cpp/imgui_stdlib.h>
-
-#include <SDL.h>
-#if defined(IMGUI_IMPL_OPENGL_ES2)
-#include <SDL_opengles2.h>
-#else
-#include <SDL_opengl.h>
-#endif
-
-#include "App.hpp"
-
-#include "common/AppDefinitions.hpp"
-#include "common/TouchHandler.hpp"
+#include <gnuradio-4.0/BlockRegistry.hpp>
+#include <gnuradio-4.0/Scheduler.hpp>
+#include <gnuradio-4.0/basic/ConverterBlocks.hpp>
+#include <gnuradio-4.0/basic/SignalGenerator.hpp>
 
 #include "blocks/Arithmetic.hpp"
 #include "blocks/ImPlotSink.hpp"
@@ -52,62 +41,49 @@
 
 #include <version.hpp>
 
-namespace DigitizerUi {
+static void renderFrame(void* arg) {
+    const auto startLoop = std::chrono::high_resolution_clock::now();
+    auto*      app       = static_cast<App*>(arg);
 
-struct SDLState {
-    SDL_Window*   window    = nullptr;
-    SDL_GLContext glContext = nullptr;
-};
+    // Poll and handle events (inputs, window resize, etc.)
+    app->isRunning = imgui_helper::processEvents();
 
-} // namespace DigitizerUi
+    EventLoop::instance().fireCallbacks();
+    TouchHandler<>::updateGestures();
 
-using namespace DigitizerUi;
+    // Start the Dear ImGui frame
+    imgui_helper::newFrame();
+    TouchHandler<>::applyToImGui();
 
-static void main_loop(void*);
+    app->processAndRender();
 
-void setWindowMode(SDL_Window* window, const WindowMode& state) {
-    using enum WindowMode;
-    const Uint32 flags        = SDL_GetWindowFlags(window);
-    const bool   isMaximised  = (flags & SDL_WINDOW_MAXIMIZED) != 0;
-    const bool   isMinimised  = (flags & SDL_WINDOW_MINIMIZED) != 0;
-    const bool   isFullscreen = (flags & SDL_WINDOW_FULLSCREEN) != 0;
-    if ((isMaximised && state == MAXIMISED) || (isMinimised && state == MINIMISED) || (isFullscreen && state == FULLSCREEN)) {
-        return;
-    }
-    switch (state) {
-    case FULLSCREEN: SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP); return;
-    case MAXIMISED:
-        SDL_SetWindowFullscreen(window, 0);
-        SDL_MaximizeWindow(window);
-        return;
-    case MINIMISED:
-        SDL_SetWindowFullscreen(window, 0);
-        SDL_MinimizeWindow(window);
-        return;
-    case RESTORED: SDL_SetWindowFullscreen(window, 0); SDL_RestoreWindow(window);
-    }
+    components::Notification::render();
+
+    // Rendering
+    imgui_helper::renderFrame();
+
+    const auto stopLoop                     = std::chrono::high_resolution_clock::now();
+    LookAndFeel::mutableInstance().execTime = std::chrono::duration_cast<std::chrono::milliseconds>(stopLoop - startLoop);
 }
 
 int main(int argc, char** argv) {
-#ifndef EMSCRIPTEN
-    if (argc > 1 && strcmp(argv[1], "--help") == 0) {
-        std::println("opendigitizer --version");
-        std::println("    print version of the opendigitizer-ui");
-        std::println("opendigitizer --help");
-        std::println("    show this help message");
-        return 0;
+    auto basename = [](std::string_view path) {
+        if (std::size_t pos = path.rfind('/'); pos != std::string_view::npos) {
+            return path.substr(pos + 1);
+        }
+        return path;
+    };
+    std::println("[Main] started: {} - {}", basename(argv[0]), kOpendigitizerVersion);
+
+    std::string glslVersion;
+    if (!imgui_helper::initSDL(glslVersion, "OpenDigitizer UI", ImVec2{1280.f, 720.f})) {
+        std::println(stderr, "[Main] SDL3 initialisation failed.");
+        return 1;
     }
 
-    if (argc > 1 && strcmp(argv[1], "--version") == 0) {
-        std::println("{}", kOpendigitizerVersion);
-        return 0;
-    }
-#endif
-
-    // Setup SDL
-    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) != 0) {
-        printf("Error: %s\n", SDL_GetError());
-        return -1;
+    if (!imgui_helper::initImGui(glslVersion)) {
+        std::println(stderr, "[Main] ImGui initialisation failed.");
+        return 1;
     }
 
     Digitizer::Settings::instance();          // TODO do we need this here?
@@ -124,78 +100,14 @@ int main(int argc, char** argv) {
     gr::blocklib::initGrMathBlocks(*registry);
     gr::blocklib::initGrTestingBlocks(*registry);
 
-#if defined(IMGUI_IMPL_OPENGL_ES2)
-    // GL ES 2.0 + GLSL 100
-    const char* glsl_version = "#version 100";
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, 0);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
-#elif defined(__APPLE__)
-    // GL 3.2 Core + GLSL 150
-    const char* glsl_version = "#version 150";
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG); // Always required on Mac
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
-#else
-    // GL 3.0 + GLSL 130
-    const char* glsl_version = "#version 130";
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, 0);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
-#endif
-
-    // Create window with graphics context
-    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
-    SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
-    SDL_DisplayMode current;
-    SDL_GetCurrentDisplayMode(0, &current);
-    const auto window_flags = static_cast<SDL_WindowFlags>(SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
-    SDLState   sdlState;
-    sdlState.window = SDL_CreateWindow("opendigitizer UI", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
-    if (!sdlState.window) {
-        std::print(stderr, "Failed to create SDL window: {}!\n", SDL_GetError());
-        return 1;
-    }
-    sdlState.glContext = SDL_GL_CreateContext(sdlState.window);
-    if (!sdlState.glContext) {
-        std::print(stderr, "Failed to initialize GL context!\n");
-        return 1;
-    }
-    // Setup Dear ImGui context
-    IMGUI_CHECKVERSION();
-    ImGui::CreateContext();
-    ImPlot::CreateContext();
-    ImGuiIO& io                  = ImGui::GetIO();
-    ImPlot::GetInputMap().Select = ImGuiPopupFlags_MouseButtonLeft;
-    ImPlot::GetInputMap().Pan    = ImGuiPopupFlags_MouseButtonMiddle;
-
-    // For an Emscripten build we are disabling file-system access, so let's not
-    // attempt to do a fopen() of the imgui.ini file. You may manually call
-    // LoadIniSettingsFromMemory() to load settings from your own storage.
-    io.IniFilename = nullptr;
-
-    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
-    io.ConfigWindowsMoveFromTitleBarOnly = true;
-
-    // Setup Platform/Renderer backends
-    ImGui_ImplSDL2_InitForOpenGL(sdlState.window, sdlState.glContext);
-    ImGui_ImplOpenGL3_Init(glsl_version);
-
     // UI init
-    LookAndFeel::mutableInstance().verticalDPI = []() -> float {
-        float diagonalDPI   = LookAndFeel::instance().defaultDPI;
-        float horizontalDPI = diagonalDPI;
-        float verticalDPI   = diagonalDPI;
-        if (SDL_GetDisplayDPI(0, &diagonalDPI, &horizontalDPI, &verticalDPI) != 0) {
-            auto msg = std::format("Failed to obtain DPI information for display 0: {}", SDL_GetError());
-            components::Notification::error(msg);
-            return LookAndFeel::instance().defaultDPI;
+    LookAndFeel::mutableInstance().verticalDPI = []() {
+        if (float scale = SDL_GetDisplayContentScale(0); scale > 0.f) {
+            return LookAndFeel::instance().defaultDPI * scale;
         }
-        return verticalDPI;
+        auto msg = std::format("[Main] Failed to obtain content scale for display 0: {}", SDL_GetError());
+        components::Notification::error(msg);
+        return LookAndFeel::instance().defaultDPI;
     }();
 
     // EMSCRIPTEN ends main before it enters the main loop,
@@ -206,104 +118,23 @@ int main(int argc, char** argv) {
 #else
     app.executable = argv[0];
 #endif
-    app.sdlState = &sdlState;
 
     LookAndFeel::mutableInstance().loadFonts();
 
     app.init(argc, argv);
 
-    // This function call won't return, and will engage in an infinite loop, processing events from the browser, and dispatching them.
 #ifdef __EMSCRIPTEN__
     emscripten_set_visibilitychange_callback(nullptr, false, em_visibilitychange_callback); // keep rendering alive even on hidden browser tabs or minimised windows
-    emscripten_set_main_loop_arg(main_loop, &app, 0, true);
+    emscripten_set_main_loop_arg(renderFrame, &app, 0, true);                               // main UI-loop (EMSCRIPTEN) - blocks
 #else
     SDL_GL_SetSwapInterval(1); // Enable vsync
 
-    while (app.isRunning) {
-        main_loop(&app);
+    while (app.isRunning) { // main UI-loop - blocks
+        renderFrame(&app);
     }
-    // Cleanup
-    ImGui_ImplOpenGL3_Shutdown();
-    ImGui_ImplSDL2_Shutdown();
-    ImGui::DestroyContext();
-
-    SDL_GL_DeleteContext(sdlState.glContext);
-    SDL_DestroyWindow(sdlState.window);
-    SDL_Quit();
 #endif
-    // emscripten_set_main_loop_timing(EM_TIMING_SETIMMEDIATE, 10);
-}
 
-namespace {
+    imgui_helper::teardownSDL();
 
-std::string localFlowgraphGrc = {};
-
-}
-
-static void main_loop(void* arg) {
-    const auto startLoop = std::chrono::high_resolution_clock::now();
-    auto*      app       = static_cast<App*>(arg);
-    ImGuiIO&   io        = ImGui::GetIO();
-
-    // Poll and handle events (inputs, window resize, etc.)
-    SDL_Event event;
-    while (SDL_PollEvent(&event)) {
-        ImGui_ImplSDL2_ProcessEvent(&event);
-        switch (event.type) {
-        case SDL_QUIT: app->isRunning = false; break;
-        case SDL_WINDOWEVENT:
-            if (event.window.windowID != SDL_GetWindowID(app->sdlState->window)) {
-                // break // TODO: why was this aborted here?
-            } else {
-                const int width  = event.window.data1;
-                const int height = event.window.data2;
-
-                ImGui::GetIO().DisplaySize = ImVec2(float(width), float(height));
-                glViewport(0, 0, width, height);
-                ImGui::SetNextWindowPos(ImVec2(0, 0));
-                ImGui::SetNextWindowSize(ImVec2(float(width), float(height)));
-            }
-            switch (event.window.event) {
-            case SDL_WINDOWEVENT_CLOSE: app->isRunning = false; break;
-            case SDL_WINDOWEVENT_RESTORED: LookAndFeel::mutableInstance().windowMode = WindowMode::RESTORED; break;
-            case SDL_WINDOWEVENT_MINIMIZED: LookAndFeel::mutableInstance().windowMode = WindowMode::MINIMISED; break;
-            case SDL_WINDOWEVENT_MAXIMIZED: LookAndFeel::mutableInstance().windowMode = WindowMode::MAXIMISED; break;
-            case SDL_WINDOWEVENT_SIZE_CHANGED: break;
-            }
-            break;
-        }
-        TouchHandler<>::processSDLEvent(event);
-        // Capture events here, based on io.WantCaptureMouse and io.WantCaptureKeyboard
-    }
-
-    EventLoop::instance().fireCallbacks();
-    TouchHandler<>::updateGestures();
-
-    // Start the Dear ImGui frame
-    ImGui_ImplOpenGL3_NewFrame();
-    ImGui_ImplSDL2_NewFrame();
-    ImGui::NewFrame();
-
-    ImGui::SetNextWindowPos({0, 0});
-    int width, height;
-    SDL_GetWindowSize(app->sdlState->window, &width, &height);
-    ImGui::SetNextWindowSize({float(width), float(height)});
-    TouchHandler<>::applyToImGui();
-
-    app->processAndRender();
-
-    components::Notification::render();
-
-    // Rendering
-    ImGui::Render();
-    SDL_GL_MakeCurrent(app->sdlState->window, app->sdlState->glContext);
-    glViewport(0, 0, int(io.DisplaySize.x), int(io.DisplaySize.y));
-    glClearColor(1, 1, 1, 1);
-    glClear(GL_COLOR_BUFFER_BIT);
-    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
-
-    const auto stopLoop                     = std::chrono::high_resolution_clock::now();
-    LookAndFeel::mutableInstance().execTime = std::chrono::duration_cast<std::chrono::milliseconds>(stopLoop - startLoop);
-    SDL_GL_SwapWindow(app->sdlState->window);
-    setWindowMode(app->sdlState->window, LookAndFeel::instance().windowMode);
+    return 0;
 }

--- a/src/ui/test/ImGuiTestApp.hpp
+++ b/src/ui/test/ImGuiTestApp.hpp
@@ -1,11 +1,17 @@
 #ifndef OPENDIGITIZER_UI_TEST_IMGUI_TEST_APP_HPP_
 #define OPENDIGITIZER_UI_TEST_IMGUI_TEST_APP_HPP_
 
-// #pragma GCC diagnostic push
-// #pragma GCC diagnostic ignore "-Wold-style-cast"
+#include "../common/ImGuiHelperSDL.hpp"
+#include "../common/ImguiWrap.hpp"
+using namespace DigitizerUi; // TODO refactor namespaces in ImguiWrap.hpp
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
 #include "imgui_test_engine/imgui_te_context.h"
 #include "imgui_test_engine/imgui_te_engine.h"
-// #pragma GCC diagnostic pop
+#include "imgui_test_engine/imgui_te_internal.h"
+#pragma GCC diagnostic pop
 
 #include <memory>
 
@@ -45,10 +51,10 @@ struct TestOptions {
    tests in registerTests() and then call runTests().
  */
 class ImGuiTestApp {
-    ImGuiApp*          _app      = nullptr;
-    ImGuiTestEngine*   _engine   = nullptr;
-    ImGuiTestEngineIO* _engineIO = nullptr;
-    const TestOptions  _options  = {};
+    std::unique_ptr<ImGuiApp> _app;
+    ImGuiTestEngine*          _engine   = nullptr;
+    ImGuiTestEngineIO*        _engineIO = nullptr;
+    const TestOptions         _options  = {};
 
 public:
     explicit ImGuiTestApp(const TestOptions& = {});

--- a/src/ui/test/qa_blockneighbourspreview.cpp
+++ b/src/ui/test/qa_blockneighbourspreview.cpp
@@ -1,15 +1,12 @@
 #include "GraphModel.hpp"
-#include "imgui.h"
+#include "ImGuiTestApp.hpp"
 #include "imgui_node_editor.h"
-#include "imgui_test_engine/imgui_te_context.h"
 
 #include "components/Block.hpp"
 #include "components/BlockNeighboursPreview.hpp"
 #include <boost/ut.hpp>
 #include <memory>
 #include <string>
-
-#include "ImGuiTestApp.hpp"
 
 using namespace boost;
 

--- a/src/ui/test/qa_chart.cpp
+++ b/src/ui/test/qa_chart.cpp
@@ -1,5 +1,5 @@
+#include "ImGuiTestApp.hpp"
 #include "imgui.h"
-#include "imgui_test_engine/imgui_te_context.h"
 
 #include <boost/ut.hpp>
 
@@ -12,8 +12,6 @@
 #include <GrFourierBlocks.hpp>
 #include <GrTestingBlocks.hpp>
 
-#include "ImGuiTestApp.hpp"
-
 #include <Dashboard.hpp>
 #include <DashboardPage.hpp>
 
@@ -21,8 +19,6 @@
 #include "blocks/Arithmetic.hpp"
 #include "blocks/ImPlotSink.hpp"
 #include "blocks/SineSource.hpp"
-
-#include "imgui_test_engine/imgui_te_internal.h"
 
 #include <cmrc/cmrc.hpp>
 
@@ -62,7 +58,7 @@ struct TestApp : public DigitizerUi::test::ImGuiTestApp {
         t->SetVarsDataType<TestState>();
 
         t->GuiFunc = [](ImGuiTestContext*) {
-            ImGui::Begin("Test Window", nullptr, ImGuiWindowFlags_NoSavedSettings);
+            IMW::Window window("Test Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
 
             ImGui::SetWindowPos({0, 0});
             ImGui::SetWindowSize(ImVec2(800, 800));
@@ -73,8 +69,6 @@ struct TestApp : public DigitizerUi::test::ImGuiTestApp {
                 page.draw();
                 ut::expect(!g_state.dashboard->plots().empty());
             }
-
-            ImGui::End();
         };
 
         t->TestFunc = [](ImGuiTestContext* ctx) {

--- a/src/ui/test/qa_chart_fgdipole.cpp
+++ b/src/ui/test/qa_chart_fgdipole.cpp
@@ -1,5 +1,4 @@
-#include "imgui.h"
-#include "imgui_test_engine/imgui_te_context.h"
+#include "ImGuiTestApp.hpp"
 
 #include <boost/ut.hpp>
 
@@ -22,8 +21,6 @@
 #include "blocks/Arithmetic.hpp"
 #include "blocks/ImPlotSink.hpp"
 #include "blocks/SineSource.hpp"
-
-#include "imgui_test_engine/imgui_te_internal.h"
 
 #include <cmrc/cmrc.hpp>
 #include <gnuradio-4.0/Graph_yaml_importer.hpp>
@@ -79,7 +76,7 @@ struct TestApp : public DigitizerUi::test::ImGuiTestApp {
         t->SetVarsDataType<TestState>();
 
         t->GuiFunc = [](ImGuiTestContext*) {
-            ImGui::Begin("Test Window", nullptr, ImGuiWindowFlags_NoSavedSettings);
+            IMW::Window window("Test Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
 
             ImGui::SetWindowPos({0, 0});
             ImGui::SetWindowSize(ImVec2(1200, 800));
@@ -90,8 +87,6 @@ struct TestApp : public DigitizerUi::test::ImGuiTestApp {
                 page.draw();
                 ut::expect(!g_state.dashboard->plots().empty());
             }
-
-            ImGui::End();
         };
 
         t->TestFunc = [](ImGuiTestContext* ctx) {

--- a/src/ui/test/qa_dialog.cpp
+++ b/src/ui/test/qa_dialog.cpp
@@ -1,10 +1,7 @@
-#include "imgui.h"
-#include "imgui_test_engine/imgui_te_context.h"
+#include "ImGuiTestApp.hpp"
 
 #include "components/Dialog.hpp"
 #include <boost/ut.hpp>
-
-#include "ImGuiTestApp.hpp"
 
 using namespace boost;
 using namespace DigitizerUi::components;
@@ -23,7 +20,7 @@ private:
         t->SetVarsDataType<TestState>();
 
         t->GuiFunc = [](ImGuiTestContext* ctx) {
-            ImGui::Begin("Test Window", NULL, ImGuiWindowFlags_NoSavedSettings);
+            IMW::Window window("Test Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
             ImGui::SetWindowSize(ImVec2(300, 300));
 
             auto&        vars   = ctx->GetVars<TestState>();
@@ -32,8 +29,6 @@ private:
             if (button != DialogButton::None) {
                 vars.pressedButton = button;
             }
-
-            ImGui::End();
         };
 
         t->TestFunc = [](ImGuiTestContext* ctx) {

--- a/src/ui/test/qa_docking.cpp
+++ b/src/ui/test/qa_docking.cpp
@@ -1,12 +1,9 @@
 #include "../ui/common/ImguiWrap.hpp"
-#include "imgui.h"
-#include "imgui_test_engine/imgui_te_context.h"
+#include "ImGuiTestApp.hpp"
 
 #include "components/Docking.hpp"
 #include <boost/ut.hpp>
 #include <format>
-
-#include "ImGuiTestApp.hpp"
 
 using namespace boost;
 using namespace DigitizerUi;

--- a/src/ui/test/qa_filtercomboboxes.cpp
+++ b/src/ui/test/qa_filtercomboboxes.cpp
@@ -1,10 +1,7 @@
-#include "imgui.h"
-#include "imgui_test_engine/imgui_te_context.h"
+#include "ImGuiTestApp.hpp"
 
 #include "components/FilterComboBoxes.hpp"
 #include <boost/ut.hpp>
-
-#include "ImGuiTestApp.hpp"
 
 using namespace boost;
 
@@ -34,6 +31,7 @@ private:
         t->SetVarsDataType<TestState>();
 
         t->GuiFunc = [](ImGuiTestContext* ctx) {
+            // IMW::Window window("Test Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
             ImGui::Begin("Test Window", NULL, ImGuiWindowFlags_NoSavedSettings);
             ImGui::SetWindowSize(ImVec2(300, 350));
 
@@ -85,7 +83,7 @@ private:
 
                 // click an item
                 ctx->ItemClick("//##Combo_00/one");
-                ut::expect(vars.lastItem.title == "one");
+                ut::expect(ut::eq(vars.lastItem.title, std::string("one")));
             };
         };
     }

--- a/src/ui/test/qa_flowgraph.cpp
+++ b/src/ui/test/qa_flowgraph.cpp
@@ -1,6 +1,5 @@
 #include "FlowgraphPage.hpp"
-#include "imgui.h"
-#include "imgui_test_engine/imgui_te_context.h"
+#include "ImGuiTestApp.hpp"
 
 #include <boost/ut.hpp>
 
@@ -13,8 +12,6 @@
 #include <GrFourierBlocks.hpp>
 #include <GrTestingBlocks.hpp>
 
-#include "ImGuiTestApp.hpp"
-
 #include <Dashboard.hpp>
 #include <DashboardPage.hpp>
 
@@ -22,8 +19,6 @@
 #include "blocks/Arithmetic.hpp"
 #include "blocks/ImPlotSink.hpp"
 #include "blocks/SineSource.hpp"
-
-#include "imgui_test_engine/imgui_te_internal.h"
 
 #include <cmrc/cmrc.hpp>
 
@@ -124,7 +119,7 @@ struct TestApp : public DigitizerUi::test::ImGuiTestApp {
             t->SetVarsDataType<TestState>();
 
             t->GuiFunc = [](ImGuiTestContext*) {
-                ImGui::Begin("Test Window", nullptr, ImGuiWindowFlags_NoSavedSettings);
+                IMW::Window window("Test Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
 
                 ImGui::SetWindowPos({0, 0});
                 ImGui::SetWindowSize(ImVec2(800, 800));
@@ -132,7 +127,6 @@ struct TestApp : public DigitizerUi::test::ImGuiTestApp {
                 g_state.drawGraph();
 
                 g_state.dashboard->handleMessages();
-                ImGui::End();
             };
 
             t->TestFunc = [](ImGuiTestContext* ctx) {

--- a/src/ui/test/qa_keypad.cpp
+++ b/src/ui/test/qa_keypad.cpp
@@ -1,8 +1,5 @@
 #include "ImGuiTestApp.hpp"
 #include "components/Keypad.hpp"
-#include "imgui.h"
-
-#include "imgui_test_engine/imgui_te_context.h"
 
 #include <boost/ut.hpp>
 
@@ -22,7 +19,7 @@ private:
         t->SetVarsDataType<TestState>();
 
         t->GuiFunc = [](ImGuiTestContext* ctx) {
-            ImGui::Begin("Test Window", NULL, ImGuiWindowFlags_NoSavedSettings);
+            IMW::Window window("Test Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
             ImGui::SetWindowSize(ImVec2(300, 300));
 
             auto& vars = ctx->GetVars<TestState>();
@@ -30,8 +27,6 @@ private:
                 // do not override with false every frame
                 vars.edited = true;
             }
-
-            ImGui::End();
         };
 
         t->TestFunc = [](ImGuiTestContext* ctx) {

--- a/src/ui/test/qa_layout.cpp
+++ b/src/ui/test/qa_layout.cpp
@@ -1,6 +1,4 @@
-#include "../ui/common/ImguiWrap.hpp"
-#include "imgui.h"
-#include "imgui_test_engine/imgui_te_context.h"
+#include "ImGuiTestApp.hpp"
 
 #include <boost/ut.hpp>
 
@@ -12,8 +10,6 @@
 #include <GrBasicBlocks.hpp>
 #include <GrTestingBlocks.hpp>
 
-#include "ImGuiTestApp.hpp"
-
 #include <Dashboard.hpp>
 #include <DashboardPage.hpp>
 
@@ -21,8 +17,6 @@
 #include "blocks/Arithmetic.hpp"
 #include "blocks/ImPlotSink.hpp"
 #include "blocks/SineSource.hpp"
-
-#include "imgui_test_engine/imgui_te_internal.h"
 
 #include <cmrc/cmrc.hpp>
 #include <memory.h>
@@ -47,8 +41,8 @@ struct TestApp : public DigitizerUi::test::ImGuiTestApp {
         t->SetVarsDataType<TestState>();
 
         t->GuiFunc = [](ImGuiTestContext* ctx) {
-            auto&                    vars = ctx->GetVars<TestState>();
-            DigitizerUi::IMW::Window window("Test Window", nullptr, ImGuiWindowFlags_NoSavedSettings);
+            auto&       vars = ctx->GetVars<TestState>();
+            IMW::Window window("Test Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
 
             ImGui::SetWindowPos({0, 0});
             ImGui::SetWindowSize(ImVec2(800, 800));

--- a/src/ui/test/qa_popup_menu.cpp
+++ b/src/ui/test/qa_popup_menu.cpp
@@ -1,10 +1,7 @@
-#include "imgui.h"
-#include "imgui_test_engine/imgui_te_context.h"
+#include "ImGuiTestApp.hpp"
 
 #include "components/PopupMenu.hpp"
 #include <boost/ut.hpp>
-
-#include "ImGuiTestApp.hpp"
 
 using namespace boost;
 
@@ -39,7 +36,7 @@ private:
         t->SetVarsDataType<TestState>();
 
         t->GuiFunc = [](ImGuiTestContext* ctx) {
-            ImGui::Begin("Test Window", NULL, ImGuiWindowFlags_NoSavedSettings);
+            IMW::Window window("Test Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
             ImGui::SetWindowPos({0, 0});
             ImGui::SetWindowSize(ImVec2(500, 500));
 
@@ -51,8 +48,6 @@ private:
                     vars.pressed = true;
                 });
             }
-
-            ImGui::End();
         };
 
         t->TestFunc = [](ImGuiTestContext* ctx) {

--- a/src/ui/utils/EmscriptenHelper.hpp
+++ b/src/ui/utils/EmscriptenHelper.hpp
@@ -6,6 +6,9 @@
 #include <emscripten/html5.h>
 #include <emscripten/threading.h>
 #endif
+#include <cstdint>
+#include <format>
+#include <print>
 
 enum class ExecutionMode : std::uint8_t { Async = 0, Sync };
 
@@ -50,7 +53,7 @@ bool em_visibilitychange_callback(int, const EmscriptenVisibilityChangeEvent* ev
 }
 #endif
 
-inline void listPersistentFiles(bool recursive = true) {
+inline void listPersistentFiles([[maybe_unused]] bool recursive = true) {
 #ifdef __EMSCRIPTEN__
     EM_ASM_(
         {

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -30,13 +30,42 @@ if(Git_FOUND)
     OUTPUT_VARIABLE OPENDIGITIZER_GIT_DESCRIBE
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()
+
+if(Git_FOUND)
+  # cmake-format: off
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+          "${CMAKE_CURRENT_SOURCE_DIR}/../../.git/HEAD"
+          "${CMAKE_CURRENT_SOURCE_DIR}/../../.git/index"
+          "${CMAKE_CURRENT_SOURCE_DIR}/../../.git/refs/heads/main"
+          "${CMAKE_CURRENT_SOURCE_DIR}/../../.git/packed-refs"
+  )
+  # cmake-format: on
+endif()
+
+# Build timestamp
+string(TIMESTAMP OPENDIGITIZER_BUILD_TIME "%Y-%m-%d %H:%M:%S")
+
+if(EMSCRIPTEN)
+  set(OPENDIGITIZER_IS_EMSCRIPTEN "true")
+else()
+  set(OPENDIGITIZER_IS_EMSCRIPTEN "false")
+endif()
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "unknown")
+endif()
+
+string(
+  CONCAT OPENDIGITIZER_VERSION_INFO
+         "${OPENDIGITIZER_GIT_DESCRIBE} | "
+         "built: ${OPENDIGITIZER_BUILD_TIME} | "
+         "emscripten: ${OPENDIGITIZER_IS_EMSCRIPTEN} | "
+         "build-type: ${CMAKE_BUILD_TYPE}")
+
+# Configure version file
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version/version.cpp.in ${CMAKE_BINARY_DIR}/generated_version/version.cpp
                @ONLY)
-if(Git_FOUND)
-  set_property(
-    DIRECTORY
-    APPEND
-    PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../../.git/HEAD")
-endif()
+
 add_library(opendigitizer_version STATIC ${CMAKE_BINARY_DIR}/generated_version/version.cpp)
 target_include_directories(opendigitizer_version PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/version/include)
+target_include_directories(opendigitizer_version PUBLIC ${CMAKE_BINARY_DIR}/generated_version)

--- a/src/utils/version/version.cpp.in
+++ b/src/utils/version/version.cpp.in
@@ -1,3 +1,3 @@
 #include "version.hpp"
 
-const std::string_view kOpendigitizerVersion{"@OPENDIGITIZER_GIT_DESCRIBE@"};
+const std::string_view kOpendigitizerVersion{"@OPENDIGITIZER_VERSION_INFO@"};


### PR DESCRIPTION
- replaced SDL2 with SDL3 using `find_package(SDL3 QUIET)` and `FetchContent` fallback for reproducibility
- refactored/simplified main.cpp structure
- updated version.cpp string generation to include git hash, build-time, WASM? and build-target