### PR TITLE
improved axis SI/scientific label formatting and setup

### DIFF
--- a/src/ui/Dashboard.cpp
+++ b/src/ui/Dashboard.cpp
@@ -386,15 +386,17 @@ void Dashboard::doLoad(const gr::property_map& dashboard) {
                     return;
                 }
 
-                axisData.min         = axisMap.contains("min") ? pmtv::cast<float>(axisMap.at("min")) : std::numeric_limits<float>::quiet_NaN();
-                axisData.max         = axisMap.contains("max") ? pmtv::cast<float>(axisMap.at("max")) : std::numeric_limits<float>::quiet_NaN();
-                std::string scaleStr = axisMap.contains("scale") ? std::get<std::string>(axisMap.at("scale")) : "Linear";
-                auto        trim     = [](const std::string& str) {
+                axisData.min          = axisMap.contains("min") ? pmtv::cast<float>(axisMap.at("min")) : std::numeric_limits<float>::quiet_NaN();
+                axisData.max          = axisMap.contains("max") ? pmtv::cast<float>(axisMap.at("max")) : std::numeric_limits<float>::quiet_NaN();
+                std::string scaleStr  = axisMap.contains("scale") ? std::get<std::string>(axisMap.at("scale")) : "Linear";
+                std::string formatStr = axisMap.contains("format") ? std::get<std::string>(axisMap.at("format")) : "Auto";
+                auto        trim      = [](const std::string& str) {
                     auto start = std::ranges::find_if_not(str, [](unsigned char ch) { return std::isspace(ch); });
                     auto end   = std::ranges::find_if_not(str.rbegin(), str.rend(), [](unsigned char ch) { return std::isspace(ch); }).base();
                     return (start < end) ? std::string(start, end) : std::string{};
                 };
-                axisData.scale = magic_enum::enum_cast<AxisScale>(trim(scaleStr), magic_enum::case_insensitive).value_or(AxisScale::Linear);
+                axisData.scale  = magic_enum::enum_cast<AxisScale>(trim(scaleStr), magic_enum::case_insensitive).value_or(AxisScale::Linear);
+                axisData.format = magic_enum::enum_cast<LabelFormat>(trim(formatStr), magic_enum::case_insensitive).value_or(LabelFormat::Auto);
 
                 if (axisMap.contains("plot_tags")) {
                     auto tagOpt = axisMap.at("plot_tags");
@@ -463,6 +465,7 @@ void Dashboard::save() {
             axisMap["min"]       = axis.min;
             axisMap["max"]       = axis.max;
             axisMap["scale"]     = std::string(magic_enum::enum_name<AxisScale>(axis.scale));
+            axisMap["format"]    = std::string(magic_enum::enum_name<LabelFormat>(axis.format));
             axisMap["plot_tags"] = axis.plotTags;
             plotAxes.emplace_back(std::move(axisMap));
         }

--- a/src/ui/Dashboard.hpp
+++ b/src/ui/Dashboard.hpp
@@ -53,6 +53,8 @@ enum class AxisScale : std::uint8_t {
     SymLog,        /// symmetric log scale
 };
 
+enum class LabelFormat : std::uint8_t { Auto = 0U, Metric, Scientific, Default };
+
 // Defines where the dashboard is stored and fetched from
 struct DashboardStorageInfo {
 private:
@@ -115,12 +117,13 @@ public:
         enum class AxisKind { X = 0, Y };
 
         struct AxisData {
-            AxisKind  axis     = AxisKind::X;
-            float     min      = std::numeric_limits<float>::quiet_NaN();
-            float     max      = std::numeric_limits<float>::quiet_NaN();
-            AxisScale scale    = AxisScale::Linear;
-            float     width    = std::numeric_limits<float>::max();
-            bool      plotTags = true;
+            AxisKind    axis     = AxisKind::X;
+            float       min      = std::numeric_limits<float>::quiet_NaN();
+            float       max      = std::numeric_limits<float>::quiet_NaN();
+            AxisScale   scale    = AxisScale::Linear;
+            LabelFormat format   = LabelFormat::Auto;
+            float       width    = std::numeric_limits<float>::max();
+            bool        plotTags = true;
         };
 
         std::string                                  name;

--- a/src/ui/assets/sampleDashboards/DemoDashboard.grc
+++ b/src/ui/assets/sampleDashboards/DemoDashboard.grc
@@ -66,51 +66,51 @@ blocks:
       - context: "FAIR.SELECTOR.C=1:S=1:P=1"
         time: !!uint64 0
         parameters:
-          start_value: 1
+          start_value: 100
           sample_rate: 1000
           signal_type: Const
       - context: "FAIR.SELECTOR.C=1:S=1:P=2"  # start pre-ramp
         time: !!uint64 0
         parameters:
           duration: 0.1
-          start_value: 1
-          final_value: 5
+          start_value: 100
+          final_value: 500
           round_off_time: 0.02
           sample_rate: 1000
           signal_type: ParabolicRamp
       - context: "FAIR.SELECTOR.C=1:S=1:P=3"  # lower-plateau
         time: !!uint64 0
         parameters:
-          start_value: 5
+          start_value: 500
           sample_rate: 1000
           signal_type: Const
       - context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
         time: !!uint64 0
         parameters:
           duration: 0.5
-          start_value: 5
-          final_value: 30
+          start_value: 500
+          final_value: 3000
           round_off_time: 0.2
           sample_rate: 1000
           signal_type: ParabolicRamp
       - context: "FAIR.SELECTOR.C=1:S=1:P=5" # upper-plateau
         time: !!uint64 0
         parameters:
-          start_value: 30
+          start_value: 3000
           sample_rate: 1000
           signal_type: Const
       - context: "FAIR.SELECTOR.C=1:S=1:P=6" # start ramp-down
         time: !!uint64 0
         parameters:
           duration: 0.3
-          start_value: 30
-          final_value: 1
+          start_value: 3000
+          final_value: 100
           sample_rate: 1000
           signal_type: CubicSpline
       - context: "FAIR.SELECTOR.C=1:S=1:P=7" # upper-plateau
         time: !!uint64 0
         parameters:
-          start_value: 1
+          start_value: 100
           sample_rate: 1000
           signal_type: Const
   - name: IntensityGenerator
@@ -197,8 +197,9 @@ dashboard:
           max: NaN # enables auto-range
           scale: LinearReverse
         - axis: Y
-          min: NaN # enables auto-range
-          max: NaN # enables auto-range
+          min: NaN # enables auto-range for first axis
+          max: NaN # enables auto-range for first axis
+          format: Default # options: Auto, Metric, Scientific, Default
       sources:
         - sinesSink
       rect: [0, 0, 1, 1]
@@ -221,8 +222,12 @@ dashboard:
           max: NaN # auto-range max
           scale: Time # UTC time axis, other options: Linear, LinearReverse, Time, Log10, SymLog
         - axis: Y
-          min: NaN # auto-range min
-          max: NaN # auto-range max
+          min: NaN # enables auto-range for first axis
+          max: NaN # enables auto-range for first axis
+        - axis: Y
+          min: -100. # second axis min
+          max: NaN # second axis max
+          format: Metric # options: Auto, Metric, Scientific, Default
       sources:
         - IntensitySink
         - DipoleCurrentSink

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -100,16 +100,6 @@ int main(int argc, char** argv) {
     gr::blocklib::initGrMathBlocks(*registry);
     gr::blocklib::initGrTestingBlocks(*registry);
 
-    // UI init
-    LookAndFeel::mutableInstance().verticalDPI = []() {
-        if (float scale = SDL_GetDisplayContentScale(0); scale > 0.f) {
-            return LookAndFeel::instance().defaultDPI * scale;
-        }
-        auto msg = std::format("[Main] Failed to obtain content scale for display 0: {}", SDL_GetError());
-        components::Notification::error(msg);
-        return LookAndFeel::instance().defaultDPI;
-    }();
-
     // EMSCRIPTEN ends main before it enters the main loop,
     // app needs to live forever, so it is static
     static App app;


### PR DESCRIPTION
  - introduced SI-prefix and scientific formatter functions (formatMetric, formatScientific) for ImPlot axis labels with unit support.
  - improved label truncation logic and fallback handling in buildLabel(...).
  - unified axis setup for primary and secondary axes, including formatter, colour, label, scale, and limit logic.
  - resolved missing ImPlotAxisFlags_* behaviours and ensured correct SetupAxisLimits / Constraints calls for mixed lock/auto modes.
  - added config parameter controlling the axis label formatting via 'format' either Auto, Metric, Scientific, Default
  - updated DemoDashboard.grc to reflect larger current amplitude range and custom axis constraints.

For consistent significant digits and axis-wide scaling, access to axis context would be needed — see the corresponding ImPlot [feature request](https://github.com/epezent/implot/issues/628). Let’s hope it takes root. :seedling: 

Example (`Voltage [V]` & `magnitude [dB]` -> `LabelFormat::Default`, `BeamIntensity [pp]` -> `LabelFormat::Scientific`, `DipoleCurrent [A]` -> `LabelFormat::Metric`):
<img width="1282" height="749" alt="image" src="https://github.com/user-attachments/assets/3af2f6a1-ae89-4fc1-8b9f-9bcacc7b3da6" />


*N.B. x-axes do not have category-based title settings but should also obey the `format = LabelFormat::XXX` yaml config declaration.*