### PR TITLE
ImPlotSink: Implement work() with a guard to allow background execution.

### DIFF
--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -355,7 +355,8 @@ void DashboardPage::drawPlot(Dashboard::Plot& plot) noexcept {
     // draw each source on the correct axis
     bool drawTag = true;
     for (opendigitizer::ImPlotSinkModel* plotSinkBlock : plot.plotSinkBlocks) {
-        if (!plotSinkBlock->isVisible) {
+        // if tab is invisible work() function does the job in Scheduler thread
+        if (!plotSinkBlock->isVisible && isTabVisible()) {
             // consume data if hidden
             std::ignore = plotSinkBlock->invokeWork();
             continue;

--- a/src/ui/utils/EmscriptenHelper.hpp
+++ b/src/ui/utils/EmscriptenHelper.hpp
@@ -39,7 +39,7 @@ inline bool isTabVisible() {
 }
 
 #ifdef __EMSCRIPTEN__
-bool em_visibilitychange_callback(int, const EmscriptenVisibilityChangeEvent* evt, void*) {
+inline bool em_visibilitychange_callback(int, const EmscriptenVisibilityChangeEvent* evt, void*) {
     constexpr int visibleFPS = 0; // 0 = requestAnimationFrame
     constexpr int hiddenFPS  = 5; // ~200ms refresh when hidden
     if (evt->hidden) {


### PR DESCRIPTION
ImPlotSink: Implement work() with a guard to allow background execution.
* Ensures that samples are consumed even when the tab is not visible, since the UI thread cannot run in the background.
* Guarantees that the plot always shows the latest available data when switching back to the tab.