### PR TITLE
CMake: make it possible to build the UI separately

### DIFF
--- a/src/service/gnuradio/test/CMakeLists.txt
+++ b/src/service/gnuradio/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_executable(qa_GnuRadioWorker qa_GnuRadioWorker.cpp)
 
-message("COPY ${CMAKE_SOURCE_DIR}/src/service/demo_sslcert/demo_private.key DESTINATION ${CMAKE_CURRENT_BINARY_DIR}")
-file(COPY "${CMAKE_SOURCE_DIR}/src/service/demo_sslcert/demo_private.key" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
-file(COPY "${CMAKE_SOURCE_DIR}/src/service/demo_sslcert/demo_public.crt" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
+message("COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../demo_sslcert/demo_private.key DESTINATION ${CMAKE_CURRENT_BINARY_DIR}")
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/../../demo_sslcert/demo_private.key" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/../../demo_sslcert/demo_public.crt" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
 
 target_link_directories(qa_GnuRadioWorker PRIVATE ${CMAKE_BINARY_DIR}/_deps/ngtcp2-install/lib)
 


### PR DESCRIPTION
Changes the path to be relative to the current source dir instead of the project source dir, which can be either /src/ui or / where in the first case the files were not found.

small followup to #340, not critical for deployment, but improves development experience.