### PR TITLE
Add run-opendigitizer target

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,19 @@ assets.
 
 ## Running
 
+Running the service for webassembly UI
+
 ```shell
-export DIGITIZER_CHECK_CERTIFICATES=0                   # to disable certificate checking, if wanted
-export DIGITIZER_HOSTNAME=localhost           # set a custom host
-export OPENCMW_REST_CERT_FILE=${BUILD_DIR}/_deps/opencmw-cpp-src/src/client/test/assets/server-cert.pem
-export OPENCMW_REST_PRIVATE_KEY_FILE=${BUILD_DIR}/_deps/opencmw-cpp-src/src/client/test/assets/server-key.pem
-build/src/service/opendigitizer &              # launches the service
-build/src/ui/opendigitizer-ui &                # launches the native digitizer UI
-xdg-open https://localhost:8080/web/index.html # launches the webassembly UI
-xdg-open https://localhost:8080/flowchart      # launches the html based web ui for the flowgraph property
-xdg-open https://localhost:8080/acquisition    # launches the html based web ui for the acquisition property
+cmake --build . --target run-opendigitizer
+xdg-open https://localhost:8443/web/index.html # launches the webassembly UI
+xdg-open https://localhost:8443/flowchart      # launches the html based web ui for the flowgraph property
+xdg-open https://localhost:8443/acquisition    # launches the html based web ui for the acquisition property
+```
+
+Running the native digitizer UI
+
+```shell
+build/src/ui/opendigitizer-ui
 ```
 
 ## Sustainable, FAIR, Clean- and Lean- Principles

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -143,3 +143,13 @@ target_link_libraries(
           GrHttpBlocksShared
           GrMathBlocksShared
           GrTestingBlocksShared)
+
+add_custom_target(
+  run-opendigitizer
+  USES_TERMINAL
+  COMMAND
+    ${CMAKE_COMMAND} -E env
+    OPENCMW_REST_CERT_FILE="${CMAKE_BINARY_DIR}/_deps/opencmw-cpp-src/src/client/test/assets/server-cert.pem"
+    OPENCMW_REST_PRIVATE_KEY_FILE="${CMAKE_BINARY_DIR}/_deps/opencmw-cpp-src/src/client/test/assets/server-key.pem"
+    DIGITIZER_CHECK_CERTIFICATES=0 DIGITIZER_HOSTNAME=localhost DIGITIZER_WASM_SERVE_DIR="${CMAKE_BINARY_DIR}/ui-wasm"
+    DIGITIZER_REMOTE_DASHBOARDS="${PROJECT_SOURCE_DIR}/dashboard/defaultDashboards" "\"$<TARGET_FILE:opendigitizer>\"")


### PR DESCRIPTION
This target call opendigitizer service with the proper enviriment variables, so one doesn't need to keep
remembering or adjusting paths.