### PR TITLE
Refactor chart/plotting system into self-contained GR4 blocks (#250)

### DIFF
--- a/.claude/commands/fix-style.md
+++ b/.claude/commands/fix-style.md
@@ -1,0 +1,62 @@
+# Fix Style
+
+Baseline conventions are in CLAUDE.md — follow them, do not restate them.
+
+Apply safe cosmetic fixes to changed files. Edit files directly, then print a summary.
+
+## Scope
+
+Default: uncommitted changes (staged + unstaged vs HEAD).
+If an argument is provided, treat it as a git range (e.g. `HEAD~3`, `main..feature`).
+
+Determine affected files:
+
+```bash
+# default (no argument)
+git diff --name-only HEAD -- '*.hpp' '*.cpp'
+# with range argument
+git diff --name-only <range> -- '*.hpp' '*.cpp'
+```
+
+Only modify lines/regions that are part of the diff or directly adjacent.
+Do not rewrite untouched code.
+
+## Fixes to Apply
+
+**Naming (§1)**
+
+- Reflected fields in `GR_MAKE_REFLECTABLE`: ensure `snake_case`
+- Public non-reflected fields: ensure `lowerCamelCase`
+- Private fields: ensure `_lowerCamelCase`
+- Methods: ensure `lowerCamelCase`
+- Types/structs/classes: ensure `UpperCamelCase`
+
+**Documentation (§3)**
+
+- Strip method-level `@brief`, `@param`, `@return` Doxygen boilerplate
+- Preserve class/struct-level `/** ... */` block comments for public infrastructure types
+- Remove comments that restate the code
+- Remove commented-out code
+- Remove decorative banners, ASCII art, and section separators (`// ---`, `// ===`, `// ── name ──`)
+
+**Wrong Abstractions (§8.7)**
+
+- Replace `std::variant` with `gr::pmt::Value` for wire-format values
+- Flag (but do not auto-fix) raw SIMD intrinsics — suggest `vir::simd`
+- Flag `throw` in library/framework code — suggest `std::expected`
+
+## Output
+
+After editing, print:
+
+```
+## fix-style summary
+- **Files modified**: list
+- **Naming fixes**: count and brief description
+- **Documentation stripped**: count
+- **Abstraction flags**: items that need manual attention
+```
+
+Run `clang-format` on all modified files after editing.
+
+Fix: $ARGUMENTS

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -1,0 +1,99 @@
+# Refactor
+
+Baseline conventions are in CLAUDE.md — follow them, do not restate them.
+
+Apply structural improvements and style fixes to changed files. Edit files directly, then print a summary.
+
+This command includes `/fix-style` — cosmetic fixes are applied automatically.
+
+These changes may alter semantics — review the diff after running.
+
+## Scope
+
+Default: uncommitted changes (staged + unstaged vs HEAD).
+If an argument is provided, treat it as a git range (e.g. `HEAD~3`, `main..feature`).
+
+Determine affected files:
+
+```bash
+# default (no argument)
+git diff --name-only HEAD -- '*.hpp' '*.cpp'
+# with range argument
+git diff --name-only <range> -- '*.hpp' '*.cpp'
+```
+
+Only modify structs/classes/functions that are part of the diff or directly affected by it.
+Do not rewrite untouched code.
+
+## Fixes to Apply
+
+### Style fixes (from /fix-style)
+
+**Naming (§1)**
+
+- Reflected fields in `GR_MAKE_REFLECTABLE`: ensure `snake_case`
+- Public non-reflected fields: ensure `lowerCamelCase`
+- Private fields: ensure `_lowerCamelCase`
+- Methods: ensure `lowerCamelCase`
+- Types/structs/classes: ensure `UpperCamelCase`
+
+**Documentation (§3)**
+
+- Strip method-level `@brief`, `@param`, `@return` Doxygen boilerplate
+- Preserve class/struct-level `/** ... */` block comments for public infrastructure types
+- Remove comments that restate the code
+- Remove commented-out code
+- Remove decorative banners, ASCII art, and section separators (`// ---`, `// ===`, `// ── name ──`)
+
+### Structural fixes
+
+**Member Ordering (§2)**
+Reorder struct/class members to match canonical order:
+
+1. type aliases & nested types
+2. ports
+3. settings & public fields
+4. `GR_MAKE_REFLECTABLE`
+5. private state (prefixed with `_`)
+6. constructor
+7. lifecycle methods (`start`, `stop`, `reset`)
+8. processing (`processOne` / `processBulk`)
+9. settings change handler
+10. helper methods (public then private)
+
+Preserve all designated initialiser compatibility — if reordering would break
+aggregate initialisation at a call site within the diff, flag it instead of fixing.
+
+**Simplification (§4)**
+
+- Replace raw loops with `std::ranges` / `std::algorithms` where intent is clearer
+- Collapse nested `if`/`else` with early returns or guard clauses
+- Extract complex inline expressions into named lambdas
+- Replace `std::function` with templates where type erasure is unnecessary
+- Apply `constexpr if` to eliminate dead branches
+- Replace recursive templates with fold expressions
+- Use structured bindings where applicable
+
+Do NOT simplify if:
+
+- The change obscures algorithmic intent
+- The replacement is longer or harder to debug
+- The original is already clear and idiomatic
+
+## Output
+
+After editing, print:
+
+```
+## refactor summary
+- **Files modified**: list
+- **Naming fixes**: count and brief description
+- **Documentation stripped**: count
+- **Member reordering**: which structs/classes were reordered
+- **Simplifications**: count and brief description per file
+- **Skipped**: items flagged but not auto-fixed (with reason)
+```
+
+Run `clang-format` on all modified files after editing.
+
+Refactor: $ARGUMENTS

--- a/.claude/commands/review-api.md
+++ b/.claude/commands/review-api.md
@@ -1,0 +1,29 @@
+# API Design Review
+
+Baseline conventions are in CLAUDE.md — follow them, do not restate them.
+
+## Focus
+
+- CRTP usage: `Block<Derived>` applied correctly, no slicing
+- Concept constraints: template parameters properly constrained with `requires`
+- Type safety: could stronger types prevent misuse? (e.g. `Annotated<>` with `Limits<>`)
+- Const-correctness: const methods truly non-mutating
+- `std::expected` vs exceptions: appropriate for this code path?
+- API surface: can callers misuse this? (wrong order, invalid states, silent defaults)
+- Consistency with existing GR4 APIs (port naming, settings patterns, lifecycle methods)
+- `GR_MAKE_REFLECTABLE` completeness: all reflected members listed
+- `snake_case` for reflected fields, `lowerCamelCase` for methods
+- Struct vs class: is `class` justified by an actual invariant?
+- Rule of zero: unnecessary constructors/destructors?
+
+## Output Format
+
+For each finding:
+
+```
+**[CRITICAL|WARNING|NOTE]** `file:line` — description
+> quoted code
+Concern: what can go wrong or what is inconsistent
+```
+
+Review: $ARGUMENTS

--- a/.claude/commands/review-correctness.md
+++ b/.claude/commands/review-correctness.md
@@ -1,0 +1,30 @@
+# Correctness Review
+
+Baseline conventions are in CLAUDE.md — follow them, do not restate them.
+
+## Focus
+
+- Off-by-one errors in loops and bounds checks
+- Iterator/pointer invalidation after container mutations
+- Integer overflow in size/index calculations
+- Undefined behaviour: signed overflow, null deref, uninitialized reads, aliasing violations
+- Floating-point edge cases: NaN propagation, Inf, denormals, precision loss
+- Race conditions in lock-free code (acquire/release ordering)
+- `std::span` / `std::string_view` constructed from non-contiguous or temporary storage
+- Implicit narrowing conversions that lose precision or sign
+- Incorrect `processOne` / `processBulk` return semantics
+- Tag propagation logic errors
+
+## Output Format
+
+For each finding:
+
+```
+**[CRITICAL|WARNING|NOTE]** `file:line` — description
+> quoted code
+Failure scenario: ...
+```
+
+Be specific. Only report genuine issues, not style preferences.
+
+Review: $ARGUMENTS

--- a/.claude/commands/review-perf.md
+++ b/.claude/commands/review-perf.md
@@ -1,0 +1,31 @@
+# Performance Review
+
+Baseline conventions are in CLAUDE.md — follow them, do not restate them.
+
+## Focus
+
+- Unnecessary heap allocations in hot paths (`processOne`, `processBulk`, inner loops)
+- Missed `vir::simd` / `std::simd` vectorisation opportunities
+- Cache-unfriendly access patterns (strided access, pointer chasing, AoS vs SoA)
+- Redundant computations that could be hoisted or cached
+- Copy where move suffices (`std::vector`, `std::string`, large structs)
+- PMR allocator opportunities for arena allocation in hot paths
+- Stack allocation viable for small fixed-size buffers
+- Branch-heavy tight loops (consider `[[likely]]` / `[[unlikely]]` or branchless alternatives)
+- Memory bandwidth bottlenecks
+
+Do NOT flag code that is clearly not on the hot path.
+Do NOT suggest micro-optimisations that harm readability unless profiler-justified.
+
+## Output Format
+
+For each finding:
+
+```
+**[CRITICAL|WARNING|NOTE]** `file:line` — description
+> quoted code
+Impact: (allocations per call / cache misses / missed vectorisation / etc.)
+Fix: concrete change
+```
+
+Review: $ARGUMENTS

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,31 @@
+# Pull Request Review
+
+Baseline conventions are in CLAUDE.md — follow them, do not restate them.
+
+Perform a concise review covering correctness, performance, API design, safety,
+simplification opportunities, and test coverage.
+
+## Output Format
+
+```
+## Summary
+One paragraph: what this PR does and its overall state.
+
+## Critical Issues
+[CRITICAL] findings that must be addressed. Omit section if none.
+
+## Warnings
+[WARNING] findings worth addressing. Omit section if none.
+
+## Notes
+[NOTE] minor improvements. Omit section if none.
+
+## Test Gaps
+Missing coverage or test quality concerns. Omit section if none.
+```
+
+Quote exact lines (`file:line` + code) for every finding.
+Keep total response under 500 words unless critical issues require elaboration.
+Do not produce a merge verdict — the human decides.
+
+Review: $ARGUMENTS

--- a/.claude/commands/review-safety.md
+++ b/.claude/commands/review-safety.md
@@ -1,0 +1,43 @@
+# Safety Review
+
+Baseline conventions are in CLAUDE.md — follow them, do not restate them.
+
+## Focus
+
+**Memory Safety**
+
+- Use-after-free (especially `std::span` / `std::string_view` from temporaries)
+- Dangling references from expired lifetimes
+- Buffer overflows / out-of-bounds access
+- Uninitialized memory reads
+- Double-free scenarios
+
+**Thread Safety**
+
+- Data races on shared mutable state
+- Memory ordering issues (relaxed vs acquire/release on atomics)
+- Lock ordering violations (potential deadlocks)
+- False sharing on adjacent cache lines
+
+**Real-Time Constraints**
+
+- Blocking operations in `processOne` / `processBulk` (I/O, locks, unbounded allocation)
+- Non-deterministic execution time in processing callbacks
+- Priority inversion risks
+
+**Exception Safety**
+
+- Resource leaks on throw paths (relevant for user-facing code that may throw)
+- Our library code must be exception-free — flag any `throw` in framework code
+
+## Output Format
+
+For each finding:
+
+```
+**[CRITICAL|WARNING|NOTE]** `file:line` — description
+> quoted code
+Risk: what can fail and under which conditions
+```
+
+Review: $ARGUMENTS

--- a/.claude/commands/review-simplify.md
+++ b/.claude/commands/review-simplify.md
@@ -1,0 +1,32 @@
+# Simplification Review
+
+Baseline conventions are in CLAUDE.md — follow them, do not restate them.
+
+## Focus
+
+- Raw loops replaceable with `std::ranges` / `std::algorithms`
+- Nested `if`/`else` collapsible with early returns or guard clauses
+- Verbose patterns replaceable with structured bindings
+- Manual tuple access replaceable with `auto [a, b] = ...`
+- `std::function` replaceable with a template (no type erasure needed)
+- Recursive templates replaceable with fold expressions
+- Explicit constructors replaceable with aggregate / designated initialisation
+- `constexpr if` eliminating dead branches
+- Named lambdas extractable from complex inline expressions
+- Over-engineered abstractions: wrappers, factories, or hierarchies with a single implementation
+- Unnecessary template parameters that could be concrete types
+
+Do NOT suggest changes that reduce debuggability, obscure algorithmic intent,
+or degrade compile-time error quality.
+
+## Output Format
+
+For each finding:
+
+```
+**[CRITICAL|WARNING|NOTE]** `file:line` — description
+> original code
+Simplification: concrete replacement (or brief description if large)
+```
+
+Review: $ARGUMENTS

--- a/.claude/commands/review-tests.md
+++ b/.claude/commands/review-tests.md
@@ -1,0 +1,33 @@
+# Test Coverage Review
+
+Baseline conventions are in CLAUDE.md — follow them, do not restate them.
+
+## Focus
+
+Evaluate existing tests for:
+
+- Edge cases: empty input, single element, maximum buffer size, type limits
+- Numerical stability: NaN, Inf, denormals, precision loss near boundaries
+- All `processOne` / `processBulk` code paths exercised
+- Tag propagation tested (if block reads/writes tags)
+- `settingsChanged` tested (if block implements it)
+- State transitions: start → stop → start, reset cycles
+- Aliasing scenarios: input buffer == output buffer (where applicable)
+- Template instantiation coverage: all supported value types tested
+
+Identify missing `qa_` files for public types.
+
+Tests must use `boost::ut`. Test names must be descriptive sentences.
+No `sleep` or timing-based assertions.
+
+## Output Format
+
+For each gap:
+
+```
+**[CRITICAL|WARNING|NOTE]** `file` or `type` — what is missing
+Why it matters: what could break undetected
+Test sketch: 2-4 lines of boost::ut pseudocode
+```
+
+Review: $ARGUMENTS

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ bin/
 build/
 out/
 cmake-build-*/
+build*/
 
 # Annoying OS Generated Files
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,446 @@
+# CLAUDE.md — GNU Radio 4.0 Code & Documentation Style Guide (V1)
+
+This is the authoritative style guide for all AI-assisted (Claude Code) and human contributions
+to GNU Radio 4.0 and related/downstream projects.
+It is **self-contained** — no other guideline files need to be read.
+
+See `.claude/commands/` for review persona commands.
+
+Think of these commands as a design and code review assistant — the same way a spell-checker catches typos
+you'd otherwise miss on the fifth read-through, the `const` linter flags, or duplicate/dead/overly-complex code
+you forgot at 2 o'clock. They don't replace your judgement; they free you up to focus on the actual problem domain
+instead of mentally tracking whether every field follows `snake_case` or checking if you accidentally left Doxygen
+boilerplate in a new block. To note: any AI-agent-driven design/implementation requires strong constraints,
+domain-knowledge, a good pre-design phase, strong unit-tests, and -- this is my recommendation -- a WIP/ToDo list
+so that the AI doesn't go haywire or start hallucinating.
+
+The review commands give you a second pair of eyes before you ping a colleague. The fix commands handle the mechanical
+cleanup so you can spend your time on architecture decisions, not reformatting.
+
+**All findings still must go through human review** — these tools just raise the baseline.
+
+---
+
+## 0 · Core Philosophy
+
+**Nomen est omen** — the name _is_ the documentation.
+Every identifier (type, field, method, parameter, variable) must be self-explanatory.
+If you need a comment to explain _what_ something does, rename it first.
+
+**Simplicity is a feature.** Prefer the simplest correct solution.
+Do not add abstraction, indirection, or generality that is not required _today_.
+Code that is easy to delete is better than code that is easy to extend.
+
+**`struct` over `class`.** Default to `struct` with public members.
+Use `class` only when a genuine invariant must be enforced (RAII resource ownership,
+thread-safety contract, non-trivial construction/destruction coupling).
+
+**Terse, production-ready code.** Method names and parameters should be self-documenting.
+Lean and clean — complexity must justify itself.
+
+---
+
+## 1 · Naming Conventions
+
+The keywords **MUST**, **SHOULD**, **MAY** follow RFC 2119.
+
+### 1.1 Types
+
+| Kind                        | Convention                                    | Examples                         |
+| --------------------------- | --------------------------------------------- | -------------------------------- |
+| `struct` / `class` / `enum` | UpperCamelCase (proper noun)                  | `Block`, `Graph`, `Selector`     |
+| `enum` values               | UpperCase if proper noun, lowerCase if common | `Planet::Earth`, `Color::red`    |
+| C++ concepts                | UpperCamelCase                                | `PortLike`, `HasProcessOne`      |
+| Type aliases (`using`)      | UpperCamelCase                                | `ValueType`, `InputRange`        |
+| Namespaces                  | all lowercase                                 | `gr`, `gr::basic`, `gr::testing` |
+
+### 1.2 Functions & Methods
+
+| Kind                               | Convention            | Examples                                        |
+| ---------------------------------- | --------------------- | ----------------------------------------------- |
+| Methods / free functions / lambdas | lowerCamelCase (verb) | `start()`, `processOne()`, `computeMagnitude()` |
+
+### 1.3 Fields & Variables
+
+| Kind                                              | Convention                      | Examples                     |
+| ------------------------------------------------- | ------------------------------- | ---------------------------- |
+| Public reflected settings (`GR_MAKE_REFLECTABLE`) | `snake_case` MUST               | `sample_rate`, `is_valid`    |
+| Public non-reflected fields                       | lowerCamelCase                  | `inputBuffer`, `fftSize`     |
+| Private / non-public fields                       | `_lowerCamelCase` (leading `_`) | `_initialised`, `_cachedFft` |
+| Function-local variables & parameters             | lowerCamelCase                  | `nSamples`, `inputSpan`      |
+| Compile-time constants                            | `kUpperCamelCase`               | `kMaxBufferSize`             |
+| Preprocessor defines / macros                     | `UPPER_SNAKE_CASE`              | `GR_ENABLE_LOGGING`          |
+
+### 1.4 Template Parameters
+
+| Kind                | Convention                   | Examples                    |
+| ------------------- | ---------------------------- | --------------------------- |
+| Type parameters     | `T` or `TSpecificName`       | `T`, `TBlock`, `TAllocator` |
+| Non-type parameters | lowerCamelCase or UPPER_CASE | `nPorts`, `kSize`           |
+
+### 1.5 Files & Directories
+
+File names MUST reflect the primary type they define: `Block.hpp`, `Selector.hpp`.
+Test files: `qa_Block.cpp`, `qa_Selector.cpp`.
+
+### 1.6 `auto` Usage
+
+- If the type is precisely known, **prefer naming it explicitly**.
+- `auto` MAY be used when the type is generic/templated, deduced from a complex expression,
+  or excessively long and obvious from context.
+- At API boundaries (function return types, public fields), **always name the type**.
+
+---
+
+## 2 · Struct & Class Layout
+
+Always use `struct` unless a class invariant genuinely demands `class`.
+Members MUST appear in the following canonical order (blank lines separate groups):
+
+1. type aliases & nested types
+2. ports
+3. settings & public fields
+4. `GR_MAKE_REFLECTABLE`
+5. private state (prefixed with `_`)
+6. constructor
+7. lifecycle methods (`start`, `stop`, `reset`)
+8. processing (`processOne` / `processBulk`)
+9. settings change handler
+10. helper methods (public then private)
+
+```cpp
+struct MyBlock : gr::Block<MyBlock> {
+    using Description = Doc<"...">;
+
+    gr::PortIn<float>  in;
+    gr::PortOut<float> out;
+
+    Annotated<float, "gain"> gain = 1.0f;
+    float sample_rate = 1.0f;
+
+    GR_MAKE_REFLECTABLE(MyBlock, in, out, gain, sample_rate);
+
+    float _cachedValue = 0.0f;
+
+    explicit MyBlock(gr::property_map init = {}) : gr::Block<MyBlock>(std::move(init)) {}
+
+    void start() { ... }
+    void stop()  { ... }
+    void reset() { ... }
+
+    [[nodiscard]] constexpr auto processOne(float x) const noexcept { ... }
+
+    void settingsChanged(const gr::property_map&, const gr::property_map&) { ... }
+};
+```
+
+**Rules:**
+
+- **All fields at the top** — they _are_ the API. This includes private state fields (prefixed `_`).
+- `processOne` and `processBulk` are mutually exclusive — implement exactly one.
+- Prefer `processOne` for simple 1:1 sample transforms.
+  Use `processBulk` for resampling, variable-rate, or when you need span access.
+- Mark processing methods `[[nodiscard]]`, `constexpr`, and `noexcept` where possible.
+
+---
+
+## 3 · Documentation Policy
+
+### What to write
+
+- **`using Description = Doc<"...">`** — one brief sentence per type explaining its purpose and
+  key usage. This is the _only_ required documentation.
+- **Class/struct-level block comments** — for public core infrastructure types (`/** ... */`),
+  a detailed description explaining purpose, supported operations, and usage context is encouraged.
+  `@brief` may be used at this level. Example:
+  ```cpp
+  /**
+   * @brief Global signal legend displaying all registered sinks.
+   *
+   * This block implements Drawable<Toolbar> and renders a horizontal legend
+   * showing all sinks from SinkRegistry. It supports:
+   * - left-click: toggle sink draw enabled
+   * - right-click: callback for settings panel
+   * - drag: start drag operation for sink transfer
+   */
+  struct GlobalSignalLegend : gr::Block<...> { ... };
+  ```
+- **Short end-of-line comments** — allowed when a field name alone cannot convey units, valid
+  ranges, or non-obvious intent (e.g. `float threshold = 0.5f; // linear, not dB`).
+- **"Why" comments** — for non-obvious algorithmic choices, regulatory constraints, or
+  workarounds. Keep to one or two lines.
+
+### What NOT to write
+
+- **Method-level `@brief` / `@param` / `@return` / Doxygen boilerplate** — banned.
+  If the name and type signature do not explain it, rename them.
+- **Restating the code in English** — `// increment counter` above `++counter` is noise.
+- **Change-log comments** — use `git log`.
+- **Commented-out code** — delete it; it lives in version control.
+- **ASCII art, decorative banners, or separator comments** — including `// ---`, `// ===`,
+  `// --- section name ---`, etc. The code structure itself should be self-evident.
+
+### What NOT to comment on in reviews
+
+- Formatting — handled by `.clang-format`.
+- Linting — handled by `.clang-tidy`.
+- Standard C++23 usage patterns that are project-standard.
+- Requesting more documentation for self-explanatory code.
+
+### Language style
+
+This project follows the English conventions of the EU Interinstitutional Style
+Guide — the shared standard usage of Ireland and the United Kingdom. This variety
+is well-codified, accessible to native and non-native speakers alike, and widely
+adopted across European and international organisations to minimise ambiguity.
+
+Adopting a single documented standard avoids unproductive debates over spelling
+and formatting. When in doubt, follow these conventions rather than personal or
+regional habit.
+
+- Use sentence case for headings (capitalise only the first word and proper nouns).
+- Do not capitalise list items or comments that are not complete sentences.
+- Introduce abbreviations on first use: "the Fast Fourier Transform (FFT)".
+- Prefer active voice and short sentences.
+
+**Example — avoid unnecessary capitalisation in comments:**
+
+```cpp
+// ✗ avoid
+enum class AxisScale {
+    Linear = 0,    // Standard linear scale [min, max]
+    Log10,         // Logarithmic base 10
+};
+
+// ✓ prefer
+enum class AxisScale {
+    Linear = 0,    // standard linear scale [min, max]
+    Log10,         // logarithmic base 10
+};
+```
+
+---
+
+## 4 · Complexity Reduction
+
+Prefer the simplest correct solution. Specifically:
+
+- **Prefer `std::ranges` / `std::algorithms` over raw loops.**
+  A named algorithm communicates intent; a `for` loop does not.
+- **Prefer named lambdas over complex inline expressions.**
+  If an expression needs a comment, give it a name instead.
+- **Prefer composition over inheritance.**
+  Use template parameters and concepts to compose behaviour.
+- **Prefer flat control flow.**
+  Early returns, guard clauses, and `std::expected` / `std::optional` over deeply nested
+  `if`/`else` trees.
+- **Prefer value semantics.**
+  Pass by value or `std::span`; avoid raw pointers and manual memory management.
+- **Extract, don't comment.**
+  If a block of code is complex enough to need a section comment, it is complex enough to be
+  a named helper function or lambda.
+
+---
+
+## 5 · Modern C++ Expectations
+
+**Target:** C++23.
+**Compilers:** GCC 15+ (libstdc++), Clang 20+ (libc++), Emscripten, later AdaptiveCpp (SYCL).
+Only use language and library features that are **available in both libstdc++ and libc++**.
+
+**Build system:** CMake exclusively.
+
+**Warnings:** Compile with `-Werror`. Already enforced for GNU Radio 4.0; downstream projects
+should strive for the same.
+
+### Prefer
+
+- **Concepts** for constraining templates — over SFINAE or `static_assert`.
+- **`constexpr` / `consteval`** — as broadly as possible; runtime only when compile-time is impossible.
+- **`std::expected<T, E>`** — for recoverable errors. Our code is **exception-free**
+  (user-defined code outside our repositories may throw).
+- **`std::optional<T>`** — for "may or may not have a value" semantics.
+- **`assert` / `std::unreachable()`** — for programmer errors and broken invariants.
+- **`std::span<T>`** — for non-owning views into contiguous data.
+- **`std::ranges` and views** — for composable data pipelines.
+- **Structured bindings** — `auto [key, value] = ...`.
+- **`std::format` / `fmt::format`** — over `std::stringstream` or manual concatenation.
+- **`std::variant` / `std::visit`** — for closed type sets; prefer over runtime polymorphism.
+- **`if constexpr`** — for compile-time branching.
+- **Designated initialisers** — `Type{.field = value}`.
+- **`[[nodiscard]]`** — on functions whose return value must not be silently discarded.
+- **`[[likely]]` / `[[unlikely]]`** — where semantically meaningful in branch-heavy code.
+- **SIMD:** prefer `vir::simd` / `std::simd` over compiler intrinsics.
+- **PMR allocators** for hot paths; stack allocation for small fixed-size buffers.
+
+### Avoid
+
+- **`new` / `delete`** — use RAII wrappers (`std::unique_ptr`, `std::vector`, PMR containers).
+- **C-style casts** — use `static_cast`, `std::bit_cast`.
+- **Macros** — except `GR_MAKE_REFLECTABLE` and other framework-required macros.
+- **`std::bind`** — use lambdas.
+- **Throwing exceptions in library/framework code** — use `std::expected` or `std::optional`.
+- **`std::endl`** — use `'\n'`.
+- **`std::mdspan`** — not operationally available yet across both standard libraries.
+  For multi-dimensional data, use `Tensor[View]<T>`.
+  For 1D/vector-only types, prefer `std::vector`, `std::array`, `std::span` (KISS).
+
+---
+
+## 6 · GR4-Specific Conventions
+
+### Blocks
+
+- Inherit via CRTP: `struct Foo : gr::Block<Foo> { ... }`.
+- Settings are `Annotated<T, "name", ...>` fields.
+  Reflected fields MUST use `snake_case` for SigMF compatibility.
+- `GR_MAKE_REFLECTABLE(...)` lists the type, then all reflected members (ports + settings).
+- Tags: in `processOne`, use `this->mergedInputTag()` / `this->publishTag(...)`;
+  in `processBulk`, use `inSpan.rawTags` / `outSpan.publishTag(...)`.
+
+### Ports
+
+- `gr::PortIn<T>`, `gr::PortOut<T>` for static ports.
+- `std::vector<gr::PortIn<T>>` / `std::vector<gr::PortOut<T>>` for dynamic ports —
+  resize in `settingsChanged`.
+- Port names must be short, descriptive nouns: `in`, `out`, `reference`, `error_signal`.
+
+### Graphs & Scheduling
+
+- Build graphs with `gr::Graph`; connect with `graph.connect<"out">(src).to<"in">(sink)`.
+- Use `gr::scheduler::Simple` unless a custom scheduler is justified.
+
+### Type-Erased Values
+
+- Use `gr::pmt::Value` for type-erased values — prefer over `std::variant` for
+  wire-format compatibility.
+
+### Error Handling
+
+- `processOne`: return the output value; signal errors via tags or `requestStop()`.
+- `processBulk`: return `gr::work::Status::OK`, `ERROR`, or `INSUFFICIENT_INPUT_ITEMS` /
+  `INSUFFICIENT_OUTPUT_ITEMS`.
+- Lifecycle methods (`start`, `stop`, `reset`): use `std::expected` for recoverable failures.
+  Do not throw.
+
+---
+
+## 7 · Testing Conventions
+
+- **File naming**: `qa_<TypeUnderTest>.cpp` (e.g. `qa_Selector.cpp`).
+- **Framework**: [Boost.UT](https://github.com/boost-ext/ut) (`boost::ut`).
+- **Structure**:
+
+  ```cpp
+  #include <boost/ut.hpp>
+  using namespace boost::ut;
+
+  const boost::ut::suite<"BlockName"> tests = [] {
+      "descriptive scenario name"_test = [] {
+          // arrange
+          // act
+          // assert with expect(...)
+      };
+  };
+  ```
+
+- **Coverage requirements**:
+  - Every public type / block MUST have a `qa_` file.
+  - Every `processOne` / `processBulk` path MUST be tested.
+  - Edge cases: empty input, single sample, maximum buffer, type boundaries.
+  - Tag propagation MUST be tested when the block reads or writes tags.
+  - Settings changes MUST be tested via `settingsChanged` if the block implements it.
+- **Test names** are sentences describing the scenario, not function names.
+- **No `sleep` / timing-based tests** — use deterministic scheduling or event signalling.
+
+---
+
+## 8 · AI-Generated Code: Anti-Patterns to Avoid
+
+These are the most common mistakes made by AI code assistants in this codebase.
+Treat violations as review blockers.
+
+### 8.1 Over-Engineering
+
+- **Do not** introduce class hierarchies, abstract base classes, or factory patterns
+  unless the existing codebase already uses that pattern for the specific concern.
+- **Do not** create wrapper types around standard library types without clear justification.
+- **Do not** add template parameters "for future flexibility" — only template what varies _now_.
+
+### 8.2 Premature Generalisation
+
+- **Do not** write a generic `Processor<T, Policy, Allocator, ...>` when a concrete
+  `struct FirFilter` suffices.
+- **Do not** extract a "common base" from two structs that happen to share two fields.
+
+### 8.3 Unnecessary Abstractions
+
+- **Do not** wrap `std::vector` in a custom `Container` class.
+- **Do not** create `enum class ErrorCode` when `std::expected` with a descriptive
+  error type (or `gr::work::Status`) already exists.
+- **Do not** introduce an `Interface` / `Impl` split for types that have exactly one
+  implementation and no testing seam requirement.
+
+### 8.4 Verbose Comments & Documentation
+
+- **Do not** generate method-level Doxygen `@param` / `@return` documentation.
+  Class-level `@brief` for public infrastructure types is acceptable (see §3).
+- **Do not** add comments that restate the code.
+- **Do not** add `// constructor`, `// destructor`, `// getters`, `// setters` section markers.
+- **Do not** generate README or markdown for internal helper files.
+
+### 8.5 Hallucinated APIs
+
+- **Verify every GR4 API call** against the actual headers in `core/include/gnuradio-4.0/`.
+  Do not assume APIs exist — check.
+- Common traps:
+  - `Block::output()` does not exist — use the port member directly.
+  - `notify_settings()` does not exist — settings propagation is automatic.
+  - `this->log(...)` — use `fmt::print` or the project's logging macro if it exists.
+
+### 8.6 Style Drift
+
+- **Do not** switch to `snake_case` for method names (they are `lowerCamelCase`).
+- **Do not** use `class` when the type has no invariant.
+- **Do not** reorder struct members away from the canonical order (§2).
+- **Do not** add `#pragma once` style changes to files that use `#ifndef` guards (or vice versa)
+  — follow what the file already uses.
+
+### 8.7 Wrong Abstractions
+
+- **Do not** use `std::mdspan` — it is not available across our target compilers.
+- **Do not** use raw SIMD intrinsics — use `vir::simd` / `std::simd`.
+- **Do not** use `std::variant` for wire-format values — use `gr::pmt::Value`.
+- **Do not** throw exceptions in library code — use `std::expected` / `std::optional`.
+
+---
+
+## 9 · Mechanical Formatting
+
+Handled entirely by **clang-format** (see `.clang-format` in the repository root).
+Do not manually adjust whitespace, brace placement, or indentation.
+Run `clang-format` before committing.
+
+This guide does **not** prescribe formatting rules — only semantic and structural ones.
+
+---
+
+## 10 · Quick Reference Checklist
+
+Before submitting any code change, verify:
+
+- [ ] Types use `struct` unless an invariant demands `class`.
+- [ ] Names are self-explanatory — no comment needed to understand _what_.
+- [ ] Struct members follow canonical order (§2).
+- [ ] Public reflected fields are `snake_case`; other fields are `lowerCamelCase`.
+- [ ] Methods are `lowerCamelCase`.
+- [ ] No method-level Doxygen boilerplate (`@param`, `@return`); class-level `@brief` is allowed.
+- [ ] No commented-out code.
+- [ ] No unnecessary abstraction layers.
+- [ ] `processOne` xor `processBulk` — not both.
+- [ ] `GR_MAKE_REFLECTABLE` lists all reflected members.
+- [ ] No exceptions thrown in library/framework code.
+- [ ] SIMD uses `vir::simd` / `std::simd`, not raw intrinsics.
+- [ ] A `qa_` test file exists with meaningful scenario coverage.
+- [ ] Compiles cleanly with `-Werror` on GCC and Clang.
+- [ ] `clang-format` has been run.

--- a/src/ui/Dashboard.hpp
+++ b/src/ui/Dashboard.hpp
@@ -33,12 +33,15 @@ namespace detail {
 #include "Scheduler.hpp"
 #include "settings.hpp"
 
+#include "charts/Charts.hpp"
+
 namespace gr {
 class Graph;
-}
+class BlockModel;
+} // namespace gr
 
 namespace opendigitizer {
-struct ImPlotSinkModel;
+struct SignalSink; // forward declaration
 }
 
 namespace DigitizerUi {
@@ -46,28 +49,18 @@ namespace DigitizerUi {
 struct DashboardDescription;
 struct SignalData;
 
-enum class AxisScale : std::uint8_t {
-    Linear = 0U,   /// default linear scale [t0, .., tn]
-    LinearReverse, /// reverse linear scale [t0-tn, ..., 0]
-    Time,          /// date/timescale
-    Log10,         /// base 10 logarithmic scale
-    SymLog,        /// symmetric log scale
-};
+// Use axis types from charts namespace (avoid duplication)
+using AxisScale   = opendigitizer::charts::AxisScale;
+using LabelFormat = opendigitizer::charts::LabelFormat;
 
-enum class LabelFormat : std::uint8_t { Auto = 0U, Metric, MetricInline, Scientific, None, Default };
-
-// Defines where the dashboard is stored and fetched from
 struct DashboardStorageInfo {
-private:
     struct PrivateTag {};
-
-public:
-    DashboardStorageInfo(std::string _path, PrivateTag) : path(std::move(_path)) {}
-
-    ~DashboardStorageInfo() noexcept;
 
     std::string path;
     bool        isEnabled = true;
+
+    DashboardStorageInfo(std::string _path, PrivateTag) : path(std::move(_path)) {}
+    ~DashboardStorageInfo() noexcept;
 
     static std::shared_ptr<DashboardStorageInfo>             get(std::string_view path);
     static std::vector<std::weak_ptr<DashboardStorageInfo>>& knownDashboardStorage();
@@ -77,169 +70,174 @@ public:
 };
 
 struct DashboardDescription {
-private:
     struct PrivateTag {};
-
     using OptionalTimePoint = std::optional<std::chrono::time_point<std::chrono::system_clock>>;
 
-    static std::vector<std::shared_ptr<DashboardDescription>> s_knownDashboards;
-
-public:
-    DashboardDescription(PrivateTag, std::string _name, std::shared_ptr<DashboardStorageInfo> _storageInfo, std::string _filename, bool _isFavorite, OptionalTimePoint _lastUsed) : name(std::move(_name)), storageInfo(std::move(_storageInfo)), filename(std::move(_filename)), isFavorite(_isFavorite), lastUsed(std::move(_lastUsed)) {}
-
-    static constexpr const char* fileExtension = ".ddd"; // ddd for "Digitizer Dashboard Description"
+    static constexpr const char* fileExtension = ".ddd";
 
     std::string                           name;
     std::shared_ptr<DashboardStorageInfo> storageInfo;
     std::string                           filename;
+    mutable bool                          isFavorite;
+    mutable OptionalTimePoint             lastUsed;
 
-    mutable bool              isFavorite;
-    mutable OptionalTimePoint lastUsed;
+    static std::vector<std::shared_ptr<DashboardDescription>> s_knownDashboards;
+
+    DashboardDescription(PrivateTag, std::string _name, std::shared_ptr<DashboardStorageInfo> _storageInfo, std::string _filename, bool _isFavorite, OptionalTimePoint _lastUsed) : name(std::move(_name)), storageInfo(std::move(_storageInfo)), filename(std::move(_filename)), isFavorite(_isFavorite), lastUsed(std::move(_lastUsed)) {}
 
     void save();
 
-    static void loadAndThen(std::shared_ptr<opencmw::client::RestClient> client, const std::shared_ptr<DashboardStorageInfo>& storageInfo, const std::string& filename, const std::function<void(std::shared_ptr<const DashboardDescription>&&)>& cb);
-
+    static void                                        loadAndThen(std::shared_ptr<opencmw::client::RestClient> client, const std::shared_ptr<DashboardStorageInfo>& storageInfo, const std::string& filename, const std::function<void(std::shared_ptr<const DashboardDescription>&&)>& cb);
     static std::shared_ptr<const DashboardDescription> createEmpty(const std::string& name);
 };
 
-class Dashboard {
-public:
-    struct Plot {
-        enum class AxisKind { X = 0, Y };
+struct Dashboard {
+    using AxisConfig = opendigitizer::charts::AxisConfig;
+    struct PrivateTag {};
 
-        struct AxisData {
-            AxisKind    axis     = AxisKind::X;
-            float       min      = std::numeric_limits<float>::quiet_NaN();
-            float       max      = std::numeric_limits<float>::quiet_NaN();
-            AxisScale   scale    = AxisScale::Linear;
-            LabelFormat format   = LabelFormat::Auto;
-            float       width    = std::numeric_limits<float>::max();
-            bool        plotTags = true;
-        };
-
-        std::string                                  name;
-        std::vector<std::string>                     sourceNames;
-        std::vector<opendigitizer::ImPlotSinkModel*> plotSinkBlocks; // Not owned by us
-        std::vector<AxisData>                        axes;
-
+    struct UIWindow {
         std::shared_ptr<DockSpace::Window> window;
+        std::shared_ptr<gr::BlockModel>    block;
 
-        Plot() {
-            static int n = 1;
-            name         = std::format("Plot {}", n++);
-            window       = std::make_shared<DockSpace::Window>(name);
-        }
+        UIWindow() = default;
+        explicit UIWindow(std::shared_ptr<gr::BlockModel> blk, std::string_view name = "") : window(std::make_shared<DockSpace::Window>(name.empty() ? std::string(blk->uniqueName()) : std::string(name))), block(std::move(blk)) {}
+
+        [[nodiscard]] bool           hasBlock() const noexcept { return block != nullptr; }
+        [[nodiscard]] bool           isChart() const noexcept { return uiCategory() == gr::UICategory::ChartPane; }
+        [[nodiscard]] gr::UICategory uiCategory() const noexcept { return block ? block->uiCategory() : gr::UICategory::None; }
     };
 
     struct Service {
-        Service(std::shared_ptr<opencmw::client::RestClient> client, std::string n, std::string u) : restClient{std::move(client)}, name(std::move(n)), uri(std::move(u)) {}
-
         std::shared_ptr<opencmw::client::RestClient> restClient;
         std::string                                  name;
         std::string                                  uri;
         std::string                                  layout;
         std::string                                  grc;
 
+        Service(std::shared_ptr<opencmw::client::RestClient> client, std::string n, std::string u) : restClient{std::move(client)}, name(std::move(n)), uri(std::move(u)) {}
+
         void reload();
-
         void execute();
-
         void emplaceBlock(std::string type, std::string params);
     };
-
-private:
-    std::shared_ptr<opencmw::client::RestClient> m_restClient;
-    std::shared_ptr<const DashboardDescription>  m_desc = nullptr;
-    std::vector<Plot>                            m_plots;
-    DockingLayoutType                            m_layout;
-    std::unordered_map<std::string, std::string> m_flowgraphUriByRemoteSource;
-    plf::colony<Service>                         m_services;
-    std::atomic<bool>                            m_isInitialised = false;
-
-    Scheduler m_scheduler;
-
-    UiGraphModel m_graphModel;
 
     std::shared_ptr<gr::PluginLoader> pluginLoader = [] {
         std::vector<std::filesystem::path> pluginPaths;
 #ifndef __EMSCRIPTEN__
-        // TODO set correct paths
         pluginPaths.push_back(std::filesystem::current_path() / "plugins");
 #endif
         return std::make_shared<gr::PluginLoader>(gr::globalBlockRegistry(), gr::globalSchedulerRegistry(), pluginPaths);
     }();
-
-private:
-    class PrivateTag {};
-
-public:
-    explicit Dashboard(PrivateTag, std::shared_ptr<opencmw::client::RestClient> restClient, const std::shared_ptr<const DashboardDescription>& desc);
-
-    static std::unique_ptr<Dashboard> create(std::shared_ptr<opencmw::client::RestClient> restClient, const std::shared_ptr<const DashboardDescription>& desc);
-
-    ~Dashboard();
-
-    void load();
-
-    void loadAndThen(std::string_view grcData, std::function<void(gr::Graph&&)> assignScheduler);
-
-    void save();
-
-    DigitizerUi::Dashboard::Plot& newPlot(int x, int y, int w, int h);
-
-    void deletePlot(Plot* plot);
-
-    void removeSinkFromPlots(std::string_view sinkName);
-
-    inline auto& plots() { return m_plots; }
-
-    DockingLayoutType layout() { return m_layout; }
-
-    void setNewDescription(const std::shared_ptr<DashboardDescription>& desc);
-
-    inline std::shared_ptr<const DashboardDescription> description() const { return m_desc; }
-
-    void registerRemoteService(std::string_view blockName, std::optional<opencmw::URI<>> uri);
-
-    void unregisterRemoteService(std::string_view blockName);
-
-    void removeUnusedRemoteServices();
-
-    void saveRemoteServiceFlowgraph(Service* s);
-
-    inline auto& remoteServices() { return m_services; }
-
-    void addRemoteSignal(const SignalData& signalData);
-
-    void loadPlotSources();
-
-    void loadPlotSourcesFor(Plot& plot);
-
-    UiGraphModel& graphModel();
-
-    std::atomic<bool> isInUse = false;
-
+    std::atomic<bool>               isInUse = false;
     std::function<void(Dashboard*)> requestClose;
 
+    std::shared_ptr<opencmw::client::RestClient> restClient;
+    std::shared_ptr<const DashboardDescription>  description = nullptr;
+    std::vector<UIWindow>                        uiWindows;
+    DockingLayoutType                            layout;
+    std::unordered_map<std::string, std::string> flowgraphUriByRemoteSource;
+    plf::colony<Service>                         services;
+    std::atomic<bool>                            isInitialised = false;
+    Scheduler                                    scheduler;
+    gr::Graph                                    uiGraph{*pluginLoader};
+    UiGraphModel                                 graphModel;
+
+    explicit Dashboard(PrivateTag, std::shared_ptr<opencmw::client::RestClient> client, const std::shared_ptr<const DashboardDescription>& desc);
+    ~Dashboard();
+
+    static std::unique_ptr<Dashboard> create(std::shared_ptr<opencmw::client::RestClient> client, const std::shared_ptr<const DashboardDescription>& desc);
+
+    void load();
+    void loadAndThen(std::string_view grcData, std::function<void(gr::Graph&&)> assignScheduler);
+    void save();
     void doLoad(const gr::property_map& dashboard);
+
+    UIWindow& newUIBlock(int x, int y, int w, int h, std::string_view chartType = "XYChart");
+    void      deleteChart(UIWindow* uiWindow);
+    UIWindow* copyChart(std::string_view sourceChartId);
+    bool      transmuteUIWindow(UIWindow& uiWindow, std::string_view newChartType);
+
+    gr::BlockModel* emplaceChartBlock(std::string_view chartTypeName, const std::string& chartName, const gr::property_map& chartParameters = {});
+    void            removeSinkFromPlots(std::string_view sinkName);
+    void            addRemoteSignal(const SignalData& signalData);
+    void            loadUIWindowSources();
+
+    void setNewDescription(const std::shared_ptr<DashboardDescription>& desc);
+    void registerRemoteService(std::string_view blockName, std::optional<opencmw::URI<>> uri);
+    void unregisterRemoteService(std::string_view blockName);
+    void removeUnusedRemoteServices();
+    void saveRemoteServiceFlowgraph(Service* s);
 
     template<typename TScheduler, typename... Args>
     void emplaceScheduler(Args&&... args) {
-        m_scheduler.emplaceScheduler<TScheduler, Args...>(std::forward<Args>(args)...);
+        scheduler.emplaceScheduler<TScheduler, Args...>(std::forward<Args>(args)...);
     }
 
     template<typename... Args>
     void emplaceGraph(Args&&... args) {
-        m_scheduler.emplaceGraph(std::forward<Args>(args)...);
+        scheduler.emplaceGraph(std::forward<Args>(args)...);
     }
 
-    auto& scheduler() { return m_scheduler; }
+    void handleMessages() { scheduler.handleMessages(graphModel); }
 
-    void handleMessages() { m_scheduler.handleMessages(m_graphModel); }
+    [[nodiscard]] UIWindow* findUIWindow(const std::shared_ptr<gr::BlockModel>& block) noexcept {
+        if (!block) {
+            return nullptr;
+        }
+        for (auto& w : uiWindows) {
+            if (w.block == block) {
+                return &w;
+            }
+        }
+        return nullptr;
+    }
 
-    [[nodiscard]] bool isInitialised() const noexcept { return m_isInitialised.load(std::memory_order_acquire); }
+    [[nodiscard]] UIWindow* findUIWindowByName(std::string_view uniqueName) noexcept {
+        for (auto& w : uiWindows) {
+            if (w.block && w.block->uniqueName() == uniqueName) {
+                return &w;
+            }
+        }
+        return nullptr;
+    }
+
+    UIWindow& getOrCreateUIWindow(const std::shared_ptr<gr::BlockModel>& block) {
+        if (auto* existing = findUIWindow(block)) {
+            return *existing;
+        }
+        uiWindows.emplace_back(block);
+        return uiWindows.back();
+    }
+
+    void removeUIWindow(const std::shared_ptr<gr::BlockModel>& block) {
+        std::erase_if(uiWindows, [&block](const UIWindow& w) { return w.block == block; });
+    }
 };
 } // namespace DigitizerUi
+
+namespace grc_compat {
+
+inline std::vector<std::string> getBlockSinkNames(const gr::BlockModel* block) {
+    if (!block) {
+        return {};
+    }
+    const auto& settings = block->settings().get();
+    if (auto it = settings.find("data_sinks"); it != settings.end()) {
+        if (auto* vec = std::get_if<std::vector<std::string>>(&it->second)) {
+            return *vec;
+        }
+    }
+    return {};
+}
+
+inline void setBlockSinkNames(gr::BlockModel* block, const std::vector<std::string>& names) {
+    if (block) {
+        std::ignore = block->settings().set({{"data_sinks", names}});
+        std::ignore = block->settings().activateContext();
+        std::ignore = block->settings().applyStagedParameters();
+    }
+}
+
+} // namespace grc_compat
 
 #endif

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -5,17 +5,19 @@
 #include <gnuradio-4.0/Tag.hpp>
 #include <implot.h>
 #include <memory>
+#include <print>
 
 #include "common/ImguiWrap.hpp"
 #include "common/LookAndFeel.hpp"
-#include "common/TouchHandler.hpp"
-#include "conversion.hpp"
 
-#include "components//ImGuiNotify.hpp"
 #include "components/Splitter.hpp"
 
+#include "blocks/GlobalSignalLegend.hpp"
 #include "blocks/ImPlotSink.hpp"
 #include "blocks/RemoteSource.hpp"
+#include "charts/Chart.hpp"
+#include "charts/SignalSink.hpp"
+#include "charts/SinkRegistry.hpp"
 
 namespace DigitizerUi {
 
@@ -23,349 +25,6 @@ namespace {
 constexpr inline auto kMaxPlots   = 16u;
 constexpr inline auto kGridWidth  = 16u;
 constexpr inline auto kGridHeight = 16u;
-
-// Holds quantity + unit
-struct AxisCategory {
-    std::string quantity;
-    std::string unit;
-    uint32_t    color    = 0xAAAAAA;
-    AxisScale   scale    = AxisScale::Linear;
-    bool        plotTags = true;
-};
-
-std::optional<std::size_t> findOrCreateCategory(std::array<std::optional<AxisCategory>, 3UZ>& cats, std::string_view qStr, std::string_view uStr, uint32_t colorDef) {
-    for (std::size_t i = 0UZ; i < cats.size(); ++i) {
-        // see if it already exists
-        if (cats[i].has_value()) {
-            const auto& cat = cats[i].value();
-            if (cat.quantity == qStr && cat.unit == uStr) {
-                return i; // found match
-            }
-        }
-    }
-
-    for (std::size_t i = 0UZ; i < cats.size(); ++i) {
-        // else try to open a new slot
-        if (!cats[i].has_value()) {
-            cats[i] = AxisCategory{.quantity = std::string(qStr), .unit = std::string(uStr), .color = colorDef};
-            return i;
-        }
-    }
-    return std::nullopt; // no slot left
-}
-
-void assignSourcesToAxes(const Dashboard::Plot& plot, Dashboard& /*dashboard*/, std::array<std::optional<AxisCategory>, 3UZ>& xCats, std::array<std::vector<std::string>, 3UZ>& xAxisGroups, std::array<std::optional<AxisCategory>, 3UZ>& yCats, std::array<std::vector<std::string>, 3UZ>& yAxisGroups) {
-    enum class AxisKind { X = 0, Y };
-
-    xCats.fill(std::nullopt);
-    yCats.fill(std::nullopt);
-    for (auto& g : xAxisGroups) {
-        g.clear();
-    }
-    for (auto& g : yAxisGroups) {
-        g.clear();
-    }
-
-    for (const auto* plotSinkBlock : plot.plotSinkBlocks) {
-        auto grBlock = opendigitizer::ImPlotSinkManager::instance().findSink([plotSinkBlock](auto& block) { return block.name() == plotSinkBlock->name(); });
-        if (!grBlock) {
-            continue;
-        }
-
-        const gr::property_map& settings   = grBlock->settings().get();
-        auto                    getSetting = [&settings]<typename T>(const T& defaultVal, std::string key) -> T {
-            if (auto it = settings.find(std::string{key}); it != settings.end()) {
-                if (const T* val = std::get_if<T>(&it->second)) {
-                    return *val;
-                }
-            }
-            return defaultVal;
-        };
-
-        // quantity, unit
-        std::array<std::string, 2UZ> qStr;
-        std::array<std::string, 2UZ> uStr;
-
-        qStr[0UZ]              = getSetting(""s, "abscissa_quantity");
-        uStr[0UZ]              = getSetting(""s, "abscissa_unit");
-        qStr[1UZ]              = getSetting(""s, "signal_quantity");
-        uStr[1UZ]              = getSetting(""s, "signal_unit");
-        const bool plotTagFlag = getSetting(true, "plot_tags");
-
-        auto color = plotSinkBlock->color();
-        for (std::size_t axisID = 0UZ; axisID < 2UZ; ++axisID) {
-            std::array<std::optional<AxisCategory>, 3UZ>& cats       = axisID == 0UZ ? xCats : yCats;
-            std::array<std::vector<std::string>, 3UZ>&    axisGroups = axisID == 0UZ ? xAxisGroups : yAxisGroups;
-            if (auto idx = findOrCreateCategory(cats, qStr[axisID], uStr[axisID], color); idx) {
-                axisGroups[idx.value()].push_back(plotSinkBlock->name());
-                cats[idx.value()]->plotTags = plotTagFlag;
-            } else {
-                components::Notification::warning(std::format("No free slots for {} axis. Ignoring plotSinkBlock '{}' (q='{}', u='{}')\n", axisID == 0UZ ? AxisKind::X : AxisKind::Y, plotSinkBlock->name(), qStr[axisID], uStr[axisID]));
-            }
-        }
-    }
-}
-
-std::string buildLabel(const std::optional<AxisCategory>& catOpt, bool isX) {
-    if (!catOpt.has_value()) {
-        // fallback
-        return isX ? "time" : "y-axis [a.u.]";
-    }
-    const auto& cat = catOpt.value();
-    if (!cat.quantity.empty() && !cat.unit.empty()) {
-        return std::format("{} [{}]", cat.quantity, cat.unit);
-    }
-    if (!cat.quantity.empty()) {
-        return cat.quantity;
-    }
-    if (!cat.unit.empty()) {
-        return cat.unit;
-    }
-    return std::format("{}-axis", (isX ? "X" : "Y")); // fallback if both empty
-}
-
-template<typename Result>
-int enforceNullTerminate(char* buff, int size, const Result& result) {
-    if ((result.out - buff) < static_cast<ptrdiff_t>(size)) {
-        *result.out = '\0';
-    } else if (size > 0) {
-        buff[size - 1] = '\0';
-    }
-    return static_cast<int>(result.out - buff); // number of characters written (excluding null terminator)
-}
-
-inline constexpr std::string_view boundedStringView(const char* ptr, std::size_t maxLength) {
-    if (!ptr) {
-        return "";
-    }
-
-    for (std::size_t i = 0UZ; i < maxLength; ++i) {
-        if (ptr[i] == '\0') {
-            return std::string_view(ptr, i);
-        }
-    }
-    return ""; // null terminator not found
-}
-
-inline int formatMetric(double value, char* buff, int size, void* data) {
-    constexpr std::array<double, 11UZ>      kScales{1e15, 1e12, 1e9, 1e6, 1e3, 1.0, 1e-3, 1e-6, 1e-9, 1e-12, 1e-15};
-    constexpr std::array<const char*, 11UZ> kPrefixes{"P", "T", "G", "M", "k", "", "m", "u", "n", "p", "f"};
-    constexpr std::size_t                   maxUnitLength = 10UZ;
-
-    const std::string_view unit = boundedStringView(static_cast<const char*>(data), maxUnitLength);
-    if (value == 0.0) {
-        return enforceNullTerminate(buff, size, std::format_to_n(buff, size, "0{}", unit));
-    }
-
-    std::string_view prefix      = kPrefixes.back();
-    double           scaledValue = value / kScales.back(); // fallback if no match
-
-    for (auto [scale, p] : std::views::zip(kScales, kPrefixes)) {
-        if (std::abs(value) >= scale) {
-            scaledValue = value / scale;
-            prefix      = p;
-            break;
-        }
-    }
-
-    return enforceNullTerminate(buff, size, std::format_to_n(buff, size, "{:g}{}{}", scaledValue, prefix, unit));
-}
-
-inline std::string formatMinimalScientific(double value, int maxDecimals = 2) {
-    if (value == 0.0) {
-        return "0";
-    }
-
-    const int    exponent = static_cast<int>(std::floor(std::log10(std::abs(value))));
-    const double mantissa = value / std::pow(10.0, exponent);
-
-    std::string mantissaStr = std::format("{:.{}f}", mantissa, maxDecimals);
-    // trim trailing zeros and '.'
-    while (!mantissaStr.empty() && mantissaStr.back() == '0') {
-        mantissaStr.pop_back();
-    }
-    if (!mantissaStr.empty() && mantissaStr.back() == '.') {
-        mantissaStr.pop_back();
-    }
-
-    return std::format("{}E{}", mantissaStr, exponent);
-}
-
-inline int formatScientific(double value, char* buff, int size, void* data) {
-    constexpr std::size_t  maxUnitLength = 10UZ;
-    const std::string_view unit          = boundedStringView(static_cast<const char*>(data), maxUnitLength);
-
-    if (value == 0.0) {
-        return enforceNullTerminate(buff, size, std::format_to_n(buff, size, "0{}", unit));
-    }
-
-    const double absVal = std::abs(value);
-    if (absVal >= 1e-3 && absVal < 10000.0) {
-        return enforceNullTerminate(buff, size, std::format_to_n(buff, size, "{:.3g}{}", value, unit));
-    } else {
-        return enforceNullTerminate(buff, size, std::format_to_n(buff, size, "{}{}", formatMinimalScientific(value), unit));
-    }
-}
-
-inline int formatDefault(double value, char* buff, int size, void* data) {
-    constexpr std::size_t  maxUnitLength = 10UZ;
-    const std::string_view unit          = boundedStringView(static_cast<const char*>(data), maxUnitLength);
-
-    if (value == 0.0) {
-        return enforceNullTerminate(buff, size, std::format_to_n(buff, size, "0{}", unit));
-    }
-
-    return enforceNullTerminate(buff, size, std::format_to_n(buff, size, "{:g}{}", value, unit));
-}
-
-void setupPlotAxes(Dashboard::Plot& plot, const std::array<std::optional<AxisCategory>, 3UZ>& xCats, const std::array<std::optional<AxisCategory>, 3UZ>& yCats) {
-    using Axis = Dashboard::Plot::AxisKind;
-
-    const std::size_t nAxesX          = static_cast<std::size_t>(std::ranges::count_if(xCats, [](const auto& c) { return c.has_value(); }));
-    const std::size_t nAxesY          = static_cast<std::size_t>(std::ranges::count_if(yCats, [](const auto& c) { return c.has_value(); }));
-    const auto        setupSingleAxis = [&nAxesX, &nAxesY, &plot](ImAxis axisId, const std::optional<AxisCategory>& cat, float axisWidth, std::optional<Dashboard::Plot::AxisData*> axisConfigInfo = std::nullopt) {
-        if (!cat.has_value()) {
-            // workaround for missing xCats definition
-            return;
-        }
-
-        const bool      isX       = axisId == ImAxis_X1 || axisId == ImAxis_X2 || axisId == ImAxis_X3;
-        const bool      finiteMin = axisConfigInfo.has_value() ? std::isfinite(axisConfigInfo.value()->min) : false;
-        const bool      finiteMax = axisConfigInfo.has_value() ? std::isfinite(axisConfigInfo.value()->max) : false;
-        const AxisScale scale     = axisConfigInfo.has_value() ? axisConfigInfo.value()->scale : cat.has_value() ? cat->scale : AxisScale::Linear;
-
-        ImPlotAxisFlags flags = ImPlotAxisFlags_None;
-        if (finiteMin && !finiteMax) {
-            flags |= ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit | ImPlotAxisFlags_LockMin;
-        } else if (!finiteMin && finiteMax) {
-            flags |= ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit | ImPlotAxisFlags_LockMax;
-        } else if (!finiteMin && !finiteMax) {
-            flags |= ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit;
-        } // else both limits set -> no auto-fit
-        if ((axisId == ImAxis_X2) || (axisId == ImAxis_X3) || (axisId == ImAxis_Y2) || (axisId == ImAxis_Y3)) {
-            flags |= ImPlotAxisFlags_Opposite;
-        }
-
-        bool pushedColor = false;
-        if (cat && (isX ? nAxesX > 1 : nAxesY > 1) && !isX) {
-            // axis colour handling isn't enabled for the x-axis for the time being.
-            const auto   colorU32toImVec4 = [](uint32_t c) { return ImVec4{float((c >> 0) & 0xFF) / 255.f, float((c >> 8) & 0xFF) / 255.f, float((c >> 16) & 0xFF) / 255.f, 1.f}; };
-            const ImVec4 col              = colorU32toImVec4(cat->color);
-            ImPlot::PushStyleColor(ImPlotCol_AxisText, col);
-            ImPlot::PushStyleColor(ImPlotCol_AxisTick, col);
-            pushedColor = true;
-        }
-
-        const auto truncateLabel = [](std::string_view original, float availableWidth) -> std::string {
-            const float textWidth = ImGui::CalcTextSize(original.data()).x;
-            if (textWidth <= availableWidth) {
-                return std::string(original);
-            }
-            static const float ellipsisWidth = ImGui::CalcTextSize("...").x;
-            if (availableWidth <= ellipsisWidth + 1.f) {
-                return "...";
-            }
-            const float       scaleFactor  = (availableWidth - ellipsisWidth) / std::max(1.f, textWidth);
-            const std::size_t fitCharCount = static_cast<std::size_t>(std::floor(scaleFactor * static_cast<float>(original.size())));
-            return std::format("...{}", original.substr(original.size() - fitCharCount));
-        };
-
-        const LabelFormat format = axisConfigInfo.has_value() ? axisConfigInfo.value()->format : LabelFormat::Auto;
-        const std::string label  = (scale == AxisScale::Time) || (format == LabelFormat::MetricInline) ? "" : truncateLabel(buildLabel(cat, isX), axisWidth);
-        ImPlot::SetupAxis(axisId, label.c_str(), flags);
-
-        if (scale != AxisScale::Time) {
-            constexpr std::array kMetricUnits{"s", "m", "A", "K", "V", "g", "eV", "Hz"};
-            constexpr std::array kLinearUnits{"dB"}; // do not use exponential
-            const std::string&   unit = (cat && !cat->unit.empty()) ? cat->unit : "";
-
-            using enum LabelFormat;
-            switch (format) {
-            case Auto:
-                if (std::ranges::contains(kMetricUnits, unit)) {
-                    ImPlot::SetupAxisFormat(axisId, formatMetric, nullptr);
-                } else if (std::ranges::contains(kLinearUnits, unit)) {
-                    ImPlot::SetupAxisFormat(axisId, formatDefault, nullptr);
-                } else {
-                    if (isX) {
-                        constexpr const char* str = "s";
-                        ImPlot::SetupAxisFormat(axisId, formatMetric, (void*)str); // present workaround until x-axis category has been established.
-                    } else {
-                        ImPlot::SetupAxisFormat(axisId, formatScientific, nullptr);
-                    }
-                }
-                break;
-            case Metric: ImPlot::SetupAxisFormat(axisId, formatMetric, nullptr); break;
-            case MetricInline: {
-                const char* str = cat && !cat->unit.empty() ? cat->unit.c_str() : "";
-                ImPlot::SetupAxisFormat(axisId, formatMetric, (void*)str);
-            } break;
-            case Scientific: ImPlot::SetupAxisFormat(axisId, formatScientific, nullptr); break;
-            case None:
-            case Default:
-            default: ImPlot::SetupAxisFormat(axisId, formatDefault, nullptr);
-            }
-        }
-
-        switch (scale) {
-            using enum AxisScale;
-        case Log10: ImPlot::SetupAxisScale(axisId, ImPlotScale_Log10); break;
-        case SymLog: ImPlot::SetupAxisScale(axisId, ImPlotScale_SymLog); break;
-        case Time:
-            ImPlot::GetStyle().UseISO8601     = true;
-            ImPlot::GetStyle().Use24HourClock = true;
-            ImPlot::SetupAxisScale(axisId, ImPlotScale_Time);
-            break;
-        default: ImPlot::SetupAxisScale(axisId, ImPlotScale_Linear); break;
-        }
-
-        if (axisConfigInfo.has_value()) {
-            const auto& info = *axisConfigInfo.value();
-            if (finiteMin && finiteMax) {
-                ImPlot::SetupAxisLimits(axisId, static_cast<double>(info.min), static_cast<double>(info.max));
-            } else if (finiteMin || finiteMax) {
-                assert(flags & ImPlotAxisFlags_LockMin || flags & ImPlotAxisFlags_LockMax);
-                const double minConstraint = finiteMin ? static_cast<double>(info.min) : -std::numeric_limits<double>::infinity();
-                const double maxConstraint = finiteMax ? static_cast<double>(info.max) : +std::numeric_limits<double>::infinity();
-                ImPlot::SetupAxisLimitsConstraints(axisId, minConstraint, maxConstraint);
-            }
-        }
-
-        if (pushedColor) {
-            ImPlot::PopStyleColor(2);
-        }
-    };
-
-    float xAxisWidth = 100.f;
-    float yAxisWidth = 100.f;
-    for (auto& axis : plot.axes) {
-        if (axis.axis == Axis::X) {
-            xAxisWidth = axis.width;
-        } else {
-            yAxisWidth = axis.width;
-        }
-    }
-
-    auto getAxisByKind = [&plot](Dashboard::Plot::AxisKind kind, std::size_t index) -> std::optional<Dashboard::Plot::AxisData*> {
-        std::size_t count = 0UZ;
-        for (auto& axis : plot.axes) {
-            if (axis.axis == kind) {
-                if (count++ == index) {
-                    return &axis;
-                }
-            }
-        }
-        return std::nullopt; // not found
-    };
-
-    for (std::size_t i = 0UZ; i < xCats.size(); ++i) {
-        setupSingleAxis(static_cast<ImAxis>(ImAxis_X1 + i), xCats[i], xAxisWidth, getAxisByKind(Dashboard::Plot::AxisKind::X, i));
-    }
-
-    for (std::size_t i = 0UZ; i < yCats.size(); ++i) {
-        setupSingleAxis(static_cast<ImAxis>(ImAxis_Y1 + i), yCats[i], yAxisWidth, getAxisByKind(Dashboard::Plot::AxisKind::Y, i));
-    }
-}
 } // namespace
 
 static bool plotButton(const char* glyph, const char* tooltip) noexcept {
@@ -393,8 +52,9 @@ static void alignForWidth(float width, float alignment = 0.5f) noexcept {
 }
 
 DashboardPage::DashboardPage() {
-    opendigitizer::ImPlotSinkManager::instance().addListener(this, [this](opendigitizer::ImPlotSinkModel& sink, bool wasAdded) {
-        if (!m_dashboard || !wasAdded || _addedSourceBlocksWaitingForSink.empty()) {
+    // Use SinkRegistry for listening to sink registration events
+    opendigitizer::charts::SinkRegistry::instance().addListener(this, [this](opendigitizer::charts::SignalSink& sink, bool wasAdded) {
+        if (!_dashboard || !wasAdded || _addedSourceBlocksWaitingForSink.empty()) {
             return;
         }
 
@@ -411,194 +71,30 @@ DashboardPage::DashboardPage() {
         gr::Message message;
         message.cmd         = gr::message::Command::Set;
         message.endpoint    = gr::scheduler::property::kEmplaceEdge;
-        message.serviceName = m_dashboard->graphModel().rootBlock.ownerSchedulerUniqueName();
-        message.data        = gr::property_map{                                                                 //
-            {std::string(gr::serialization_fields::EDGE_SOURCE_BLOCK), sourceInWaiting.sourceBlockName}, //
-            {std::string(gr::serialization_fields::EDGE_SOURCE_PORT), "out"},                            //
-            {std::string(gr::serialization_fields::EDGE_DESTINATION_BLOCK), sink.uniqueName},            //
-            {std::string(gr::serialization_fields::EDGE_DESTINATION_PORT), "in"},                        //
-            {std::string(gr::serialization_fields::EDGE_MIN_BUFFER_SIZE), gr::Size_t(4096)},             //
-            {std::string(gr::serialization_fields::EDGE_WEIGHT), 1},                                     //
+        message.serviceName = _dashboard->graphModel.rootBlock.ownerSchedulerUniqueName();
+        message.data        = gr::property_map{                                                                     //
+            {std::string(gr::serialization_fields::EDGE_SOURCE_BLOCK), sourceInWaiting.sourceBlockName},     //
+            {std::string(gr::serialization_fields::EDGE_SOURCE_PORT), "out"},                                //
+            {std::string(gr::serialization_fields::EDGE_DESTINATION_BLOCK), std::string(sink.uniqueName())}, //
+            {std::string(gr::serialization_fields::EDGE_DESTINATION_PORT), "in"},                            //
+            {std::string(gr::serialization_fields::EDGE_MIN_BUFFER_SIZE), gr::Size_t(4096)},                 //
+            {std::string(gr::serialization_fields::EDGE_WEIGHT), 1},                                         //
             {std::string(gr::serialization_fields::EDGE_NAME), std::string()}};
-        m_dashboard->graphModel().sendMessage(std::move(message));
+        _dashboard->graphModel.sendMessage(std::move(message));
 
-        auto& plot = m_dashboard->newPlot(0, 0, 1, 1);
-        plot.sourceNames.push_back(sourceInWaiting.signalData.signalName);
-        m_dashboard->loadPlotSourcesFor(plot);
+        auto& uiWindow = _dashboard->newUIBlock(0, 0, 1, 1);
+        auto  names    = grc_compat::getBlockSinkNames(uiWindow.block.get());
+        names.push_back(sourceInWaiting.signalData.signalName);
+        grc_compat::setBlockSinkNames(uiWindow.block.get(), names);
     });
 }
 
-DashboardPage::~DashboardPage() { opendigitizer::ImPlotSinkManager::instance().removeListener(this); }
-
-inline void formatAxisValue(const ImPlotAxis& axis, double value, char* buf, int size) {
-    if (axis.Scale == ImPlotScale_Time) {
-        const auto formatIsoTime = [](double timestamp, char* buffer, std::size_t size_) noexcept {
-            using Clock          = std::chrono::system_clock;
-            const auto timePoint = Clock::time_point(std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(timestamp)));
-            const auto secs      = std::chrono::time_point_cast<std::chrono::seconds>(timePoint);
-            const auto ms        = std::chrono::duration_cast<std::chrono::milliseconds>(timePoint - secs).count();
-
-            auto result = std::format_to_n(buffer, static_cast<int>(size_) - 1, "{:%Y-%m-%dT%H:%M:%S}.{:03}", secs, ms);
-
-            buffer[std::min(static_cast<std::size_t>(result.size), size_ - 1UZ)] = '\0'; // ensure null-termination
-        };
-        formatIsoTime(value, buf, static_cast<std::size_t>(size));
-    } else if (axis.Formatter) {
-        axis.Formatter(value, buf, size, axis.FormatterData);
-    } else {
-        // do nothing
-    }
-}
-
-inline void showPlotMouseTooltip(double on_delay_s = 1.0f, double off_delay_s = 30.0f) {
-    if (!ImPlot::IsPlotHovered()) {
-        return;
-    }
-
-    ImPlotContext* ctx  = ImPlot::GetCurrentContext();
-    ImPlotPlot*    plot = ImPlot::GetCurrentPlot();
-    if (!ctx || !plot) {
-        return;
-    }
-
-    const ImVec2  px = ImGui::GetMousePos();
-    static ImVec2 lastPX{0, 0};
-    static double lastTime = 0.0;
-    const double  now      = ImGui::GetTime();
-
-    constexpr float epsilon = 10.0f;
-    const bool      samePos = std::abs(px.x - lastPX.x) < epsilon && std::abs(px.y - lastPX.y) < epsilon;
-
-    if (!samePos) {
-        lastPX   = px;
-        lastTime = now;
-        return;
-    }
-
-    if ((now - lastTime) < on_delay_s || (now - lastTime) > off_delay_s) {
-        return;
-    }
-
-    auto drawAxisTooltip = [](ImPlotPlot* plot_, ImAxis axisIdx) {
-        ImPlotAxis& axis = plot_->Axes[axisIdx];
-        if (!axis.Enabled) {
-            return;
-        }
-
-        const auto mousePos = ImPlot::GetPlotMousePos(axis.Vertical ? IMPLOT_AUTO : axisIdx, axis.Vertical ? axisIdx : IMPLOT_AUTO);
-
-        char buf[128UZ];
-        formatAxisValue(axis, axis.Vertical ? mousePos.y : mousePos.x, buf, sizeof(buf));
-
-        std::string_view label = plot_->GetAxisLabel(axis);
-        if (label.empty()) {
-            ImGui::Text("%s", buf);
-        } else {
-            ImGui::Text("%s: %s", label.data(), buf);
-        }
-    };
-
-    // draw actual tooltip
-    IMW::Font    font(LookAndFeel::instance().fontSmall[LookAndFeel::instance().prototypeMode ? 1UZ : 0UZ]);
-    IMW::ToolTip tooltip;
-    for (int i = 0; i < 3; ++i) {
-        drawAxisTooltip(plot, ImAxis_X1 + i);
-    }
-    for (int i = 0; i < 3; ++i) {
-        drawAxisTooltip(plot, ImAxis_Y1 + i);
-    }
-}
-
-// for inter-frame storage
-static std::map<Dashboard::Plot*, std::array<std::optional<AxisCategory>, 3UZ>> xCatsMap{};
-static std::map<Dashboard::Plot*, std::array<std::optional<AxisCategory>, 3UZ>> yCatsMap{};
-
-// Draw the multi-axis plot
-void DashboardPage::drawPlot(Dashboard::Plot& plot) noexcept {
-    // 1) Build up two sets of categories for X & Y
-    std::array<std::optional<AxisCategory>, 3UZ> xCats = xCatsMap[&plot];
-    std::array<std::vector<std::string>, 3UZ>    xAxisGroups{};
-    std::array<std::optional<AxisCategory>, 3UZ> yCats = xCatsMap[&plot];
-    ;
-    std::array<std::vector<std::string>, 3UZ> yAxisGroups{};
-
-    assignSourcesToAxes(plot, *m_dashboard, xCats, xAxisGroups, yCats, yAxisGroups);
-
-    // 2) Setup up to 3 X axes & 3 Y axes
-    setupPlotAxes(plot, xCats, yCats);
-    ImPlot::SetupFinish();
-
-    // show tool-tip
-    showPlotMouseTooltip();
-
-    // compute axis pixel width or height
-    {
-        const ImPlotRect axisLimits = ImPlot::GetPlotLimits(IMPLOT_AUTO, IMPLOT_AUTO);
-        const ImVec2     p0         = ImPlot::PlotToPixels(axisLimits.X.Min, axisLimits.Y.Min);
-        const ImVec2     p1         = ImPlot::PlotToPixels(axisLimits.X.Max, axisLimits.Y.Max);
-        const float      xWidth     = std::round(std::abs(p1.x - p0.x));
-        const float      yHeight    = std::round(std::abs(p1.y - p0.y));
-        std::ranges::for_each(plot.axes, [xWidth, yHeight](auto& a) { a.width = (a.axis == Dashboard::Plot::AxisKind::X) ? xWidth : yHeight; });
-    }
-
-    // draw each source on the correct axis
-    bool drawTag = true;
-    for (opendigitizer::ImPlotSinkModel* plotSinkBlock : plot.plotSinkBlocks) {
-        // if tab is invisible work() function does the job in Scheduler thread
-        if (!plotSinkBlock->isVisible && isTabVisible()) {
-            // consume data if hidden
-            std::ignore = plotSinkBlock->invokeWork();
-            continue;
-        }
-
-        const auto& sourceBlockName = plotSinkBlock->name();
-
-        // figure out which axis group check X first
-        std::size_t xAxisID = std::numeric_limits<std::size_t>::max();
-        for (std::size_t i = 0UZ; i < 3UZ && xAxisID == std::numeric_limits<std::size_t>::max(); ++i) {
-            auto it = std::ranges::find(xAxisGroups[i], plotSinkBlock->name());
-            if (it != xAxisGroups[i].end()) {
-                xAxisID = i;
-            }
-        }
-        if (xAxisID == std::numeric_limits<std::size_t>::max()) {
-            // default to X0 if not found
-            xAxisID = 0UZ;
-        }
-
-        // check Y if not found
-        std::size_t yAxisID = std::numeric_limits<std::size_t>::max();
-        for (std::size_t i = 0UZ; i < 3UZ && yAxisID == std::numeric_limits<std::size_t>::max(); ++i) {
-            auto it = std::ranges::find(yAxisGroups[i], plotSinkBlock->name());
-            if (it != yAxisGroups[i].end()) {
-                yAxisID = i;
-            }
-        }
-        if (yAxisID == std::numeric_limits<std::size_t>::max()) {
-            // default to Y0 if not found
-            yAxisID = 0;
-        }
-
-        if (!plot.axes[xAxisID].plotTags) {
-            drawTag = false;
-        }
-        std::ignore = plotSinkBlock->draw({{"draw_tag", drawTag}, {"xAxisID", xAxisID}, {"yAxisID", yAxisID}, {"scale", std::string(magic_enum::enum_name(plot.axes[0].scale))}});
-        drawTag     = false;
-
-        // allow legend item labels to be DND sources
-        if (ImPlot::BeginDragDropSourceItem(sourceBlockName.c_str())) {
-            DigitizerUi::DashboardPage::DndItem dnd = {&plot, plotSinkBlock};
-            ImGui::SetDragDropPayload(dnd_type, &dnd, sizeof(dnd));
-
-            ImPlot::ItemIcon(plotSinkBlock->color());
-            ImGui::SameLine();
-            ImGui::TextUnformatted(sourceBlockName.c_str());
-            ImPlot::EndDragDropSource();
-        }
-    }
-}
+DashboardPage::~DashboardPage() { opendigitizer::charts::SinkRegistry::instance().removeListener(this); }
 
 void DashboardPage::draw(Mode mode) noexcept {
+    processPendingTransmutation();
+    processPendingRemovals();
+
     const float  left = ImGui::GetCursorPosX();
     const float  top  = ImGui::GetCursorPosY();
     const ImVec2 size = ImGui::GetContentRegionAvail();
@@ -606,7 +102,7 @@ void DashboardPage::draw(Mode mode) noexcept {
     const bool      horizontalSplit   = size.x > size.y;
     constexpr float splitterWidth     = 6;
     constexpr float halfSplitterWidth = splitterWidth / 2.f;
-    const float     ratio             = components::Splitter(size, horizontalSplit, splitterWidth, 0.2f, !m_editPane.selectedBlock());
+    const float     ratio             = components::Splitter(size, horizontalSplit, splitterWidth, 0.2f, !_editPane.selectedBlock());
 
     ImGui::SetCursorPosX(left);
     ImGui::SetCursorPosY(top);
@@ -615,15 +111,57 @@ void DashboardPage::draw(Mode mode) noexcept {
         IMW::Child plotsChild("##plots", horizontalSplit ? ImVec2(size.x * (1.f - ratio) - halfSplitterWidth, size.y) : ImVec2(size.x, size.y * (1.f - ratio) - halfSplitterWidth), false, ImGuiWindowFlags_NoScrollbar);
 
         if (ImGui::IsWindowHovered() && ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
-            m_editPane.setSelectedBlock(nullptr, nullptr);
+            _editPane.setSelectedBlock(nullptr, nullptr);
         }
 
-        // Plots
+        // Render ChartPane blocks
         {
             IMW::Group group;
-            drawPlots(mode);
+
+            _paneSize = ImGui::GetContentRegionAvail();
+            _paneSize.y -= _legendBox.y;
+
+            const float w = _paneSize.x / float(kGridWidth);
+            const float h = _paneSize.y / float(kGridHeight);
+
+            // Draw layout grid in Layout mode
+            if (mode == Mode::Layout) {
+                const uint32_t gridLineColor = LookAndFeel::instance().style == LookAndFeel::Style::Light ? 0x40000000 : 0x40ffffff;
+                auto           pos           = ImGui::GetCursorScreenPos();
+                for (float x = pos.x; x < pos.x + _paneSize.x; x += w) {
+                    ImGui::GetWindowDrawList()->AddLine({x, pos.y}, {x, pos.y + _paneSize.y}, gridLineColor);
+                }
+                for (float y = pos.y; y < pos.y + _paneSize.y; y += h) {
+                    ImGui::GetWindowDrawList()->AddLine({pos.x, y}, {pos.x + _paneSize.x, y}, gridLineColor);
+                }
+            }
+
+            DockSpace::Windows windows;
+
+            // Iterate uiGraph blocks filtered by ChartPane category
+            for (auto& blockPtr : _dashboard->uiGraph.blocks()) {
+                if (blockPtr->uiCategory() != gr::UICategory::ChartPane) {
+                    continue;
+                }
+
+                // Get or create UIWindow for this block (lazy creation)
+                auto& uiWindow = _dashboard->getOrCreateUIWindow(blockPtr);
+                if (!uiWindow.window) {
+                    continue;
+                }
+
+                windows.push_back(uiWindow.window);
+                // Capture shared_ptr by value to ensure block stays alive during render
+                uiWindow.window->renderFunc = [this, block = blockPtr, mode] {
+                    gr::property_map drawConfig;
+                    drawConfig["layoutMode"] = (mode == Mode::Layout);
+                    block->draw(drawConfig);
+                };
+            }
+
+            _dockSpace.render(windows, _paneSize);
         }
-        ImGui::SetCursorPos(ImVec2(0, ImGui::GetWindowHeight() - legend_box.y));
+        ImGui::SetCursorPos(ImVec2(0, ImGui::GetWindowHeight() - _legendBox.y));
 
         // Legend
         {
@@ -631,45 +169,81 @@ void DashboardPage::draw(Mode mode) noexcept {
             // Button strip
             if (mode == Mode::Layout) {
                 if (plotButton("\uF201", "create new chart")) {
-                    // chart-line
-                    newPlot();
+                    _showNewPlotModal = true;
                 }
                 ImGui::SameLine();
                 if (plotButton("\uF7A5", "change to the horizontal layout")) {
-                    m_dockSpace.setLayoutType(DockingLayoutType::Row);
+                    _dockSpace.setLayoutType(DockingLayoutType::Row);
                 }
                 ImGui::SameLine();
                 if (plotButton("\uF7A4", "change to the vertical layout")) {
-                    m_dockSpace.setLayoutType(DockingLayoutType::Column);
+                    _dockSpace.setLayoutType(DockingLayoutType::Column);
                 }
                 ImGui::SameLine();
                 if (plotButton("\uF58D", "change to the grid layout")) {
-                    m_dockSpace.setLayoutType(DockingLayoutType::Grid);
+                    _dockSpace.setLayoutType(DockingLayoutType::Grid);
                 }
                 ImGui::SameLine();
                 if (plotButton("\uF248", "change to the free layout")) {
-                    m_dockSpace.setLayoutType(DockingLayoutType::Free);
+                    _dockSpace.setLayoutType(DockingLayoutType::Free);
                 }
                 ImGui::SameLine();
             }
 
-            drawGlobalLegend(mode);
+            // Render Toolbar blocks (legend, etc.) - centre-aligned
+            {
+                static constexpr std::string_view kLegendBlockType = "DigitizerUi::GlobalSignalLegend";
 
-            if (m_dashboard && m_remoteSignalSelector) {
+                alignForWidth(std::max(10.f, _legendBox.x), 0.5f);
+                _legendBox.x = 0.f;
+
+                ImVec2 totalSize{0.f, 0.f};
+                for (auto& blockPtr : _dashboard->uiGraph.blocks()) {
+                    if (blockPtr->uiCategory() != gr::UICategory::Toolbar) {
+                        continue;
+                    }
+
+                    // Configure GlobalSignalLegend before drawing
+                    const bool isLegendBlock = (blockPtr->typeName() == kLegendBlockType);
+                    if (isLegendBlock) {
+                        auto* legendBlock = static_cast<GlobalSignalLegend*>(blockPtr->raw());
+                        legendBlock->setPaneWidth(_paneSize.x);
+                        legendBlock->setRightClickCallback([this](std::string_view sinkUniqueName) {
+                            _editPane.setSelectedBlock(_dashboard->graphModel.rootBlock.findBlockByUniqueName(std::string(sinkUniqueName)), std::addressof(_dashboard->graphModel));
+                            _editPane.closeTime = std::chrono::system_clock::now() + LookAndFeel::instance().editPaneCloseDelay;
+                        });
+                    }
+
+                    // Draw the toolbar block
+                    gr::property_map drawConfig;
+                    drawConfig["paneWidth"] = _paneSize.x;
+                    blockPtr->draw(drawConfig);
+
+                    // Track legend size
+                    if (isLegendBlock) {
+                        auto* legendBlock = static_cast<GlobalSignalLegend*>(blockPtr->raw());
+                        totalSize         = legendBlock->legendSize();
+                    }
+                }
+
+                _legendBox = totalSize;
+            }
+
+            if (_dashboard && _remoteSignalSelector) {
                 // Post button strip
                 if (mode == Mode::Layout) {
                     ImGui::SameLine();
                     if (plotButton("\uf067", "add signal")) {
                         // 'plus' button in the global legend, adds a new signal
                         // to the dashboard
-                        m_remoteSignalSelector->open();
+                        _remoteSignalSelector->open();
                     }
 
-                    for (const auto& selectedRemoteSignal : m_remoteSignalSelector->drawAndReturnSelected()) {
+                    for (const auto& selectedRemoteSignal : _remoteSignalSelector->drawAndReturnSelected()) {
                         const auto& uriStr_           = selectedRemoteSignal.uri();
                         _addingRemoteSignals[uriStr_] = selectedRemoteSignal;
 
-                        m_dashboard->addRemoteSignal(selectedRemoteSignal);
+                        _dashboard->addRemoteSignal(selectedRemoteSignal);
 
                         opendigitizer::RemoteSourceManager::instance().setRemoteSourceAddedCallback(uriStr_, [this, selectedRemoteSignal](opendigitizer::RemoteSourceModel& remoteSource) {
                             const auto& uriStr = selectedRemoteSignal.uri();
@@ -701,7 +275,7 @@ void DashboardPage::draw(Mode mode) noexcept {
                             message.cmd      = gr::message::Command::Set;
                             message.endpoint = gr::scheduler::property::kEmplaceBlock;
                             // The root block needs to be a scheduler
-                            message.serviceName = m_dashboard->graphModel().rootBlock.ownerSchedulerUniqueName();
+                            message.serviceName = _dashboard->graphModel.rootBlock.ownerSchedulerUniqueName();
                             message.data        = gr::property_map{
                                 //
                                 {"type"s, sinkBlockType + sinkBlockParams}, //
@@ -714,7 +288,7 @@ void DashboardPage::draw(Mode mode) noexcept {
                                     } //
                                 } //
                             };
-                            m_dashboard->graphModel().sendMessage(std::move(message));
+                            _dashboard->graphModel.sendMessage(std::move(message));
                         });
                     }
                 }
@@ -730,221 +304,70 @@ void DashboardPage::draw(Mode mode) noexcept {
                 ImGui::Text("%s", str.c_str());
             }
         }
-        legend_box.y = std::floor(ImGui::GetItemRectSize().y * 1.5f);
+        _legendBox.y = std::floor(ImGui::GetItemRectSize().y * 1.5f);
     }
 
     if (horizontalSplit) {
         const float w = size.x * ratio;
-        components::BlockControlsPanel(m_editPane, {left + size.x - w + halfSplitterWidth, top}, {w - halfSplitterWidth, size.y}, true);
+        components::BlockControlsPanel(_editPane, {left + size.x - w + halfSplitterWidth, top}, {w - halfSplitterWidth, size.y}, true);
     } else {
         const float h = size.y * ratio;
-        components::BlockControlsPanel(m_editPane, {left, top + size.y - h + halfSplitterWidth}, {size.x, h - halfSplitterWidth}, false);
+        components::BlockControlsPanel(_editPane, {left, top + size.y - h + halfSplitterWidth}, {size.x, h - halfSplitterWidth}, false);
     }
+
+    // Modal dialogs
+    drawNewPlotModal();
 }
 
-void DashboardPage::drawPlots(DigitizerUi::DashboardPage::Mode mode) {
-    pane_size = ImGui::GetContentRegionAvail();
-    pane_size.y -= legend_box.y;
-
-    const float w = pane_size.x / float(kGridWidth);
-    const float h = pane_size.y / float(kGridHeight);
-
-    if (mode == Mode::Layout) {
-        drawGrid(w, h);
+DigitizerUi::Dashboard::UIWindow* DashboardPage::newUIBlock(std::string_view chartType) {
+    if (_dashboard->uiWindows.size() < kMaxPlots) {
+        return std::addressof(_dashboard->newUIBlock(0, 0, 1, 1, chartType));
     }
-
-    Dashboard::Plot* toDelete = nullptr;
-
-    DockSpace::Windows windows;
-    auto&              plots = m_dashboard->plots();
-    windows.reserve(plots.size());
-
-    for (auto& plot : plots) {
-        windows.push_back(plot.window);
-        plot.window->renderFunc = [this, &plot, mode] {
-            const float offset = (mode == Mode::Layout) ? 5.f : 0.f;
-
-            const bool  showTitle = false; // TODO: make this and the title itself a configurable/editable entity
-            ImPlotFlags plotFlags = ImPlotFlags_NoChild | ImPlotFlags_NoMouseText;
-            plotFlags |= showTitle ? ImPlotFlags_None : ImPlotFlags_NoTitle;
-            plotFlags |= mode == Mode::Layout ? ImPlotFlags_None : ImPlotFlags_NoLegend;
-
-            ImPlot::PushStyleVar(ImPlotStyleVar_PlotPadding, ImVec2{0, 0}); // TODO: make this perhaps a global style setting via ImPlot::GetStyle()
-            ImPlot::PushStyleVar(ImPlotStyleVar_LabelPadding, ImVec2{3, 1});
-            auto plotSize = ImGui::GetContentRegionAvail();
-            ImPlot::PushStyleVar(ImPlotStyleVar_FitPadding, ImVec2(0.00f, 0.05f));
-            if (TouchHandler<>::BeginZoomablePlot(plot.name, plotSize - ImVec2(2 * offset, 2 * offset), plotFlags)) {
-                drawPlot(plot);
-
-                // allow the main plot area to be a DND target
-                if (ImPlot::BeginDragDropTargetPlot()) {
-                    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(dnd_type)) {
-                        auto* dnd = static_cast<DndItem*>(payload->Data);
-                        plot.plotSinkBlocks.push_back(dnd->plotSource);
-                        if (auto* dndPlot = dnd->plot) {
-                            dndPlot->plotSinkBlocks.erase(std::ranges::find(dndPlot->plotSinkBlocks, dnd->plotSource));
-                        }
-                    }
-                    ImPlot::EndDragDropTarget();
-                }
-
-                // update plot.axes if auto-fit is not used
-                ImPlotRect rect = ImPlot::GetPlotLimits();
-                for (auto& axis : plot.axes) {
-                    const bool      isX              = (axis.axis == Dashboard::Plot::AxisKind::X);
-                    const ImAxis    axisId           = isX ? ImAxis_X1 : ImAxis_Y1; // TODO multi-axis extension
-                    ImPlotAxisFlags axisFlags        = ImPlot::GetCurrentPlot()->Axes[axisId].Flags;
-                    bool            isAutoOrRangeFit = (axisFlags & (ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit)) != 0;
-                    if (!isAutoOrRangeFit) {
-                        // store back min/max from the actual final plot region
-                        if (axis.axis == Dashboard::Plot::AxisKind::X) {
-                            axis.min = static_cast<float>(rect.X.Min);
-                            axis.max = static_cast<float>(rect.X.Max);
-                        } else {
-                            axis.min = static_cast<float>(rect.Y.Min);
-                            axis.max = static_cast<float>(rect.Y.Max);
-                        }
-                    }
-                }
-
-                // handle hover detection if in layout mode
-                if (mode == Mode::Layout) {
-                    bool plotItemHovered = ImPlot::IsPlotHovered() || ImPlot::IsAxisHovered(ImAxis_X1) || ImPlot::IsAxisHovered(ImAxis_X2) || ImPlot::IsAxisHovered(ImAxis_X3) || ImPlot::IsAxisHovered(ImAxis_Y1) || ImPlot::IsAxisHovered(ImAxis_Y2) || ImPlot::IsAxisHovered(ImAxis_Y3);
-                    if (!plotItemHovered) {
-                        // Unfortunately there is no function that returns whether the entire legend is hovered,
-                        // we need to check one entry at a time
-                        for (const auto& plotSinkBlock : plot.plotSinkBlocks) {
-                            const auto& sourceName = plotSinkBlock->name();
-                            if (ImPlot::IsLegendEntryHovered(sourceName.c_str())) {
-                                plotItemHovered = true;
-
-                                if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
-                                    // TODO(NOW) which node was clicked -- it needs to have a sane way to get this?
-                                    m_editPane.setSelectedBlock(nullptr, nullptr); // dashboard.localFlowGraph.findBlock(plotSinkBlock->blockName);
-                                    m_editPane.closeTime = std::chrono::system_clock::now() + LookAndFeel::instance().editPaneCloseDelay;
-                                }
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                TouchHandler<>::EndZoomablePlot();
-                ImPlot::PopStyleVar(3);
-            }
-        };
-    }
-
-    m_dockSpace.render(windows, pane_size);
-
-    if (toDelete) {
-        m_dashboard->deletePlot(toDelete);
-    }
-}
-
-void DashboardPage::drawGrid(float w, float h) {
-    const uint32_t gridLineColor = LookAndFeel::instance().style == LookAndFeel::Style::Light ? 0x40000000 : 0x40ffffff;
-
-    auto pos = ImGui::GetCursorScreenPos();
-    for (float x = pos.x; x < pos.x + pane_size.x; x += w) {
-        ImGui::GetWindowDrawList()->AddLine({x, pos.y}, {x, pos.y + pane_size.y}, gridLineColor);
-    }
-    for (float y = pos.y; y < pos.y + pane_size.y; y += h) {
-        ImGui::GetWindowDrawList()->AddLine({pos.x, y}, {pos.x + pane_size.x, y}, gridLineColor);
-    }
-}
-
-void DashboardPage::drawGlobalLegend([[maybe_unused]] const DashboardPage::Mode& mode) noexcept {
-    alignForWidth(std::max(10.f, legend_box.x), 0.5f);
-    legend_box.x = 0.f;
-    {
-        IMW::Group group;
-
-        enum class MouseClick { No, Left, Right };
-
-        const auto LegendItem = [](std::uint32_t color, std::string_view text, bool enabled = true) -> MouseClick {
-            MouseClick   result    = MouseClick::No;
-            const ImVec2 cursorPos = ImGui::GetCursorScreenPos();
-            const ImVec2 rectSize(ImGui::GetTextLineHeight() - 4, ImGui::GetTextLineHeight());
-            ImGui::GetWindowDrawList()->AddRectFilled(cursorPos + ImVec2(0, 2), cursorPos + rectSize - ImVec2(0, 2), color | 0xFF000000);
-            if (ImGui::InvisibleButton("##Button", rectSize)) {
-                result = MouseClick::Left;
-            }
-            ImGui::SameLine();
-
-            // Draw button text with transparent background
-            ImVec2          buttonSize(rectSize.x + ImGui::CalcTextSize(text.data()).x - 4, ImGui::GetTextLineHeight());
-            IMW::StyleColor buttonStyle(ImGuiCol_Button, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
-            IMW::StyleColor hoveredStyle(ImGuiCol_ButtonHovered, ImVec4(0.0f, 0.0f, 0.0f, 0.1f));
-            IMW::StyleColor activeStyle(ImGuiCol_ButtonActive, ImVec4(0.0f, 0.0f, 0.0f, 0.2f));
-            IMW::StyleColor textStyle(ImGuiCol_Text, enabled ? ImGui::GetStyleColorVec4(ImGuiCol_Text) : ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-
-            if (ImGui::Button(text.data(), buttonSize)) {
-                result = MouseClick::Left;
-            }
-
-            if (ImGui::IsMouseReleased(ImGuiPopupFlags_MouseButtonRight & ImGuiPopupFlags_MouseButtonMask_) && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup)) {
-                result = MouseClick::Right;
-            }
-
-            return result;
-        };
-
-        int index    = 0;
-        legend_box.x = pane_size.x; // The plots have already filled in full width, legend should be on the new line
-        opendigitizer::ImPlotSinkManager::instance().forEach([&](opendigitizer::ImPlotSinkModel& signal) {
-            IMW::ChangeId itemId(index++);
-            auto          color = signal.color();
-
-            const std::string& label = signal.signalName().empty() ? signal.name() : signal.signalName();
-
-            const auto widthEstimate = ImGui::CalcTextSize(label.c_str()).x + 20 /* icon width */;
-            if ((legend_box.x + widthEstimate) < 0.9f * pane_size.x) {
-                ImGui::SameLine();
-            } else {
-                legend_box.x = 0.f; // start a new line
-            }
-
-            auto clickedMouseButton = LegendItem(color, label, signal.isVisible);
-            if (clickedMouseButton == MouseClick::Right) {
-                m_editPane.setSelectedBlock(m_dashboard->graphModel().rootBlock.findBlockByUniqueName(signal.uniqueName), std::addressof(m_dashboard->graphModel()));
-                m_editPane.closeTime = std::chrono::system_clock::now() + LookAndFeel::instance().editPaneCloseDelay;
-            }
-            if (clickedMouseButton == MouseClick::Left) {
-                signal.isVisible = !signal.isVisible;
-            }
-            legend_box.x += ImGui::GetItemRectSize().x;
-
-            if (auto dndSource = IMW::DragDropSource(ImGuiDragDropFlags_None)) {
-                DndItem dnd = {nullptr, &signal};
-                ImGui::SetDragDropPayload(dnd_type, &dnd, sizeof(dnd));
-                LegendItem(color, label, signal.isVisible);
-            }
-        });
-    }
-    legend_box.x = ImGui::GetItemRectSize().x;
-    legend_box.y = std::max(5.f, ImGui::GetItemRectSize().y);
-
-    if (auto dndTarget = IMW::DragDropTarget()) {
-        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(dnd_type)) {
-            auto* dnd = static_cast<DndItem*>(payload->Data);
-            if (auto* dndPlot = dnd->plot) {
-                dndPlot->plotSinkBlocks.erase(std::ranges::find(dndPlot->plotSinkBlocks, dnd->plotSource));
-            }
-        }
-    }
-    // end draw legend
-}
-
-DigitizerUi::Dashboard::Plot* DashboardPage::newPlot() {
-    if (m_dashboard->plots().size() < kMaxPlots) {
-        // Plot will get adjusted by the layout automatically
-        return std::addressof(m_dashboard->newPlot(0, 0, 1, 1));
-    }
-
     return nullptr;
 }
 
-void DashboardPage::setLayoutType(DockingLayoutType type) { m_dockSpace.setLayoutType(type); }
+void DashboardPage::drawNewPlotModal() {
+    using namespace opendigitizer::charts;
+
+    if (!_showNewPlotModal) {
+        return;
+    }
+
+    ImGui::OpenPopup("New Chart");
+
+    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSize(ImVec2(300, 0), ImGuiCond_Appearing);
+
+    if (ImGui::BeginPopupModal("New Chart", &_showNewPlotModal, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::Text("Select chart type:");
+        ImGui::Separator();
+
+        auto chartTypes = opendigitizer::charts::registeredChartTypes();
+        for (const auto& type : chartTypes) {
+            bool selected = (_selectedChartType == type);
+            if (ImGui::Selectable(type.c_str(), selected)) {
+                _selectedChartType = type;
+            }
+        }
+
+        ImGui::Separator();
+
+        if (ImGui::Button("Create", ImVec2(120, 0))) {
+            newUIBlock(_selectedChartType);
+            _showNewPlotModal = false;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(120, 0))) {
+            _showNewPlotModal = false;
+            ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::EndPopup();
+    }
+}
+
+void DashboardPage::setLayoutType(DockingLayoutType type) { _dockSpace.setLayoutType(type); }
 
 } // namespace DigitizerUi

--- a/src/ui/DashboardPage.hpp
+++ b/src/ui/DashboardPage.hpp
@@ -2,56 +2,61 @@
 #define DASHBOARDPAGE_H
 
 #include <deque>
+#include <optional>
 #include <stack>
 #include <string>
 #include <unordered_map>
 
 #include "Dashboard.hpp"
+#include "charts/Chart.hpp"        // For g_addSinkToChart, g_requestChartTransmutation
+#include "charts/SinkRegistry.hpp" // For SinkRegistry listener
 #include "common/ImguiWrap.hpp"
 #include "components/Block.hpp"
 #include "components/Docking.hpp"
 #include "components/SignalSelector.hpp"
 
-#include <memory.h>
+#include <memory>
 
 namespace DigitizerUi {
 
 class DashboardPage {
 public:
     enum class Mode { View, Layout };
-    struct DndItem {
-        Dashboard::Plot*                plot       = nullptr;
-        opendigitizer::ImPlotSinkModel* plotSource = nullptr;
-    };
 
 private:
-    ImVec2 pane_size{0, 0};     // updated by drawPlots(...)
-    ImVec2 legend_box{500, 40}; // updated by drawLegend(...)
+    ImVec2 _paneSize{0, 0};     // updated by drawPlots(...)
+    ImVec2 _legendBox{500, 40}; // updated by drawLegend(...)
 
-    static constexpr inline auto* dnd_type = "DND_SOURCE";
-
-    // Signals which are schedulerd to be added
+    // signals which are scheduled to be added
     // (source block creation requested)
     std::unordered_map<std::string, SignalData> _addingRemoteSignals;
 
-    // Source blocks which are added, and are
-    // waiting for the plot sinks to be created
+    // source blocks which are added, waiting for the plot sinks to be created
     struct SourceBlockInWaiting {
         SignalData  signalData;
         std::string sourceBlockName;
     };
     std::unordered_map<std::string, SourceBlockInWaiting> _addedSourceBlocksWaitingForSink;
 
-    DockSpace                             m_dockSpace;
-    components::BlockControlsPanelContext m_editPane;
-    std::unique_ptr<SignalSelector>       m_remoteSignalSelector;
+    DockSpace                             _dockSpace;
+    components::BlockControlsPanelContext _editPane;
+    std::unique_ptr<SignalSelector>       _remoteSignalSelector;
 
-    Dashboard* m_dashboard = nullptr;
+    Dashboard* _dashboard = nullptr;
 
-    void drawPlots(DigitizerUi::DashboardPage::Mode mode);
-    void drawGrid(float w, float h);
-    void drawGlobalLegend(const Mode& mode) noexcept;
-    void drawPlot(DigitizerUi::Dashboard::Plot& plot) noexcept;
+    // modal dialog state for new plot creation
+    bool        _showNewPlotModal  = false;
+    std::string _selectedChartType = "XYChart";
+
+    // deferred chart transmutation request (processed at start of next frame)
+    struct PendingTransmutation {
+        std::string chartId;
+        std::string newChartType;
+    };
+    std::optional<PendingTransmutation> _pendingTransmutation;
+
+    // deferred chart removal requests (processed at start of next frame)
+    std::vector<std::string> _pendingRemovals;
 
 public:
     DashboardPage();
@@ -60,16 +65,89 @@ public:
     void draw(Mode mode = Mode::View) noexcept;
     void setLayoutType(DockingLayoutType);
 
-    /* no optional of ref yet */ DigitizerUi::Dashboard::Plot* newPlot();
+    /* no optional of ref yet */ DigitizerUi::Dashboard::UIWindow* newUIBlock(std::string_view chartType = "XYChart");
+    void                                                           drawNewPlotModal();
 
     void setDashboard(Dashboard& dashboard) {
-        m_dashboard = std::addressof(dashboard);
+        _dashboard = std::addressof(dashboard);
 #ifndef OPENDIGITIZER_TEST
         // SignalSelector triggers RemoteSignalSources which uses opencmw::client::ClientContext
         // making self-contained tests difficult to write. Everything is tightly coupled and
         // this is the best place to break the dependency.
-        m_remoteSignalSelector = std::make_unique<SignalSelector>(dashboard.graphModel());
+        _remoteSignalSelector = std::make_unique<SignalSelector>(dashboard.graphModel);
 #endif
+        // set up g_addSinkToChart callback for D&D add operations
+        opendigitizer::charts::dnd::g_addSinkToChart = [this](std::string_view chartId, std::string_view sinkName) {
+            if (!_dashboard) {
+                return;
+            }
+            for (auto& uiWindow : _dashboard->uiWindows) {
+                if (uiWindow.block && uiWindow.block->uniqueName() == chartId) {
+                    auto names = grc_compat::getBlockSinkNames(uiWindow.block.get());
+                    if (std::find(names.begin(), names.end(), std::string(sinkName)) == names.end()) {
+                        names.push_back(std::string(sinkName));
+                        grc_compat::setBlockSinkNames(uiWindow.block.get(), names);
+                    }
+                    return;
+                }
+            }
+        };
+
+        // set up g_requestChartTransmutation callback for chart type changes
+        // transmutation is deferred to the start of next frame to avoid
+        // modifying/destroying charts during their draw() call
+        opendigitizer::charts::g_requestChartTransmutation = [this](std::string_view chartId, std::string_view newChartType) -> bool {
+            if (!_dashboard) {
+                return false;
+            }
+            // store request for deferred processing
+            _pendingTransmutation = PendingTransmutation{std::string(chartId), std::string(newChartType)};
+            return true;
+        };
+
+        // set up g_requestChartDuplication callback for "Duplicate Chart" menu item
+        opendigitizer::charts::g_requestChartDuplication = [this](std::string_view chartId) {
+            if (!_dashboard) {
+                return;
+            }
+            _dashboard->copyChart(chartId);
+        };
+
+        // set up g_requestChartRemoval callback for "Remove Chart" menu item
+        // removal is deferred to avoid modifying the chart collection during iteration
+        opendigitizer::charts::g_requestChartRemoval = [this](std::string_view chartId) { requestChartRemoval(chartId); };
+    }
+
+    void processPendingTransmutation() {
+        if (!_pendingTransmutation || !_dashboard) {
+            return;
+        }
+
+        auto request          = std::move(*_pendingTransmutation);
+        _pendingTransmutation = std::nullopt;
+
+        // find UIWindow by chartId and transmute
+        for (auto& uiWindow : _dashboard->uiWindows) {
+            if (uiWindow.block && uiWindow.block->uniqueName() == request.chartId) {
+                _dashboard->transmuteUIWindow(uiWindow, request.newChartType);
+                return;
+            }
+        }
+    }
+
+    void requestChartRemoval(std::string_view chartId) { _pendingRemovals.emplace_back(chartId); }
+
+    void processPendingRemovals() {
+        if (_pendingRemovals.empty() || !_dashboard) {
+            return;
+        }
+
+        for (const auto& chartId : _pendingRemovals) {
+            if (auto* uiWindow = _dashboard->findUIWindowByName(chartId)) {
+                _dashboard->deleteChart(uiWindow);
+            }
+        }
+        _pendingRemovals.clear();
     }
 };
 

--- a/src/ui/FlowgraphPage.cpp
+++ b/src/ui/FlowgraphPage.cpp
@@ -799,8 +799,8 @@ FlowgraphPage::~FlowgraphPage() = default;
 
 void FlowgraphPage::reset() {
     if (_dashboard) {
-        _dashboard->graphModel().rootBlock.childEdges.clear();
-        _dashboard->graphModel().rootBlock.childBlocks.clear();
+        _dashboard->graphModel.rootBlock.childEdges.clear();
+        _dashboard->graphModel.rootBlock.childBlocks.clear();
     }
 
     _editors.clear();
@@ -998,7 +998,7 @@ void FlowgraphPage::drawLocalYamlTab() {
             message.endpoint    = gr::scheduler::property::kGraphGRC;
             auto owner          = _editors.front().ownersForRoot();
             message.serviceName = owner.scheduler;
-            _dashboard->graphModel().sendMessage(std::move(message));
+            _dashboard->graphModel.sendMessage(std::move(message));
         }
     }
 
@@ -1007,11 +1007,11 @@ void FlowgraphPage::drawLocalYamlTab() {
         gr::Message message;
         message.cmd      = gr::message::Command::Set;
         message.endpoint = gr::scheduler::property::kGraphGRC;
-        message.data     = gr::property_map{{"value", _dashboard->graphModel().m_localFlowgraphGrc}};
-        _dashboard->graphModel().sendMessage(std::move(message));
+        message.data     = gr::property_map{{"value", _dashboard->graphModel.m_localFlowgraphGrc}};
+        _dashboard->graphModel.sendMessage(std::move(message));
     }
 
-    ImGui::InputTextMultiline("##grc", &_dashboard->graphModel().m_localFlowgraphGrc, ImGui::GetContentRegionAvail());
+    ImGui::InputTextMultiline("##grc", &_dashboard->graphModel.m_localFlowgraphGrc, ImGui::GetContentRegionAvail());
 }
 
 void FlowgraphPage::drawRemoteYamlTab(Dashboard::Service& service) {
@@ -1046,9 +1046,9 @@ void FlowgraphPage::draw() noexcept {
         if (!_editors.empty()) {
             _currentTabIsFlowGraph = true;
             drawNodeEditorTab();
-        } else if (!_dashboard->graphModel().rootBlock.blockUniqueName.empty()) {
+        } else if (!_dashboard->graphModel.rootBlock.blockUniqueName.empty()) {
             // We don't have an editor until the root graph is loaded
-            pushEditor("rootBlock node editor", _dashboard->graphModel(), std::addressof(_dashboard->graphModel().rootBlock));
+            pushEditor("rootBlock node editor", _dashboard->graphModel, std::addressof(_dashboard->graphModel.rootBlock));
         }
     }
 
@@ -1056,7 +1056,7 @@ void FlowgraphPage::draw() noexcept {
         drawLocalYamlTab();
     }
 
-    for (auto& service : _dashboard->remoteServices()) {
+    for (auto& service : _dashboard->services) {
         drawRemoteYamlTab(service);
     }
 }

--- a/src/ui/FlowgraphPage.hpp
+++ b/src/ui/FlowgraphPage.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <functional>
-#include <span>
 #include <stack>
 #include <vector>
 
@@ -17,10 +16,6 @@
 #include "GraphModel.hpp"
 
 struct TestState;
-
-namespace opendigitizer {
-struct ImPlotSinkModel;
-}
 
 namespace DigitizerUi {
 
@@ -193,9 +188,9 @@ public:
 
     void setDashboard(Dashboard* dashboard) {
         _dashboard = dashboard;
-        _newBlockSelector.setGraphModel(dashboard ? std::addressof(dashboard->graphModel()) : nullptr);
+        _newBlockSelector.setGraphModel(dashboard ? std::addressof(dashboard->graphModel) : nullptr);
         if (dashboard) {
-            _remoteSignalSelector = std::make_unique<SignalSelector>(dashboard->graphModel());
+            _remoteSignalSelector = std::make_unique<SignalSelector>(dashboard->graphModel);
         } else {
             _remoteSignalSelector.reset();
         }

--- a/src/ui/GraphModel.cpp
+++ b/src/ui/GraphModel.cpp
@@ -718,7 +718,7 @@ bool UiGraphModel::processMessage(const gr::Message& message) {
         targetBlock.block->handleChildBlockEmplaced(data);
 
     } else if (message.endpoint == scheduler::kBlockRemoved) {
-        targetBlock.block->handleChildBlockRemoved(uniqueName());
+        targetBlock.block->handleChildBlockRemoved(uniqueName("uniqueName"));
 
     } else if (message.endpoint == scheduler::kBlockReplaced) {
         targetBlock.block->handleChildBlockRemoved(uniqueName("replacedBlockUniqueName"));

--- a/src/ui/RemoteSignalSources.cpp
+++ b/src/ui/RemoteSignalSources.cpp
@@ -2,6 +2,9 @@
 
 #include "common/ImguiWrap.hpp"
 
+#include <charconv>
+#include <cstdlib>
+
 #include <misc/cpp/imgui_stdlib.h>
 
 void QueryFilterElement::drawFilterLine() {
@@ -91,9 +94,11 @@ void SignalList::update() {
         auto& strValue = it->filterText;
         if (it != filters.end() && strValue != "") {
             if constexpr (std::is_integral_v<std::remove_cvref_t<decltype(member(queryEntry))>>) {
-                member(queryEntry) = std::atoi(strValue.c_str());
+                std::remove_cvref_t<decltype(member(queryEntry))> val{};
+                std::from_chars(strValue.data(), strValue.data() + strValue.size(), val);
+                member(queryEntry) = val;
             } else if constexpr (std::is_floating_point_v<std::remove_cvref_t<decltype(member(queryEntry))>>) {
-                member(queryEntry) = std::stof(strValue);
+                member(queryEntry) = static_cast<std::remove_cvref_t<decltype(member(queryEntry))>>(std::strtod(strValue.c_str(), nullptr));
             } else {
                 member(queryEntry) = strValue;
             }

--- a/src/ui/assets/sampleDashboards/DemoDashboard.grc
+++ b/src/ui/assets/sampleDashboards/DemoDashboard.grc
@@ -26,7 +26,7 @@ blocks:
     parameters:
       name: sinesSink
       signal_name: value
-      signal_quantity: voltage
+      signal_quantity: sum voltage
       signal_unit: V
   - id: opendigitizer::ImPlotSink<gr::DataSet<float32>>
     parameters:
@@ -175,9 +175,25 @@ blocks:
       signal_name: beam intensity
       signal_quantity: BeamIntensity
       signal_unit: ppp
+  - id: opendigitizer::ImPlotSink<float32>
+    parameters:
+      name: sineSink1
+      color: 0x00C800
+      signal_name: sine 2Hz
+      signal_quantity: voltage
+      signal_unit: V
+  - id: opendigitizer::ImPlotSink<float32>
+    parameters:
+      name: sineSink3
+      color: 0xC800C8
+      signal_name: sine 5Hz
+      signal_quantity: voltage
+      signal_unit: V
 connections:
   - [sine source 1, 0, sum sigs, 0]
   - [sine source 3, 0, sum sigs, 1]
+  - [ sine source 1, 0, sineSink1, 0 ]
+  - [ sine source 3, 0, sineSink3, 0 ]
   - [sum sigs, 0, FFT, 0]
   - [sum sigs, 0, sinesSink, 0]
   - [FFT, 0, fftSink, 0]
@@ -198,8 +214,14 @@ dashboard:
     - name: IntensitySink
       block: IntensitySink
       port: 0
+    - name: sineSink1
+      block: sineSink1
+    - name: sineSink3
+      block: sineSink3
   plots:
-    - name: Plot 1
+    - name: Raw Signal
+      parameters:
+        show_legend: true
       axes:
         - axis: X
           min: NaN # enables auto-range
@@ -212,7 +234,21 @@ dashboard:
       sources:
         - sinesSink
       rect: [0, 0, 1, 1]
-    - name: Plot 2
+    - name: Correlation
+      type: opendigitizer::charts::YYChart
+      axes:
+        - axis: X
+          min: NaN
+          max: NaN
+        - axis: Y
+          min: NaN
+          max: NaN
+      sources:
+        - sineSink1
+        - sineSink3
+        - sinesSink
+      rect: [ 1, 0, 1, 1 ]
+    - name: FFT Spectrum
       axes:
         - axis: X
           min: 0.0001
@@ -224,8 +260,10 @@ dashboard:
           max: NaN
       sources:
         - fftSink
-      rect: [1, 0, 1, 1]
-    - name: Plot 3
+      rect: [ 2, 0, 1, 1 ]
+    - name: Function Generators
+      parameters:
+        n_history: 10000 # number of samples to plot
       axes:
         - axis: X
           min: NaN # auto-range min
@@ -241,4 +279,4 @@ dashboard:
       sources:
         - IntensitySink
         - DipoleCurrentSink
-      rect: [0, 1, 2, 1] # x, y, width, height
+      rect: [ 0, 1, 3, 1 ] # x, y, width, height - spans all 3 columns

--- a/src/ui/blocks/GlobalSignalLegend.hpp
+++ b/src/ui/blocks/GlobalSignalLegend.hpp
@@ -1,0 +1,145 @@
+#ifndef OPENDIGITIZER_GLOBAL_SIGNAL_LEGEND_HPP
+#define OPENDIGITIZER_GLOBAL_SIGNAL_LEGEND_HPP
+
+#include <functional>
+#include <string_view>
+
+#include <gnuradio-4.0/Block.hpp>
+
+#include "../charts/Chart.hpp"
+#include "../charts/SinkRegistry.hpp"
+#include "../common/ImguiWrap.hpp"
+
+namespace DigitizerUi {
+
+/// Global signal legend displaying all registered sinks from SinkRegistry.
+/// Supports left-click toggle, right-click settings, drag to charts, and drop from charts.
+struct GlobalSignalLegend : gr::Block<GlobalSignalLegend, gr::BlockingIO<false>, gr::Drawable<gr::UICategory::Toolbar, "ImGui">> {
+    using RightClickCallback = std::function<void(std::string_view sinkUniqueName)>;
+
+    enum class ClickResult { None, Left, Right };
+
+    GR_MAKE_REFLECTABLE(GlobalSignalLegend);
+
+    ImVec2             _legendSize{0.f, 0.f};
+    float              _paneWidth{800.f};
+    RightClickCallback _onRightClick;
+
+    GlobalSignalLegend() = default;
+    explicit GlobalSignalLegend(gr::property_map initParams) { std::ignore = initParams; }
+
+    void setRightClickCallback(RightClickCallback callback) { _onRightClick = std::move(callback); }
+    void setPaneWidth(float width) { _paneWidth = width; }
+
+    gr::work::Status draw(const gr::property_map& config = {}) noexcept {
+        // allow paneWidth to be passed via config
+        if (auto it = config.find("paneWidth"); it != config.end()) {
+            if (auto* val = std::get_if<float>(&it->second)) {
+                _paneWidth = *val;
+            }
+        }
+        _legendSize = drawLegend(_paneWidth, _onRightClick ? &_onRightClick : nullptr);
+        return gr::work::Status::OK;
+    }
+
+    [[nodiscard]] ImVec2 legendSize() const noexcept { return _legendSize; }
+
+    static ClickResult drawLegendItem(std::uint32_t color, std::string_view text, bool enabled = true) {
+        using namespace opendigitizer::charts;
+        ClickResult result = ClickResult::None;
+
+        const ImVec2 cursorPos = ImGui::GetCursorScreenPos();
+        const ImVec2 rectSize(ImGui::GetTextLineHeight() - 4, ImGui::GetTextLineHeight());
+
+        // draw color indicator
+        ImGui::GetWindowDrawList()->AddRectFilled(cursorPos + ImVec2(0, 2), cursorPos + rectSize - ImVec2(0, 2), rgbToImGuiABGR(color));
+
+        if (ImGui::InvisibleButton("##ColorBox", rectSize)) {
+            result = ClickResult::Left;
+        }
+        ImGui::SameLine();
+
+        // draw button text with transparent background
+        ImVec2 buttonSize(rectSize.x + ImGui::CalcTextSize(text.data()).x - 4, ImGui::GetTextLineHeight());
+
+        IMW::StyleColor buttonStyle(ImGuiCol_Button, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+        IMW::StyleColor hoveredStyle(ImGuiCol_ButtonHovered, ImVec4(0.0f, 0.0f, 0.0f, 0.1f));
+        IMW::StyleColor activeStyle(ImGuiCol_ButtonActive, ImVec4(0.0f, 0.0f, 0.0f, 0.2f));
+        IMW::StyleColor textStyle(ImGuiCol_Text, enabled ? ImGui::GetStyleColorVec4(ImGuiCol_Text) : ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+
+        if (ImGui::Button(text.data(), buttonSize)) {
+            result = ClickResult::Left;
+        }
+
+        if (ImGui::IsMouseReleased(ImGuiPopupFlags_MouseButtonRight & ImGuiPopupFlags_MouseButtonMask_) && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup)) {
+            result = ClickResult::Right;
+        }
+
+        return result;
+    }
+
+    ImVec2 drawLegend(float paneWidth, RightClickCallback* onRightClick) {
+        using namespace opendigitizer::charts;
+        ImVec2 legendSize{0.f, 0.f};
+        float  accumulatedWidth = paneWidth; // start at full width to force new line
+
+        {
+            IMW::Group group;
+
+            int index = 0;
+            SinkRegistry::instance().forEach([&](SignalSink& sink) {
+                IMW::ChangeId itemId(index++);
+
+                const auto        color = sink.color();
+                const std::string label = sink.signalName().empty() ? std::string(sink.name()) : std::string(sink.signalName());
+
+                // check if we need to wrap to next line
+                const auto widthEstimate = ImGui::CalcTextSize(label.c_str()).x + 20.f;
+                if ((accumulatedWidth + widthEstimate) < 0.9f * paneWidth) {
+                    ImGui::SameLine();
+                } else {
+                    accumulatedWidth = 0.f;
+                }
+
+                // draw the legend item
+                auto clickResult = drawLegendItem(color, label, sink.drawEnabled());
+
+                if (clickResult == ClickResult::Right && onRightClick) {
+                    (*onRightClick)(sink.uniqueName());
+                }
+                if (clickResult == ClickResult::Left) {
+                    sink.setDrawEnabled(!sink.drawEnabled());
+                }
+
+                accumulatedWidth += ImGui::GetItemRectSize().x;
+
+                // drag source - from global legend (empty source_chart_id = no removal needed)
+                if (auto dndSource = IMW::DragDropSource(ImGuiDragDropFlags_None)) {
+                    dnd::Payload payload{};
+                    opendigitizer::charts::dnd::copyToBuffer(payload.sink_name, label);
+                    // source_chart_id stays empty (dragging from legend = no chart to remove from)
+                    ImGui::SetDragDropPayload(dnd::kPayloadType, &payload, sizeof(payload));
+
+                    // draw preview
+                    drawLegendItem(color, label, sink.drawEnabled());
+                }
+            });
+        }
+
+        legendSize.x = ImGui::GetItemRectSize().x;
+        legendSize.y = std::max(5.f, ImGui::GetItemRectSize().y);
+
+        // drop target - accept drops from charts, signal removal via dnd::g_state
+        dnd::handleLegendDropTarget();
+
+        return legendSize;
+    }
+};
+
+} // namespace DigitizerUi
+
+// register GlobalSignalLegend with the GR4 block registry
+GR_REGISTER_BLOCK("DigitizerUi::GlobalSignalLegend", DigitizerUi::GlobalSignalLegend)
+inline auto registerGlobalSignalLegend = gr::registerBlock<DigitizerUi::GlobalSignalLegend>(gr::globalBlockRegistry());
+
+#endif // OPENDIGITIZER_GLOBAL_SIGNAL_LEGEND_HPP

--- a/src/ui/blocks/ImPlotSink.hpp
+++ b/src/ui/blocks/ImPlotSink.hpp
@@ -2,8 +2,20 @@
 #define OPENDIGITIZER_IMPLOTSINK_HPP
 
 #include <imgui.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <expected>
+#include <format>
+#include <functional>
 #include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
 #include <unordered_map>
+#include <vector>
 
 #include <gnuradio-4.0/Block.hpp>
 #include <gnuradio-4.0/BlockModel.hpp>
@@ -18,17 +30,19 @@
 
 #include "../components/ColourManager.hpp"
 
-#include "../common/ImguiWrap.hpp"
 #include <implot.h>
 
 #include "conversion.hpp"
-#include "meta.hpp"
 
+#include "../charts/Chart.hpp"
+#include "../charts/SignalSink.hpp"
+#include "../charts/SinkRegistry.hpp"
 #include "../utils/EmscriptenHelper.hpp"
 
 namespace opendigitizer {
 
-constexpr std::string_view kFishyTagKey = "ui_fishy_tag";
+using charts::AxisScale;
+using charts::tags::kFishyTagKey;
 
 struct TagData {
     double           timestamp;
@@ -48,328 +62,42 @@ T getValueOrDefault(const gr::property_map& map, const std::string& key, const T
     return defaultValue;
 }
 
-inline ImVec2 plotVerticalTagLabel(const std::string_view& label, double xData, const ImPlotRect& plotLimits, bool plotLeft, double fractionBelowTop = 0.02, double sizeRatioLimit = 0.75) {
-    const double yRange   = std::abs(plotLimits.Y.Max - plotLimits.Y.Min);
-    const double ySafeTop = plotLimits.Y.Max - fractionBelowTop * yRange;
-    const double yClamped = std::clamp(ySafeTop, plotLimits.Y.Min, plotLimits.Y.Max);
-    ImVec2       pixelPos = ImPlot::PlotToPixels(xData, yClamped);
-    if (label.empty()) {
-        return pixelPos;
-    }
-
-    const double yPixelRange = static_cast<double>(std::abs(ImPlot::PlotToPixels(0.0, plotLimits.Y.Max).y - ImPlot::PlotToPixels(0.0, plotLimits.Y.Min).y));
-    ImVec2       textSize    = ImGui::CalcTextSize(label.data());
-    if (static_cast<double>(textSize.x) > sizeRatioLimit * yPixelRange) {
-        return pixelPos; // the text is too large relative to the vertical scale
-    }
-
-    ImVec2 pixOffset{plotLeft ? (-textSize.y + 2.0f) : (+5.0f), textSize.x};
-    ImPlot::PlotText(label.data(), xData, yClamped, pixOffset, static_cast<int>(ImPlotTextFlags_Vertical) | static_cast<int>(ImPlotItemFlags_NoFit));
-    return {pixelPos.x + pixOffset.x + textSize.y, pixelPos.y};
-}
-
-template<typename T>
-static double transformX(double xVal, DigitizerUi::AxisScale axisScale, double xMin, double xMax) {
-    using enum DigitizerUi::AxisScale;
-    switch (axisScale) {
-    case Time: return xVal;
-    case LinearReverse:
-        if constexpr (gr::DataSetLike<T>) {
-            return xVal;
-        } else {
-            return xVal - xMax;
-        }
-    case Linear:
-    case Log10:
-    case SymLog:
-    default: {
-        if constexpr (gr::DataSetLike<T>) {
-            return xVal;
-        } else {
-            return xVal - xMin;
-        }
-    }
-    }
-}
-
-template<typename T>
-void drawAndPruneTags(std::deque<TagData>& tagValues, double minX, double maxX, DigitizerUi::AxisScale axisScale, const ImVec4& color) {
-    using enum DigitizerUi::AxisScale;
-    using namespace DigitizerUi;
-
-    std::erase_if(tagValues, [=](const auto& tag) { return static_cast<double>(tag.timestamp) < std::min(minX, maxX); });
-    if (tagValues.empty()) {
-        return;
-    }
-
-    IMW::Font   titleFont(LookAndFeel::instance().fontTiny[LookAndFeel::instance().prototypeMode]);
-    const float fontHeight  = ImGui::GetFontSize();
-    const auto  plotLimits  = ImPlot::GetPlotLimits(IMPLOT_AUTO, IMPLOT_AUTO);
-    const float yPixelRange = std::abs(ImPlot::PlotToPixels(0.0, plotLimits.Y.Max).y - ImPlot::PlotToPixels(0.0, plotLimits.Y.Min).y);
-    ImGui::PushStyleColor(ImGuiCol_Text, color);
-    float lastTextPixelX = ImPlot::PlotToPixels(transformX<T>(std::min(minX, maxX), axisScale, minX, maxX), 0.0).x;
-    float lastAxisPixelX = ImPlot::PlotToPixels(transformX<T>(std::max(minX, maxX), axisScale, minX, maxX), 0.0).x;
-    for (const auto& tag : tagValues) {
-        double      xTagPosition = transformX<T>(tag.timestamp, axisScale, minX, maxX);
-        const float xPixelPos    = ImPlot::PlotToPixels(xTagPosition, 0.0).x;
-
-        if (tag.map.contains(kFishyTagKey)) {
-            ImPlot::SetNextLineStyle(ImVec4(1.0, 0.0, 1.0, 1.0));
-        } else {
-            ImPlot::SetNextLineStyle(color);
-        }
-        ImPlot::PlotInfLines("", &xTagPosition, 1, ImPlotInfLinesFlags_None);
-
-        // suppress tag labels if it is too close to the previous one or close to the extremities
-        if ((xPixelPos - lastTextPixelX) > 1.5f * fontHeight && (lastAxisPixelX - xPixelPos) > 2.0f * fontHeight) {
-            const std::string triggerLabel     = getValueOrDefault<std::string>(tag.map, gr::tag::TRIGGER_NAME.shortKey(), "TRIGGER");
-            const ImVec2      triggerLabelSize = ImGui::CalcTextSize(triggerLabel.c_str());
-
-            if (triggerLabelSize.x < 0.75f * yPixelRange) {
-                lastTextPixelX = plotVerticalTagLabel(triggerLabel, xTagPosition, plotLimits, true).x;
-            } else {
-                continue;
-            }
-
-            const std::string triggerCtx = getValueOrDefault<std::string>(tag.map, gr::tag::CONTEXT.shortKey(), "");
-            if (!triggerCtx.empty() && triggerCtx != triggerLabel) {
-                const ImVec2 triggerCtxLabelSize = ImGui::CalcTextSize(triggerCtx.c_str());
-                if (triggerCtxLabelSize.x < 0.75f * yPixelRange) {
-                    lastTextPixelX = plotVerticalTagLabel(triggerCtx, xTagPosition, plotLimits, false).x;
-                }
-            }
-        } // plot labels
-    }
-    ImGui::PopStyleColor();
-}
-
-template<typename T>
-void drawDataSetTimingEvents(const gr::DataSet<T>& dataset, DigitizerUi::AxisScale axisScale, const ImVec4& color) {
-    using enum DigitizerUi::AxisScale;
-    if (dataset.timing_events.empty() || dataset.axisValues(0).empty()) {
-        return;
-    }
-
-    // Let's assume axisValues(0) is our main X-axis
-    // We'll do a front/back min/max for pruning
-    const auto&  xAxisSpan = dataset.axisValues(0);
-    const double minX      = static_cast<double>(xAxisSpan.front());
-    const double maxX      = static_cast<double>(xAxisSpan.back());
-
-    ImGui::PushStyleColor(ImGuiCol_Text, color);
-    float       lastTextPixelX = ImPlot::PlotToPixels(transformX<gr::DataSet<T>>(std::min(minX, maxX), axisScale, minX, maxX), 0.0).x;
-    float       lastAxisPixelX = ImPlot::PlotToPixels(transformX<gr::DataSet<T>>(std::max(minX, maxX), axisScale, minX, maxX), 0.0).x;
-    const float fontHeight     = ImGui::GetFontSize();
-    const auto  plotLimits     = ImPlot::GetPlotLimits(IMPLOT_AUTO, IMPLOT_AUTO);
-    const float yPixelRange    = std::abs(ImPlot::PlotToPixels(0.0, plotLimits.Y.Max).y - ImPlot::PlotToPixels(0.0, plotLimits.Y.Min).y);
-    for (std::size_t sig_i = 0; sig_i < dataset.timing_events.size(); ++sig_i) {
-        auto& eventsForSig = dataset.timing_events[sig_i];
-
-        for (auto& [xIndex, tagMap] : eventsForSig) {
-            if (xIndex < 0 || static_cast<std::size_t>(xIndex) >= xAxisSpan.size()) {
-                continue; // out-of-bounds
-            }
-
-            double      xVal         = static_cast<double>(xAxisSpan[static_cast<std::size_t>(xIndex)]);
-            double      xTagPosition = transformX<gr::DataSet<T>>(xVal, axisScale, minX, maxX);
-            const float xPixelPos    = ImPlot::PlotToPixels(xTagPosition, 0.0).x;
-            ImPlot::SetNextLineStyle(color);
-            ImPlot::PlotInfLines("", &xTagPosition, 1, ImPlotInfLinesFlags_None);
-
-            // suppress tag labels if it is too close to the previous one or close to the extremities
-            if ((xPixelPos - lastTextPixelX) > 1.5f * fontHeight && (lastAxisPixelX - xPixelPos) > 2.0f * fontHeight) {
-                const std::string triggerLabel     = getValueOrDefault<std::string>(tagMap, gr::tag::TRIGGER_NAME.shortKey(), "TRIGGER");
-                const ImVec2      triggerLabelSize = ImGui::CalcTextSize(triggerLabel.c_str());
-                if (triggerLabelSize.x < 0.75f * yPixelRange) {
-                    lastTextPixelX = plotVerticalTagLabel(triggerLabel, xTagPosition, plotLimits, true).x;
-                } else {
-                    continue;
-                }
-
-                const std::string triggerCtx = getValueOrDefault<std::string>(tagMap, gr::tag::CONTEXT.shortKey(), "");
-                if (!triggerCtx.empty() && triggerCtx != triggerLabel) {
-                    const ImVec2 triggerCtxLabelSize = ImGui::CalcTextSize(triggerCtx.c_str());
-                    if (triggerCtxLabelSize.x < 0.75f * yPixelRange) {
-                        lastTextPixelX = plotVerticalTagLabel(triggerCtx, xTagPosition, plotLimits, false).x;
-                    }
-                }
-            } // plot labels
-        }
-    }
-
-    ImGui::PopStyleColor();
-}
-
-inline void setAxisFromConfig(const gr::property_map& config) {
-    static constexpr ImAxis xAxes[] = {ImAxis_X1, ImAxis_X2, ImAxis_X3};
-    static constexpr ImAxis yAxes[] = {ImAxis_Y1, ImAxis_Y2, ImAxis_Y3};
-    ImPlot::SetAxis(xAxes[std::clamp(getValueOrDefault<std::size_t>(config, "xAxisID", 0UZ), 0UZ, 2UZ)]);
-    ImPlot::SetAxis(yAxes[std::clamp(getValueOrDefault<std::size_t>(config, "yAxisID", 0UZ), 0UZ, 2UZ)]);
-}
-
-struct ImPlotSinkModel {
-    std::string uniqueName;
-
-    ImPlotSinkModel(std::string _uniqueName) : uniqueName(std::move(_uniqueName)) {}
-
-    virtual ~ImPlotSinkModel() {}
-
-    virtual gr::work::Status draw(const gr::property_map& config = {}) noexcept = 0;
-
-    virtual std::string name() const                    = 0;
-    virtual void        setName(std::string name)       = 0;
-    virtual std::string signalName() const              = 0;
-    virtual void        setSignalName(std::string name) = 0;
-
-    virtual gr::SettingsBase& settings() const = 0;
-
-    virtual gr::work::Result work(std::size_t count) = 0;
-    virtual gr::work::Status invokeWork()            = 0;
-
-    virtual void* raw() const = 0;
-
-    virtual std::uint32_t color() const = 0;
-
-    bool isVisible = true;
-};
-
-class ImPlotSinkManager {
-private:
-    ImPlotSinkManager() = default;
-
-    ~ImPlotSinkManager() {
-        // Clear it now, otherwise sink dtor calls ImPlotSinkManager::unregisterPlotSink() but
-        // ImPlotSinkManager would be partially-deleted already
-        _knownSinks.clear();
-    }
-
-    ImPlotSinkManager(const ImPlotSinkManager&)            = delete;
-    ImPlotSinkManager& operator=(const ImPlotSinkManager&) = delete;
-
-    std::unordered_map<std::string, std::unique_ptr<ImPlotSinkModel>>      _knownSinks;
-    std::unordered_map<void*, std::function<void(ImPlotSinkModel&, bool)>> _listeners;
-
-    template<typename TBlock>
-    struct SinkWrapper : ImPlotSinkModel {
-        SinkWrapper(TBlock* _block) : ImPlotSinkModel(_block->unique_name), block(_block) {}
-
-        gr::work::Status draw(const gr::property_map& config = {}) noexcept override { return block->draw(config); }
-
-        std::string name() const override { return block->name; }
-        void        setName(std::string name) override { block->name = std::move(name); }
-        std::string signalName() const override { return block->signal_name; }
-        void        setSignalName(std::string name) override { block->signal_name = std::move(name); }
-
-        gr::SettingsBase& settings() const override { return block->settings(); }
-
-        gr::work::Result work(std::size_t count) override { return block->work(count); }
-        gr::work::Status invokeWork() override { return block->invokeWorkWithGuard(); }
-
-        void* raw() const override { return static_cast<void*>(block); }
-
-        std::uint32_t color() const override { return block->_colour.colour(); }
-
-        TBlock* block = nullptr;
-    };
-
-    void notifyListeners(ImPlotSinkModel& sink, bool isAdded) {
-        for (auto& [_, listener] : _listeners) {
-            listener(sink, isAdded);
-        }
-    }
-
-public:
-    static ImPlotSinkManager& instance() {
-        static ImPlotSinkManager s_instance;
-        return s_instance;
-    }
-
-    template<typename TBlock>
-    void registerPlotSink(TBlock* block) {
-        auto& wrapper = _knownSinks[block->unique_name];
-        if (wrapper != nullptr) {
-            return;
-        }
-        wrapper = std::make_unique<SinkWrapper<TBlock>>(block);
-        notifyListeners(*wrapper, true);
-    }
-
-    template<typename TBlock>
-    void unregisterPlotSink(TBlock* block) {
-        // might not exist because registerPlotSink() isn't called in ctor but later
-        auto it = _knownSinks.find(block->unique_name);
-        if (it != _knownSinks.end()) {
-            notifyListeners(*it->second, false);
-            _knownSinks.erase(it);
-        }
-    }
-
-    template<typename Pred>
-    ImPlotSinkModel* findSink(Pred pred) const {
-        auto it = std::ranges::find_if(_knownSinks, [&](const auto& kvp) { return pred(*kvp.second.get()); });
-        if (it == _knownSinks.cend()) {
-            return nullptr;
-        }
-        return it->second.get();
-    }
-
-    template<typename Fn>
-    void forEach(Fn function) {
-        for (const auto& [_, sinkPtr] : _knownSinks) {
-            function(*sinkPtr.get());
-        }
-    }
-
-    void addListener(void* owner, std::function<void(ImPlotSinkModel&, bool)> listener) { _listeners[owner] = std::move(listener); }
-    void removeListener(void* owner) { _listeners.erase(owner); }
-};
-
-template<typename TBlock>
-using ImPlotSinkBase = gr::Block<TBlock, gr::BlockingIO<false>, gr::Drawable<gr::UICategory::ChartPane, "ImGui">>;
-
-using namespace gr;
+using charts::tags::drawDataSetTimingEvents;
+using charts::tags::drawTags;
 
 GR_REGISTER_BLOCK(opendigitizer::ImPlotSink, float, double, gr::DataSet<float>, gr::DataSet<double>)
 
-// TODO: use on_scope_exit from gr4/meta/utils.hpp (update of GR4 is needed)
-namespace details {
-template<typename Fn>
-struct on_scope_exit {
-    Fn function;
-
-    on_scope_exit(Fn fn) : function(std::move(fn)) {}
-
-    ~on_scope_exit() { function(); };
-};
-} // namespace details
-
 template<typename T>
-struct ImPlotSink : ImPlotSinkBase<ImPlotSink<T>> {
-    using ValueType = gr::meta::fundamental_base_value_type_t<T>;
-    // optional shortening
+struct ImPlotSink : gr::Block<ImPlotSink<T>, gr::Drawable<gr::UICategory::ChartPane, "ImGui">> {
+    using ValueType                   = gr::meta::fundamental_base_value_type_t<T>;
+    static constexpr bool IsStreaming = std::is_arithmetic_v<T>;
+    static constexpr bool IsDataSet   = gr::DataSetLike<T>;
+
     template<typename U, gr::meta::fixed_string description = "", typename... Arguments>
     using A = gr::Annotated<U, description, Arguments...>;
 
-    PortIn<T> in;
+    gr::PortIn<T> in;
 
-    ManagedColour                                                                                                                                         _colour;
-    A<uint32_t, "plot color", Doc<"RGB color for the plot">>                                                                                              color         = 0U;
-    A<gr::Size_t, "required buffer size", Doc<"Minimum number of samples to retain">>                                                                     required_size = gr::DataSetLike<T> ? 10U : 2048U; // TODO: make this a multi-consumer/vector property
-    A<std::string, "signal name", Visible, Doc<"Human-readable identifier for the signal">>                                                               signal_name;
-    A<std::string, "abscissa quantity", Visible, Doc<"Physical quantity of the primary (X) axis">>                                                        abscissa_quantity = "time";
-    A<std::string, "abscissa unit", Visible, Doc<"Unit of measurement of the primary (X) axis">>                                                          abscissa_unit     = "s";
-    A<std::string, "signal quantity", Visible, Doc<"Physical quantity represented by the signal">>                                                        signal_quantity;
-    A<std::string, "signal unit", Visible, Doc<"Unit of measurement for the signal values">>                                                              signal_unit;
-    A<float, "signal min", Doc<"Minimum expected value for the signal">, Limits<std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max()>> signal_min     = std::numeric_limits<float>::lowest();
-    A<float, "signal max", Doc<"Maximum expected value for the signal">, Limits<std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max()>> signal_max     = std::numeric_limits<float>::max();
-    A<float, "sample rate", Visible, Doc<"Sampling frequency in Hz">, Unit<"Hz">, Limits<float(0), std::numeric_limits<float>::max()>>                    sample_rate    = 1000.0f;
-    A<gr::Size_t, "dataset index", Visible, Doc<"Index of the dataset, if applicable">>                                                                   dataset_index  = std::numeric_limits<gr::Size_t>::max();
-    A<gr::Size_t, "history length", Doc<"Number of samples retained for historical visualization">>                                                       n_history      = 3U;
-    A<float, "history offset", Doc<"Time offset for historical data display">, Unit<"s">, Limits<float(0.0), std::numeric_limits<float>::max()>>          history_offset = 0.01f;
-    A<bool, "plot tags", Doc<"true: draw the timing tags">>                                                                                               plot_tags      = true;
+    ManagedColour                                                                                                                                                 _colour;
+    A<uint32_t, "plot color", gr::Doc<"RGB color for the plot">>                                                                                                  color         = 0U;
+    A<gr::Size_t, "required buffer size", gr::Doc<"Minimum number of samples to retain">>                                                                         required_size = gr::DataSetLike<T> ? 10U : 2048U;
+    A<std::string, "signal name", gr::Visible, gr::Doc<"Human-readable identifier for the signal">>                                                               signal_name;
+    A<std::string, "abscissa quantity", gr::Visible, gr::Doc<"Physical quantity of the primary (X) axis">>                                                        abscissa_quantity = "time";
+    A<std::string, "abscissa unit", gr::Visible, gr::Doc<"Unit of measurement of the primary (X) axis">>                                                          abscissa_unit     = "s";
+    A<std::string, "signal quantity", gr::Visible, gr::Doc<"Physical quantity represented by the signal">>                                                        signal_quantity;
+    A<std::string, "signal unit", gr::Visible, gr::Doc<"Unit of measurement for the signal values">>                                                              signal_unit;
+    A<float, "signal min", gr::Doc<"Minimum expected value for the signal">, gr::Limits<std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max()>> signal_min     = std::numeric_limits<float>::lowest();
+    A<float, "signal max", gr::Doc<"Maximum expected value for the signal">, gr::Limits<std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max()>> signal_max     = std::numeric_limits<float>::max();
+    A<float, "sample rate", gr::Visible, gr::Doc<"Sampling frequency in Hz">, gr::Unit<"Hz">, gr::Limits<float(0), std::numeric_limits<float>::max()>>            sample_rate    = 1000.0f;
+    A<gr::Size_t, "dataset index", gr::Visible, gr::Doc<"Index of the dataset, if applicable">>                                                                   dataset_index  = std::numeric_limits<gr::Size_t>::max();
+    A<gr::Size_t, "history length", gr::Doc<"Number of samples retained for historical visualization">>                                                           n_history      = 3U;
+    A<float, "history offset", gr::Doc<"Time offset for historical data display">, gr::Unit<"s">, gr::Limits<float(0.0), std::numeric_limits<float>::max()>>      history_offset = 0.01f;
+    A<bool, "plot tags", gr::Doc<"true: draw the timing tags">>                                                                                                   plot_tags      = true;
+    A<std::uint8_t, "line style", gr::Visible, gr::Doc<"Line drawing style: 0=Solid, 1=Dashed, 2=Dotted, 3=DashDot, 4=None">>                                     line_style     = 0U;
+    A<float, "line width", gr::Visible, gr::Doc<"Line width in pixels">, gr::Unit<"px">, gr::Limits<float(0.1), float(10.0)>>                                     line_width     = 1.0f;
 
     GR_MAKE_REFLECTABLE(ImPlotSink, in, color, required_size, signal_name, abscissa_quantity, abscissa_unit, signal_quantity, signal_unit, signal_min, signal_max, sample_rate, //
-        dataset_index, n_history, history_offset, plot_tags);
+        dataset_index, n_history, history_offset, plot_tags, line_style, line_width);
 
     double _xUtcOffset = [] {
         using namespace std::chrono;
@@ -384,13 +112,34 @@ struct ImPlotSink : ImPlotSinkBase<ImPlotSink<T>> {
     double      _sample_period = 1.0 / static_cast<double>(sample_rate);
     std::size_t _sample_count  = 0UZ;
 
-    // true while either work() or draw() is running; synchronizes calls between the two threads:
-    // work() executes in the scheduler thread when the tab is invisible, draw() executes in the UI thread when the tab is visible
-    std::atomic_flag _isWorkRunning = false;
+    // shared mutex for thread-safe data access between processBulk() and draw()
+    // shared_ptr so SinkAdapter can safely hold a reference that outlives the block
+    std::shared_ptr<std::mutex> _dataMutex = std::make_shared<std::mutex>();
 
-    ImPlotSink(gr::property_map initParameters) : ImPlotSinkBase<ImPlotSink<T>>(std::move(initParameters)) {}
+    // capacity request tracking with auto-expiry
+    struct CapacityRequest {
+        std::size_t                                        capacity;
+        std::chrono::time_point<std::chrono::steady_clock> expiry_time;
+    };
+    std::unordered_map<std::string, CapacityRequest> _capacityRequests;
 
-    ~ImPlotSink() { ImPlotSinkManager::instance().unregisterPlotSink(this); }
+    // DataSet cache for float conversion
+    mutable std::vector<gr::DataSet<float>> _dsCache;
+
+    // Y values cache for float conversion (used by getY() when T != float)
+    mutable std::vector<float> _yFloatCache;
+
+    // Adapter for SinkRegistry registration (shared ownership with registry)
+    std::shared_ptr<SignalSink> _sinkAdapter;
+
+    ImPlotSink(gr::property_map initParameters) : gr::Block<ImPlotSink<T>, gr::Drawable<gr::UICategory::ChartPane, "ImGui">>(std::move(initParameters)) {}
+
+    ~ImPlotSink() {
+        if (_sinkAdapter) {
+            static_cast<SinkAdapter<ImPlotSink<T>>*>(_sinkAdapter.get())->invalidate();
+            charts::SinkRegistry::instance().unregisterSink(this->unique_name);
+        }
+    }
 
     void settingsChanged(const gr::property_map& /* oldSettings */, const gr::property_map& newSettings) {
         if (newSettings.contains("color") || color == 0U) {
@@ -402,48 +151,362 @@ struct ImPlotSink : ImPlotSinkBase<ImPlotSink<T>> {
             color = _colour.colour();
         }
 
-        if (_xValues.capacity() != required_size) {
-            _xValues.resize(required_size);
-            _tagValues.clear();
-        }
-        if (_yValues.capacity() != required_size) {
-            _yValues.resize(required_size);
-            _tagValues.clear();
+        {
+            std::lock_guard lock(*_dataMutex);
+            if (_xValues.capacity() != required_size || _yValues.capacity() != required_size) {
+                _xValues.resize(required_size);
+                _yValues.resize(required_size);
+                _tagValues.clear();
+            }
         }
 
         _sample_period = 1.0 / static_cast<double>(sample_rate);
-        ImPlotSinkManager::instance().registerPlotSink(this);
+
+        // Register with SinkRegistry (only once)
+        if (!_sinkAdapter) {
+            _sinkAdapter = std::make_shared<SinkAdapter<ImPlotSink<T>>>(*this);
+            charts::SinkRegistry::instance().registerSink(_sinkAdapter);
+        }
     }
 
-    template<typename = void>
-    gr::work::Result work(std::size_t requestedWork = std::numeric_limits<std::size_t>::max()) noexcept {
-        if (isTabVisible()) {
-            return {requestedWork, 0uz, gr::work::Status::OK};
+    [[nodiscard]] std::string_view signalName() const noexcept { return signal_name.value.empty() ? this->name.value : signal_name.value; }
+    [[nodiscard]] float            sampleRate() const noexcept { return sample_rate; }
+    [[nodiscard]] LineStyle        lineStyle() const noexcept { return static_cast<LineStyle>(std::min(line_style.value, std::uint8_t{4})); }
+    [[nodiscard]] float            lineWidth() const noexcept { return line_width; }
+
+    [[nodiscard]] std::string_view signalQuantity() const noexcept { return signal_quantity; }
+    [[nodiscard]] std::string_view signalUnit() const noexcept { return signal_unit; }
+    [[nodiscard]] std::string_view abscissaQuantity() const noexcept { return abscissa_quantity; }
+    [[nodiscard]] std::string_view abscissaUnit() const noexcept { return abscissa_unit; }
+    [[nodiscard]] float            signalMin() const noexcept { return signal_min; }
+    [[nodiscard]] float            signalMax() const noexcept { return signal_max; }
+
+    [[nodiscard]] std::size_t totalSampleCount() const noexcept { return _sample_count; }
+
+    [[nodiscard]] std::size_t size() const noexcept {
+        if constexpr (IsStreaming) {
+            return _xValues.size();
+        } else if constexpr (IsDataSet) {
+            if (_yValues.empty()) {
+                return 0;
+            }
+            const auto& ds = _yValues.at(0);
+            if (ds.axis_values.empty()) {
+                return 0;
+            }
+            return ds.axis_values[0].size();
         }
-        if (_isWorkRunning.test_and_set(std::memory_order_acquire)) {
-            return {requestedWork, 0uz, gr::work::Status::OK};
-        }
-        details::on_scope_exit _   = [&] { _isWorkRunning.clear(std::memory_order_release); };
-        auto                   res = this->workInternal(requestedWork);
-        return res;
+        return 0;
     }
 
-    gr::work::Status invokeWorkWithGuard() {
-        if (_isWorkRunning.test_and_set(std::memory_order_acquire)) {
-            return gr::work::Status::OK;
+    [[nodiscard]] double xAt(std::size_t i) const {
+        if constexpr (IsStreaming) {
+            return _xValues.get_span(0)[i];
+        } else if constexpr (IsDataSet) {
+            if (_yValues.empty()) {
+                return 0.0;
+            }
+            const auto& ds = _yValues.at(0);
+            if (ds.axis_values.empty() || i >= ds.axis_values[0].size()) {
+                return 0.0;
+            }
+            return static_cast<double>(ds.axis_values[0][i]);
         }
-        details::on_scope_exit _ = [&] { _isWorkRunning.clear(std::memory_order_release); };
-        return this->invokeWork();
+        return 0.0;
     }
 
-    constexpr void processOne(const T& input) noexcept {
+    [[nodiscard]] float yAt(std::size_t i) const {
+        if constexpr (IsStreaming) {
+            return static_cast<float>(_yValues.get_span(0)[i]);
+        } else if constexpr (IsDataSet) {
+            if (_yValues.empty()) {
+                return 0.0f;
+            }
+            const auto& ds         = _yValues.at(0);
+            auto        signalIdx  = static_cast<std::size_t>(dataset_index);
+            const auto  numSignals = ds.size();
+            if (numSignals == 0) {
+                return 0.0f;
+            }
+            if (signalIdx >= numSignals) {
+                signalIdx = 0;
+            }
+            auto signalValues = ds.signalValues(signalIdx);
+            if (i >= signalValues.size()) {
+                return 0.0f;
+            }
+            return static_cast<float>(signalValues[i]);
+        }
+        return 0.0f;
+    }
+
+    [[nodiscard]] PlotData plotData() const {
+        if constexpr (IsStreaming) {
+            static auto getter = +[](int idx, void* userData) -> PlotPoint {
+                auto* self  = static_cast<const ImPlotSink*>(userData);
+                auto  xSpan = self->_xValues.get_span(0);
+                auto  ySpan = self->_yValues.get_span(0);
+                return {xSpan[static_cast<std::size_t>(idx)], static_cast<double>(ySpan[static_cast<std::size_t>(idx)])};
+            };
+            return {getter, const_cast<ImPlotSink*>(this), static_cast<int>(_xValues.size())};
+        } else if constexpr (IsDataSet) {
+            static auto getter = +[](int idx, void* userData) -> PlotPoint {
+                auto* self = static_cast<const ImPlotSink*>(userData);
+                return {self->xAt(static_cast<std::size_t>(idx)), static_cast<double>(self->yAt(static_cast<std::size_t>(idx)))};
+            };
+            return {getter, const_cast<ImPlotSink*>(this), static_cast<int>(size())};
+        }
+        return {nullptr, nullptr, 0};
+    }
+
+    [[nodiscard]] bool        hasDataSets() const noexcept { return IsDataSet && _yValues.size() > 0; }
+    [[nodiscard]] std::size_t dataSetCount() const noexcept { return IsDataSet ? _yValues.size() : 0; }
+
+    [[nodiscard]] std::span<const gr::DataSet<float>> dataSets() const {
+        if constexpr (IsDataSet) {
+            auto span = _yValues.get_span(0);
+            if constexpr (std::is_same_v<T, gr::DataSet<float>>) {
+                return span;
+            } else {
+                _dsCache.clear();
+                for (const auto& ds : span) {
+                    gr::DataSet<float> converted;
+                    converted.timestamp    = ds.timestamp;
+                    converted.signal_names = ds.signal_names;
+                    converted.signal_units = ds.signal_units;
+                    converted.axis_names   = ds.axis_names;
+                    converted.axis_units   = ds.axis_units;
+                    converted.extents      = ds.extents;
+                    converted.signal_values.assign(ds.signal_values.begin(), ds.signal_values.end());
+                    for (const auto& av : ds.axis_values) {
+                        converted.axis_values.emplace_back(av.begin(), av.end());
+                    }
+                    _dsCache.push_back(std::move(converted));
+                }
+                return _dsCache;
+            }
+        }
+        return {};
+    }
+
+    [[nodiscard]] bool hasStreamingTags() const noexcept { return IsStreaming && !_tagValues.empty(); }
+
+    [[nodiscard]] std::pair<double, double> tagTimeRange() const noexcept {
+        if constexpr (IsStreaming) {
+            if (_tagValues.empty()) {
+                return {0.0, 0.0};
+            }
+            return {_tagValues.front().timestamp, _tagValues.back().timestamp};
+        }
+        return {0.0, 0.0};
+    }
+
+    void forEachTag(std::function<void(double, const gr::property_map&)> callback) const {
+        if constexpr (IsStreaming) {
+            for (const auto& tag : _tagValues) {
+                callback(tag.timestamp, tag.map);
+            }
+        }
+    }
+
+    [[nodiscard]] double timeFirst() const noexcept {
+        if constexpr (IsStreaming) {
+            return _xValues.empty() ? 0.0 : _xValues.get_span(0).front();
+        }
+        return 0.0;
+    }
+
+    [[nodiscard]] double timeLast() const noexcept {
+        if constexpr (IsStreaming) {
+            return _xValues.empty() ? 0.0 : _xValues.get_span(0).back();
+        }
+        return 0.0;
+    }
+
+    [[nodiscard]] std::size_t bufferCapacity() const noexcept { return static_cast<std::size_t>(required_size); }
+
+    void requestCapacity(std::string_view source, std::size_t capacity, std::chrono::seconds timeout = std::chrono::seconds{60}) {
+        std::lock_guard lock(*_dataMutex);
+
+        auto expiry_time                       = std::chrono::steady_clock::now() + timeout;
+        _capacityRequests[std::string(source)] = CapacityRequest{capacity, expiry_time};
+
+        // recalculate required_size from all active requests (supports both increase and decrease)
+        std::size_t maxCapacity = gr::DataSetLike<T> ? 10UZ : 2048UZ;
+        for (const auto& [_, request] : _capacityRequests) {
+            maxCapacity = std::max(maxCapacity, request.capacity);
+        }
+        if (maxCapacity != static_cast<std::size_t>(required_size)) {
+            required_size = static_cast<gr::Size_t>(maxCapacity);
+            _xValues.resize(required_size);
+            _yValues.resize(required_size);
+        }
+    }
+
+    void expireCapacityRequests() {
+        std::lock_guard lock(*_dataMutex);
+        auto            now = std::chrono::steady_clock::now();
+
+        std::erase_if(_capacityRequests, [now](const auto& pair) { return pair.second.expiry_time < now; });
+
+        // Recalculate required_size from remaining requests
+        std::size_t maxCapacity = gr::DataSetLike<T> ? 10UZ : 2048UZ; // minimum default
+        for (const auto& [_, request] : _capacityRequests) {
+            maxCapacity = std::max(maxCapacity, request.capacity);
+        }
+        required_size = static_cast<gr::Size_t>(maxCapacity);
+    }
+
+    [[nodiscard]] SignalSink::DataRange getXRange(double tMin, double tMax) const {
+        if constexpr (IsStreaming) {
+            if (_xValues.empty()) {
+                return {0, 0};
+            }
+            auto xSpan = _xValues.get_span(0);
+            // Binary search for range bounds
+            auto itBegin = std::lower_bound(xSpan.begin(), xSpan.end(), tMin);
+            auto itEnd   = std::upper_bound(xSpan.begin(), xSpan.end(), tMax);
+            if (itBegin >= itEnd) {
+                return {0, 0};
+            }
+            std::size_t startIdx = static_cast<std::size_t>(std::distance(xSpan.begin(), itBegin));
+            std::size_t count    = static_cast<std::size_t>(std::distance(itBegin, itEnd));
+            return {startIdx, count};
+        }
+        return {0, 0};
+    }
+
+    [[nodiscard]] SignalSink::DataRange getTagRange(double tMin, double tMax) const {
+        if constexpr (IsStreaming) {
+            if (_tagValues.empty()) {
+                return {0, 0};
+            }
+            // Find first tag >= tMin
+            auto itBegin = std::find_if(_tagValues.begin(), _tagValues.end(), [tMin](const TagData& tag) { return tag.timestamp >= tMin; });
+            // Find first tag > tMax
+            auto itEnd = std::find_if(itBegin, _tagValues.end(), [tMax](const TagData& tag) { return tag.timestamp > tMax; });
+            if (itBegin >= itEnd) {
+                return {0, 0};
+            }
+            std::size_t startIdx = static_cast<std::size_t>(std::distance(_tagValues.begin(), itBegin));
+            std::size_t count    = static_cast<std::size_t>(std::distance(itBegin, itEnd));
+            return {startIdx, count};
+        }
+        return {0, 0};
+    }
+
+    [[nodiscard]] SignalSink::XRangeResult getX(double tMin = -std::numeric_limits<double>::infinity(), double tMax = +std::numeric_limits<double>::infinity()) const {
+        if constexpr (IsStreaming) {
+            if (_xValues.empty()) {
+                return {{}, 0.0, 0.0};
+            }
+            auto xSpan = _xValues.get_span(0);
+            // Clamp requested range to available data
+            double dataMin      = xSpan.front();
+            double dataMax      = xSpan.back();
+            double effectiveMin = std::max(tMin, dataMin);
+            double effectiveMax = std::min(tMax, dataMax);
+
+            if (effectiveMin > effectiveMax) {
+                return {{}, dataMin, dataMax}; // Requested range outside data
+            }
+
+            // Binary search for range bounds
+            auto itBegin = std::lower_bound(xSpan.begin(), xSpan.end(), effectiveMin);
+            auto itEnd   = std::upper_bound(xSpan.begin(), xSpan.end(), effectiveMax);
+            if (itBegin >= itEnd) {
+                return {{}, dataMin, dataMax};
+            }
+
+            std::size_t startIdx = static_cast<std::size_t>(std::distance(xSpan.begin(), itBegin));
+            std::size_t count    = static_cast<std::size_t>(std::distance(itBegin, itEnd));
+            return {xSpan.subspan(startIdx, count), *itBegin, *(itEnd - 1)};
+        }
+        return {{}, 0.0, 0.0};
+    }
+
+    [[nodiscard]] SignalSink::YRangeResult getY(double tMin = -std::numeric_limits<double>::infinity(), double tMax = +std::numeric_limits<double>::infinity()) const {
+        if constexpr (IsStreaming) {
+            if (_yValues.empty() || _xValues.empty()) {
+                return {{}, 0.0, 0.0};
+            }
+
+            // Get the X range first to determine indices
+            auto xResult = getX(tMin, tMax);
+            if (xResult.data.empty()) {
+                return {{}, xResult.actual_t_min, xResult.actual_t_max};
+            }
+
+            // Calculate indices from X range
+            auto        xSpan    = _xValues.get_span(0);
+            std::size_t startIdx = static_cast<std::size_t>(xResult.data.data() - xSpan.data());
+            std::size_t count    = xResult.data.size();
+
+            // Get Y values as float span
+            if constexpr (std::is_same_v<ValueType, float>) {
+                auto ySpan = _yValues.get_span(0);
+                return {ySpan.subspan(startIdx, count), xResult.actual_t_min, xResult.actual_t_max};
+            } else {
+                // For non-float types, we need to convert - use cached conversion
+                _yFloatCache.resize(count);
+                auto ySpan = _yValues.get_span(0);
+                for (std::size_t i = 0; i < count; ++i) {
+                    _yFloatCache[i] = static_cast<float>(ySpan[startIdx + i]);
+                }
+                return {std::span<const float>(_yFloatCache), xResult.actual_t_min, xResult.actual_t_max};
+            }
+        }
+        return {{}, 0.0, 0.0};
+    }
+
+    [[nodiscard]] SignalSink::TagRangeResult getTags(double tMin = -std::numeric_limits<double>::infinity(), double tMax = +std::numeric_limits<double>::infinity()) const {
+        if constexpr (IsStreaming) {
+            if (_tagValues.empty()) {
+                return {{}, 0.0, 0.0};
+            }
+
+            // Get actual data bounds
+            double dataMin      = _tagValues.front().timestamp;
+            double dataMax      = _tagValues.back().timestamp;
+            double effectiveMin = std::max(tMin, dataMin);
+            double effectiveMax = std::min(tMax, dataMax);
+
+            std::vector<SignalSink::TagEntry> result;
+            for (const auto& tag : _tagValues) {
+                if (tag.timestamp >= effectiveMin && tag.timestamp <= effectiveMax) {
+                    result.push_back({tag.timestamp, tag.map});
+                }
+            }
+
+            if (result.empty()) {
+                return {{}, dataMin, dataMax};
+            }
+            double firstTimestamp = result.front().timestamp;
+            double lastTimestamp  = result.back().timestamp;
+            return {std::move(result), firstTimestamp, lastTimestamp};
+        }
+        return {{}, 0.0, 0.0};
+    }
+
+    [[nodiscard]] std::mutex&                 dataMutex() const { return *_dataMutex; }
+    [[nodiscard]] std::shared_ptr<std::mutex> sharedDataMutex() const { return _dataMutex; }
+
+    void pruneTags(double minX) {
+        if constexpr (IsStreaming) {
+            std::erase_if(_tagValues, [minX](const auto& tag) { return tag.timestamp < minX; });
+        }
+    }
+
+    gr::work::Status processBulk(std::span<const T> input) noexcept {
+        std::lock_guard lock(*_dataMutex);
+
+        // Handle tag at start of span (GR4 guarantees tag on first sample if present)
         if (this->inputTagsPresent()) {
-            // received tag
-            const gr::property_map& tag = this->_mergedInputTag.map;
+            const gr::property_map& tagMap = this->mergedInputTag().map;
 
-            if (tag.contains(gr::tag::TRIGGER_TIME.shortKey())) {
-                const auto   offset       = static_cast<double>(getValueOrDefault<float>(tag, gr::tag::TRIGGER_OFFSET.shortKey(), 0.f));
-                const auto   utcTime      = static_cast<double>(getValueOrDefault<uint64_t>(tag, gr::tag::TRIGGER_TIME.shortKey(), 0U)) + offset;
+            if (tagMap.contains(gr::tag::TRIGGER_TIME.shortKey())) {
+                const auto   offset       = static_cast<double>(getValueOrDefault<float>(tagMap, gr::tag::TRIGGER_OFFSET.shortKey(), 0.f));
+                const auto   utcTime      = static_cast<double>(getValueOrDefault<uint64_t>(tagMap, gr::tag::TRIGGER_TIME.shortKey(), 0U)) + offset;
                 const double tagEventTime = utcTime * 1e-9 + offset; // [s]
                 bool         tagOK        = true;
 
@@ -456,37 +519,44 @@ struct ImPlotSink : ImPlotSinkBase<ImPlotSink<T>> {
                 }
 
                 if (plot_tags) {
-                    _tagValues.push_back({.timestamp = _xUtcOffset, .map = this->mergedInputTag().map});
+                    _tagValues.push_back({.timestamp = _xUtcOffset, .map = tagMap});
                     if (!tagOK) {
                         _tagValues.back().map[std::string(kFishyTagKey)] = true;
                     }
                 }
             }
-            this->_mergedInputTag.map.clear(); // TODO: provide proper API for clearing tags
         }
-        if constexpr (std::is_arithmetic_v<T>) {
-            _xValues.push_back(_xUtcOffset + static_cast<double>(_sample_count) * _sample_period);
+
+        // Process all samples in the span
+        for (const auto& sample : input) {
+            if constexpr (std::is_arithmetic_v<T>) {
+                _xValues.push_back(_xUtcOffset + static_cast<double>(_sample_count) * _sample_period);
+            }
+            _yValues.push_back(sample);
+            _sample_count++;
         }
-        _yValues.push_back(input);
-        _sample_count++;
+
+        return gr::work::Status::OK;
     }
 
     gr::work::Status draw(const gr::property_map& config = {}) noexcept {
-        using DigitizerUi::AxisScale;
-        using enum DigitizerUi::AxisScale;
+        using enum AxisScale;
 
         if (!isTabVisible()) {
             return gr::work::Status::OK;
         }
-        if (_isWorkRunning.test_and_set(std::memory_order_acquire)) {
-            return gr::work::Status::OK;
+
+        // Acquire lock for thread-safe data access during rendering.
+        // Data is copied to GPU buffers by ImPlot API calls below.
+        std::lock_guard lock(*_dataMutex);
+
+        // Set axes from config
+        {
+            static constexpr ImAxis xAxes[] = {ImAxis_X1, ImAxis_X2, ImAxis_X3};
+            static constexpr ImAxis yAxes[] = {ImAxis_Y1, ImAxis_Y2, ImAxis_Y3};
+            ImPlot::SetAxis(xAxes[std::clamp(getValueOrDefault<std::size_t>(config, "xAxisID", 0UZ), 0UZ, 2UZ)]);
+            ImPlot::SetAxis(yAxes[std::clamp(getValueOrDefault<std::size_t>(config, "yAxisID", 0UZ), 0UZ, 2UZ)]);
         }
-
-        details::on_scope_exit _ = [&] { _isWorkRunning.clear(std::memory_order_release); };
-
-        [[maybe_unused]] const gr::work::Status status = this->invokeWork();
-
-        setAxisFromConfig(config);
         std::string scaleStr = config.contains("scale") ? std::get<std::string>(config.at("scale")) : "Linear";
         auto        trim     = [](const std::string& str) {
             auto start = std::ranges::find_if_not(str, [](unsigned char ch) { return std::isspace(ch); });
@@ -503,20 +573,20 @@ struct ImPlotSink : ImPlotSinkBase<ImPlotSink<T>> {
         }
 
         struct PlotLineContext {
-            std::span<const double>    xValues;
-            std::span<const ValueType> yValues;
-            AxisScale                  axisScale;
-            ValueType                  yOffset{0};
+            std::span<const double>    x_values;
+            std::span<const ValueType> y_values;
+            AxisScale                  axis_scale;
+            ValueType                  y_offset{0};
         };
 
         constexpr auto pointGetter = +[](int signedIndex, void* user_data) -> ImPlotPoint {
             std::size_t idx = static_cast<std::size_t>(signedIndex);
             auto*       ctx = static_cast<PlotLineContext*>(user_data);
 
-            double xVal = ctx->xValues[idx];
-            double yVal = static_cast<double>(ctx->yValues[idx] + ctx->yOffset);
+            double xVal = ctx->x_values[idx];
+            double yVal = static_cast<double>(ctx->y_values[idx] + ctx->y_offset);
 
-            switch (ctx->axisScale) {
+            switch (ctx->axis_scale) {
             case Time: return {xVal, yVal};
 
             case LinearReverse: {
@@ -524,7 +594,7 @@ struct ImPlotSink : ImPlotSinkBase<ImPlotSink<T>> {
                     return {xVal, yVal};
                 } else {
                     // fundamental types
-                    double xMax = ctx->xValues.back();
+                    double xMax = ctx->x_values.back();
                     return {xVal - xMax, yVal};
                 }
             }
@@ -537,14 +607,14 @@ struct ImPlotSink : ImPlotSinkBase<ImPlotSink<T>> {
                     return {xVal, yVal};
                 } else {
                     // fundamental types
-                    double xMin = ctx->xValues.front();
+                    double xMin = ctx->x_values.front();
                     return {xVal - xMin, yVal};
                 }
             }
             }
         };
 
-        auto lineColor = ImGui::ColorConvertU32ToFloat4(_colour.colour() | 0xFF000000);
+        auto lineColor = ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(_colour.colour()));
         if constexpr (std::is_arithmetic_v<T>) {
             ImPlot::SetNextLineStyle(lineColor);
 
@@ -553,11 +623,18 @@ struct ImPlotSink : ImPlotSinkBase<ImPlotSink<T>> {
             if (getValueOrDefault<bool>(config, "draw_tag", false)) {
                 ImVec4 tagColor = lineColor;
                 tagColor.w *= 0.35f; // semi-transparent tags
-                drawAndPruneTags<T>(_tagValues, minX, maxX, axisScale, tagColor);
+                std::erase_if(_tagValues, [minX](const auto& tag) { return tag.timestamp < minX; });
+                drawTags(
+                    [&](auto&& fn) {
+                        for (const auto& t : _tagValues) {
+                            fn(t.timestamp, t.map);
+                        }
+                    },
+                    axisScale, minX, maxX, tagColor);
             }
 
             PlotLineContext ctx{_xValues.get_span(0UZ), _yValues.get_span(0UZ), axisScale, ValueType{0}};
-            ImPlot::PlotLineG(label.c_str(), pointGetter, &ctx, static_cast<int>(_xValues.size())); // limited to int, even if xValues can have long values
+            ImPlot::PlotLineG(label.c_str(), pointGetter, &ctx, static_cast<int>(_xValues.size())); // limited to int, even if x_values can have long values
         } else if constexpr (gr::DataSetLike<T>) {
             const std::size_t nMax = std::min(_yValues.size(), static_cast<std::size_t>(n_history));
             for (std::size_t historyIdx = nMax; historyIdx-- > 0;) {
@@ -594,20 +671,20 @@ struct ImPlotSink : ImPlotSinkBase<ImPlotSink<T>> {
                     // draw all signals
                     auto [minVal, maxVal] = std::ranges::minmax(dataSet.signal_values);
                     ValueType baseOffset  = static_cast<ValueType>(history_offset) * (maxVal - minVal);
-                    for (std::size_t signalIdx = 0UZ; signalIdx < nsignals; ++signalIdx) {
+                    for (std::size_t sigIdx = 0UZ; sigIdx < nsignals; ++sigIdx) {
                         ImPlot::SetNextLineStyle(lineColor);
-                        PlotLineContext ctx{xAxisDouble, dataSet.signalValues(signalIdx), axisScale, static_cast<ValueType>(signalIdx + historyIdx) * baseOffset};
-                        ImPlot::PlotLineG(historyIdx == 0UZ ? dataSet.signal_names[signalIdx].c_str() : "", pointGetter, &ctx, static_cast<int>(npoints));
+                        PlotLineContext ctx{xAxisDouble, dataSet.signalValues(sigIdx), axisScale, static_cast<ValueType>(sigIdx + historyIdx) * baseOffset};
+                        ImPlot::PlotLineG(historyIdx == 0UZ ? dataSet.signal_names[sigIdx].c_str() : "", pointGetter, &ctx, static_cast<int>(npoints));
                     }
                 } else {
                     // single sub-signal
                     if (dataset_index >= static_cast<gr::Size_t>(nsignals)) {
                         dataset_index = 0U;
                     }
-                    const auto signalIdx = static_cast<std::size_t>(dataset_index);
+                    const auto sigIdx = static_cast<std::size_t>(dataset_index);
                     ImPlot::SetNextLineStyle(lineColor);
-                    PlotLineContext ctx{xAxisDouble, dataSet.signalValues(signalIdx), axisScale};
-                    ImPlot::PlotLineG(dataSet.signal_names[signalIdx].c_str(), pointGetter, &ctx, static_cast<int>(npoints));
+                    PlotLineContext ctx{xAxisDouble, dataSet.signalValues(sigIdx), axisScale};
+                    ImPlot::PlotLineG(dataSet.signal_names[sigIdx].c_str(), pointGetter, &ctx, static_cast<int>(npoints));
                 }
             }
         } //  if constexpr (gr::DataSetLike<T>) { .. }

--- a/src/ui/blocks/ToolbarBlock.hpp
+++ b/src/ui/blocks/ToolbarBlock.hpp
@@ -72,7 +72,7 @@ public:
     requires(storageType != StorageType::ATOMIC)
         : _state(other._state) {} // plain enum
 
-    [[nodiscard]] std::expected<void, gr::Error> changeToolStateTo(State newState, const std::source_location location = std::source_location::current()) {
+    [[nodiscard]] std::expected<void, gr::Error> changeToolStateTo([[maybe_unused]] State newState, [[maybe_unused]] const std::source_location location = std::source_location::current()) {
 #if 0 // TODO port to new messaging architecture
         const State oldState = _state;
         if (isValidTransition(oldState, newState)) {
@@ -130,7 +130,7 @@ struct PlayStopToolbarBlock : public play_stop::StateMachine<PlayStopToolbarBloc
 
     GR_MAKE_REFLECTABLE(PlayStopToolbarBlock, ctrlOut);
 
-    gr::work::Status draw(const gr::property_map& config = {}) noexcept {
+    gr::work::Status draw([[maybe_unused]] const gr::property_map& config = {}) noexcept {
         const gr::work::Status status = gr::work::Status::OK; // this->invokeWork(); // calls work(...) -> processOne(...) (all in the same thread as this 'draw()'
         using namespace gr::message;
 

--- a/src/ui/charts/Chart.hpp
+++ b/src/ui/charts/Chart.hpp
@@ -1,0 +1,1874 @@
+#ifndef OPENDIGITIZER_CHARTS_CHART_HPP
+#define OPENDIGITIZER_CHARTS_CHART_HPP
+
+#include "SignalSink.hpp"
+#include "SinkRegistry.hpp"
+
+#include "../common/ImguiWrap.hpp"
+#include "../common/LookAndFeel.hpp"
+
+#include <imgui.h>
+#include <implot.h>
+#include <implot_internal.h>
+
+#include "../common/TouchHandler.hpp"
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
+#include <gnuradio-4.0/Tag.hpp>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <format>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <ranges>
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace opendigitizer::charts {
+
+enum class XAxisMode : std::uint8_t { UtcTime, RelativeTime, SampleIndex };
+
+enum class AxisScale {
+    Linear = 0,    // standard linear scale [min, max]
+    LinearReverse, // reversed linear scale [max, min]
+    Time,          // datetime/timestamp scale
+    Log10,         // logarithmic base 10
+    SymLog         // symmetric log (handles negative values)
+};
+
+enum class LabelFormat {
+    Auto = 0,     // automatic based on range
+    Metric,       // SI prefixes (k, M, G, etc.)
+    MetricInline, // SI prefixes inline with value
+    Scientific,   // scientific notation
+    None,         // no labels
+    Default       // default floating-point format
+};
+
+enum class HistoryUnit : int {
+    seconds = 0, // time-based history depth (resolved via sample rate)
+    samples = 1  // sample-count-based history depth
+};
+
+struct AxisConfig {
+    enum class AxisKind { X = 0, Y, Z };
+
+    AxisKind    axis     = AxisKind::X;
+    float       min      = std::numeric_limits<float>::quiet_NaN();
+    float       max      = std::numeric_limits<float>::quiet_NaN();
+    AxisScale   scale    = AxisScale::Linear;
+    LabelFormat format   = LabelFormat::Auto;
+    float       width    = std::numeric_limits<float>::max();
+    bool        plotTags = true;
+};
+
+[[nodiscard]] inline std::optional<AxisConfig> parseAxisConfig(const gr::property_map& constraints, bool isX, std::size_t index = 0) {
+    using AxisKind            = AxisConfig::AxisKind;
+    const AxisKind targetKind = isX ? AxisKind::X : AxisKind::Y;
+
+    auto axesIt = constraints.find("axes");
+    if (axesIt == constraints.end()) {
+        return std::nullopt;
+    }
+    const auto* axesVec = std::get_if<std::vector<pmtv::pmt>>(&axesIt->second);
+    if (!axesVec) {
+        return std::nullopt;
+    }
+
+    std::size_t count = 0;
+    for (const auto& axisPmt : *axesVec) {
+        const auto* axisMap = std::get_if<gr::property_map>(&axisPmt);
+        if (!axisMap) {
+            continue;
+        }
+        auto axisStrIt = axisMap->find("axis");
+        if (axisStrIt == axisMap->end()) {
+            continue;
+        }
+        const auto* axisStr = std::get_if<std::string>(&axisStrIt->second);
+        if (!axisStr) {
+            continue;
+        }
+        AxisKind parsedKind = (*axisStr == "X" || *axisStr == "x") ? AxisKind::X : AxisKind::Y;
+        if (parsedKind != targetKind) {
+            continue;
+        }
+        if (count != index) {
+            ++count;
+            continue;
+        }
+
+        AxisConfig cfg;
+        cfg.axis = parsedKind;
+        if (auto it = axisMap->find("min"); it != axisMap->end()) {
+            cfg.min = pmtv::cast<float>(it->second);
+        }
+        if (auto it = axisMap->find("max"); it != axisMap->end()) {
+            cfg.max = pmtv::cast<float>(it->second);
+        }
+        if (auto it = axisMap->find("scale"); it != axisMap->end()) {
+            if (const auto* s = std::get_if<std::string>(&it->second)) {
+                cfg.scale = magic_enum::enum_cast<AxisScale>(*s, magic_enum::case_insensitive).value_or(AxisScale::Linear);
+            }
+        }
+        if (auto it = axisMap->find("format"); it != axisMap->end()) {
+            if (const auto* s = std::get_if<std::string>(&it->second)) {
+                cfg.format = magic_enum::enum_cast<LabelFormat>(*s, magic_enum::case_insensitive).value_or(LabelFormat::Auto);
+            }
+        }
+        if (auto it = axisMap->find("plot_tags"); it != axisMap->end()) {
+            if (const auto* b = std::get_if<bool>(&it->second)) {
+                cfg.plotTags = *b;
+            }
+        }
+        return cfg;
+    }
+    return std::nullopt;
+}
+
+struct AxisCategory {
+    std::string   quantity;              // Physical quantity (e.g., "voltage", "frequency")
+    std::string   unit;                  // Unit of measurement (e.g., "V", "Hz")
+    std::uint32_t color    = 0xFFFFFFFF; // Color for axis labels/ticks
+    AxisScale     scale    = AxisScale::Linear;
+    bool          plotTags = true;
+
+    [[nodiscard]] bool matches(std::string_view q, std::string_view u) const noexcept { return quantity == q && unit == u; }
+
+    [[nodiscard]] std::string buildLabel() const {
+        if (!quantity.empty() && !unit.empty()) {
+            return quantity + " [" + unit + "]";
+        }
+        if (!quantity.empty()) {
+            return quantity;
+        }
+        if (!unit.empty()) {
+            return unit;
+        }
+        return "";
+    }
+};
+
+namespace axis {
+
+template<typename Result>
+inline int enforceNullTerminate(char* buff, int size, const Result& result) {
+    if ((result.out - buff) < static_cast<std::ptrdiff_t>(size)) {
+        *result.out = '\0';
+    } else if (size > 0) {
+        buff[size - 1] = '\0';
+    }
+    return static_cast<int>(result.out - buff);
+}
+
+inline constexpr std::string_view boundedStringView(const char* ptr, std::size_t maxLength) {
+    if (!ptr) {
+        return "";
+    }
+    for (std::size_t i = 0UZ; i < maxLength; ++i) {
+        if (ptr[i] == '\0') {
+            return std::string_view(ptr, i);
+        }
+    }
+    return "";
+}
+
+inline int formatMetric(double value, char* buff, int size, void* data) {
+    constexpr std::array<double, 11UZ>      kScales{1e15, 1e12, 1e9, 1e6, 1e3, 1.0, 1e-3, 1e-6, 1e-9, 1e-12, 1e-15};
+    constexpr std::array<const char*, 11UZ> kPrefixes{"P", "T", "G", "M", "k", "", "m", "u", "n", "p", "f"};
+    constexpr std::size_t                   maxUnitLength = 10UZ;
+
+    const std::string_view unit = boundedStringView(static_cast<const char*>(data), maxUnitLength);
+    if (value == 0.0) {
+        return enforceNullTerminate(buff, size, std::format_to_n(buff, static_cast<std::ptrdiff_t>(size), "0{}", unit));
+    }
+
+    std::string_view prefix      = kPrefixes.back();
+    double           scaledValue = value / kScales.back();
+
+    for (auto [scale, p] : std::views::zip(kScales, kPrefixes)) {
+        if (std::abs(value) >= scale) {
+            scaledValue = value / scale;
+            prefix      = p;
+            break;
+        }
+    }
+
+    return enforceNullTerminate(buff, size, std::format_to_n(buff, static_cast<std::ptrdiff_t>(size), "{:g}{}{}", scaledValue, prefix, unit));
+}
+
+inline std::string formatMinimalScientific(double value, int maxDecimals = 2) {
+    if (value == 0.0) {
+        return "0";
+    }
+    const int    exponent = static_cast<int>(std::floor(std::log10(std::abs(value))));
+    const double mantissa = value / std::pow(10.0, exponent);
+
+    std::string mantissaStr = std::format("{:.{}f}", mantissa, maxDecimals);
+    while (!mantissaStr.empty() && mantissaStr.back() == '0') {
+        mantissaStr.pop_back();
+    }
+    if (!mantissaStr.empty() && mantissaStr.back() == '.') {
+        mantissaStr.pop_back();
+    }
+    return std::format("{}E{}", mantissaStr, exponent);
+}
+
+inline int formatScientific(double value, char* buff, int size, void* data) {
+    constexpr std::size_t  maxUnitLength = 10UZ;
+    const std::string_view unit          = boundedStringView(static_cast<const char*>(data), maxUnitLength);
+
+    if (value == 0.0) {
+        return enforceNullTerminate(buff, size, std::format_to_n(buff, static_cast<std::ptrdiff_t>(size), "0{}", unit));
+    }
+    const double absVal = std::abs(value);
+    if (absVal >= 1e-3 && absVal < 10000.0) {
+        return enforceNullTerminate(buff, size, std::format_to_n(buff, static_cast<std::ptrdiff_t>(size), "{:.3g}{}", value, unit));
+    } else {
+        return enforceNullTerminate(buff, size, std::format_to_n(buff, static_cast<std::ptrdiff_t>(size), "{}{}", formatMinimalScientific(value), unit));
+    }
+}
+
+inline int formatDefault(double value, char* buff, int size, void* data) {
+    constexpr std::size_t  maxUnitLength = 10UZ;
+    const std::string_view unit          = boundedStringView(static_cast<const char*>(data), maxUnitLength);
+
+    if (value == 0.0) {
+        return enforceNullTerminate(buff, size, std::format_to_n(buff, static_cast<std::ptrdiff_t>(size), "0{}", unit));
+    }
+    return enforceNullTerminate(buff, size, std::format_to_n(buff, static_cast<std::ptrdiff_t>(size), "{:g}{}", value, unit));
+}
+
+inline std::string truncateLabel(std::string_view original, float availableWidth) {
+    const float textWidth = ImGui::CalcTextSize(original.data()).x;
+    if (textWidth <= availableWidth) {
+        return std::string(original);
+    }
+    static const float ellipsisWidth = ImGui::CalcTextSize("...").x;
+    if (availableWidth <= ellipsisWidth + 1.f) {
+        return "...";
+    }
+    const float       scaleFactor  = (availableWidth - ellipsisWidth) / std::max(1.f, textWidth);
+    const std::size_t fitCharCount = static_cast<std::size_t>(std::floor(scaleFactor * static_cast<float>(original.size())));
+    return std::format("...{}", original.substr(original.size() - fitCharCount));
+}
+
+inline void setupAxis(ImAxis axisId, const std::optional<AxisCategory>& category, LabelFormat format, float axisWidth, double minLimit, double maxLimit, std::size_t nTotalAxes, AxisScale scaleOverride, std::array<std::string, 6>& unitStringStorage, bool showGrid = true) {
+    if (!category.has_value()) {
+        return;
+    }
+
+    const bool      isX       = axisId == ImAxis_X1 || axisId == ImAxis_X2 || axisId == ImAxis_X3;
+    const bool      finiteMin = std::isfinite(minLimit);
+    const bool      finiteMax = std::isfinite(maxLimit);
+    const AxisScale scale     = scaleOverride;
+
+    ImPlotAxisFlags flags = showGrid ? ImPlotAxisFlags_None : ImPlotAxisFlags_NoGridLines;
+    if (finiteMin && !finiteMax) {
+        flags |= ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit | ImPlotAxisFlags_LockMin;
+    } else if (!finiteMin && finiteMax) {
+        flags |= ImPlotAxisFlags_AutoFit | ImPlotAxisFlags_RangeFit | ImPlotAxisFlags_LockMax;
+    } else if (!finiteMin && !finiteMax) {
+        flags |= ImPlotAxisFlags_AutoFit;
+    }
+
+    if ((axisId == ImAxis_X2) || (axisId == ImAxis_X3) || (axisId == ImAxis_Y2) || (axisId == ImAxis_Y3)) {
+        flags |= ImPlotAxisFlags_Opposite;
+    }
+
+    bool pushedColor = false;
+    if ((nTotalAxes > 1) && !isX) {
+        const auto   colorU32toImVec4 = [](std::uint32_t c) { return ImVec4{float((c >> 16) & 0xFF) / 255.f, float((c >> 8) & 0xFF) / 255.f, float((c >> 0) & 0xFF) / 255.f, 1.f}; };
+        const ImVec4 col              = colorU32toImVec4(category->color);
+        ImPlot::PushStyleColor(ImPlotCol_AxisText, col);
+        ImPlot::PushStyleColor(ImPlotCol_AxisTick, col);
+        pushedColor = true;
+    }
+
+    const std::string label = (scale == AxisScale::Time) || (format == LabelFormat::MetricInline) ? "" : truncateLabel(category->buildLabel(), axisWidth);
+    ImPlot::SetupAxis(axisId, label.c_str(), flags);
+
+    if (scale != AxisScale::Time) {
+        constexpr std::array kMetricUnits{"s", "m", "A", "K", "V", "g", "eV", "Hz"};
+        constexpr std::array kLinearUnits{"dB"};
+        const std::string&   unit = category->unit;
+
+        switch (format) {
+        case LabelFormat::Auto:
+            if (std::ranges::contains(kMetricUnits, unit)) {
+                ImPlot::SetupAxisFormat(axisId, formatMetric, nullptr);
+            } else if (std::ranges::contains(kLinearUnits, unit)) {
+                ImPlot::SetupAxisFormat(axisId, formatDefault, nullptr);
+            } else if (isX) {
+                constexpr const char* str = "s";
+                ImPlot::SetupAxisFormat(axisId, formatMetric, const_cast<void*>(static_cast<const void*>(str)));
+            } else {
+                ImPlot::SetupAxisFormat(axisId, formatScientific, nullptr);
+            }
+            break;
+        case LabelFormat::Metric: ImPlot::SetupAxisFormat(axisId, formatMetric, nullptr); break;
+        case LabelFormat::MetricInline: {
+            unitStringStorage[static_cast<std::size_t>(axisId)] = unit;
+            ImPlot::SetupAxisFormat(axisId, formatMetric, const_cast<void*>(static_cast<const void*>(unitStringStorage[static_cast<std::size_t>(axisId)].c_str())));
+        } break;
+        case LabelFormat::Scientific: ImPlot::SetupAxisFormat(axisId, formatScientific, nullptr); break;
+        case LabelFormat::None:
+        case LabelFormat::Default:
+        default: ImPlot::SetupAxisFormat(axisId, formatDefault, nullptr);
+        }
+    }
+
+    switch (scale) {
+    case AxisScale::Log10: ImPlot::SetupAxisScale(axisId, ImPlotScale_Log10); break;
+    case AxisScale::SymLog: ImPlot::SetupAxisScale(axisId, ImPlotScale_SymLog); break;
+    case AxisScale::Time:
+        ImPlot::GetStyle().UseISO8601     = true;
+        ImPlot::GetStyle().Use24HourClock = true;
+        ImPlot::SetupAxisScale(axisId, ImPlotScale_Time);
+        break;
+    default: ImPlot::SetupAxisScale(axisId, ImPlotScale_Linear); break;
+    }
+
+    if (finiteMin && finiteMax) {
+        // Use ImPlotCond_Always to ensure limits from context menu are applied every frame
+        ImPlot::SetupAxisLimits(axisId, minLimit, maxLimit, ImPlotCond_Always);
+    } else if (finiteMin || finiteMax) {
+        const double minConstraint = finiteMin ? minLimit : -std::numeric_limits<double>::infinity();
+        const double maxConstraint = finiteMax ? maxLimit : +std::numeric_limits<double>::infinity();
+        ImPlot::SetupAxisLimitsConstraints(axisId, minConstraint, maxConstraint);
+    }
+
+    if (pushedColor) {
+        ImPlot::PopStyleColor(2);
+    }
+}
+
+inline std::optional<std::size_t> findOrCreateCategory(std::array<std::optional<AxisCategory>, 3>& categories, std::string_view quantity, std::string_view unit, std::uint32_t color) {
+    // Find existing category with matching quantity/unit
+    auto existingIt = std::ranges::find_if(categories, [&](const auto& cat) { return cat.has_value() && cat->matches(quantity, unit); });
+    if (existingIt != categories.end()) {
+        return static_cast<std::size_t>(std::distance(categories.begin(), existingIt));
+    }
+
+    // Find first empty slot and create new category
+    auto emptyIt = std::ranges::find_if(categories, [](const auto& cat) { return !cat.has_value(); });
+    if (emptyIt != categories.end()) {
+        *emptyIt = AxisCategory{.quantity = std::string(quantity), .unit = std::string(unit), .color = color};
+        return static_cast<std::size_t>(std::distance(categories.begin(), emptyIt));
+    }
+
+    return std::nullopt;
+}
+
+inline void buildAxisCategories(const std::vector<std::shared_ptr<SignalSink>>& signalSinks, std::array<std::optional<AxisCategory>, 3>& xCategories, std::array<std::optional<AxisCategory>, 3>& yCategories, std::array<std::vector<std::string>, 3>& xAxisGroups, std::array<std::vector<std::string>, 3>& yAxisGroups) {
+    std::ranges::for_each(xCategories, [](auto& cat) { cat.reset(); });
+    std::ranges::for_each(yCategories, [](auto& cat) { cat.reset(); });
+    std::ranges::for_each(xAxisGroups, [](auto& group) { group.clear(); });
+    std::ranges::for_each(yAxisGroups, [](auto& group) { group.clear(); });
+
+    for (const auto& sink : signalSinks) {
+        const std::string sinkName = std::string(sink->uniqueName());
+        if (auto idx = findOrCreateCategory(xCategories, sink->abscissaQuantity(), sink->abscissaUnit(), sink->color())) {
+            xAxisGroups[*idx].push_back(sinkName);
+        }
+        if (auto idx = findOrCreateCategory(yCategories, sink->signalQuantity(), sink->signalUnit(), sink->color())) {
+            yAxisGroups[*idx].push_back(sinkName);
+        }
+    }
+}
+
+inline std::size_t findAxisForSink(std::string_view sinkName, bool isXAxis, const std::array<std::vector<std::string>, 3>& xAxisGroups, const std::array<std::vector<std::string>, 3>& yAxisGroups) {
+    const auto& groups  = isXAxis ? xAxisGroups : yAxisGroups;
+    auto        foundIt = std::ranges::find_if(groups, [sinkName](const auto& group) { return std::ranges::contains(group, sinkName); });
+    return foundIt != groups.end() ? static_cast<std::size_t>(std::distance(groups.begin(), foundIt)) : 0;
+}
+
+inline std::size_t activeAxisCount(const std::array<std::optional<AxisCategory>, 3>& categories) noexcept {
+    return static_cast<std::size_t>(std::ranges::count_if(categories, [](const auto& c) { return c.has_value(); }));
+}
+
+} // namespace axis
+
+namespace tags {
+
+/// Marker key for tags that appear out-of-order or have suspicious timestamps.
+inline constexpr std::string_view kFishyTagKey = "ui_fishy_tag";
+
+inline double transformX(double xVal, AxisScale axisScale, double xMin, double xMax, bool isDataSet = false) {
+    if (isDataSet) {
+        return xVal;
+    }
+    switch (axisScale) {
+    case AxisScale::Time: return xVal;
+    case AxisScale::LinearReverse: return xVal - xMax;
+    default: return xVal - xMin;
+    }
+}
+
+inline ImVec2 plotVerticalTagLabel(std::string_view label, double xData, const ImPlotRect& plotLimits, bool plotLeft, double fractionBelowTop = 0.02, double sizeRatioLimit = 0.75) {
+    const double yRange   = std::abs(plotLimits.Y.Max - plotLimits.Y.Min);
+    const double ySafeTop = plotLimits.Y.Max - fractionBelowTop * yRange;
+    const double yClamped = std::clamp(ySafeTop, plotLimits.Y.Min, plotLimits.Y.Max);
+    ImVec2       pixelPos = ImPlot::PlotToPixels(xData, yClamped);
+    if (label.empty()) {
+        return pixelPos;
+    }
+
+    const double yPixelRange = static_cast<double>(std::abs(ImPlot::PlotToPixels(0.0, plotLimits.Y.Max).y - ImPlot::PlotToPixels(0.0, plotLimits.Y.Min).y));
+    ImVec2       textSize    = ImGui::CalcTextSize(label.data());
+    if (static_cast<double>(textSize.x) > sizeRatioLimit * yPixelRange) {
+        return pixelPos;
+    }
+
+    ImVec2 pixOffset{plotLeft ? (-textSize.y + 2.0f) : (+5.0f), textSize.x};
+    ImPlot::PlotText(label.data(), xData, yClamped, pixOffset, static_cast<int>(ImPlotTextFlags_Vertical) | static_cast<int>(ImPlotItemFlags_NoFit));
+    return {pixelPos.x + pixOffset.x + textSize.y, pixelPos.y};
+}
+
+template<typename ForEachTagFn>
+inline void drawTags(ForEachTagFn&& forEachTagFn, AxisScale axisScale, double xMin, double xMax, ImVec4 tagColor) {
+    DigitizerUi::IMW::Font titleFont(DigitizerUi::LookAndFeel::instance().fontTiny[DigitizerUi::LookAndFeel::instance().prototypeMode]);
+
+    const float fontHeight  = ImGui::GetFontSize();
+    const auto  plotLimits  = ImPlot::GetPlotLimits(IMPLOT_AUTO, IMPLOT_AUTO);
+    const float yPixelRange = std::abs(ImPlot::PlotToPixels(0.0, plotLimits.Y.Max).y - ImPlot::PlotToPixels(0.0, plotLimits.Y.Min).y);
+
+    ImGui::PushStyleColor(ImGuiCol_Text, tagColor);
+
+    float lastTextPixelX = ImPlot::PlotToPixels(transformX(std::min(xMin, xMax), axisScale, xMin, xMax), 0.0).x;
+    float lastAxisPixelX = ImPlot::PlotToPixels(transformX(std::max(xMin, xMax), axisScale, xMin, xMax), 0.0).x;
+
+    forEachTagFn([&](double timestamp, const gr::property_map& properties) {
+        if (timestamp < std::min(xMin, xMax) || timestamp > std::max(xMin, xMax)) {
+            return;
+        }
+
+        double      xTagPosition = transformX(timestamp, axisScale, xMin, xMax);
+        const float xPixelPos    = ImPlot::PlotToPixels(xTagPosition, 0.0).x;
+
+        // highlight fishy tags (out-of-order timestamps) in magenta
+        if (properties.contains(std::string(kFishyTagKey))) {
+            ImPlot::SetNextLineStyle(ImVec4(1.0f, 0.0f, 1.0f, 1.0f));
+        } else {
+            ImPlot::SetNextLineStyle(tagColor);
+        }
+        ImPlot::PlotInfLines("", &xTagPosition, 1, ImPlotInfLinesFlags_None);
+
+        // suppress tag labels if too close to previous or to axis extremities
+        if ((xPixelPos - lastTextPixelX) > 1.5f * fontHeight && (lastAxisPixelX - xPixelPos) > 2.0f * fontHeight) {
+            std::string triggerLabel = "TRIGGER";
+            if (auto it = properties.find(std::string(gr::tag::TRIGGER_NAME.shortKey())); it != properties.end()) {
+                if (auto* str = std::get_if<std::string>(&it->second)) {
+                    triggerLabel = *str;
+                }
+            }
+
+            const ImVec2 triggerLabelSize = ImGui::CalcTextSize(triggerLabel.c_str());
+            if (triggerLabelSize.x < 0.75f * yPixelRange) {
+                lastTextPixelX = plotVerticalTagLabel(triggerLabel, xTagPosition, plotLimits, true).x;
+
+                std::string triggerCtx;
+                if (auto it = properties.find(std::string(gr::tag::CONTEXT.shortKey())); it != properties.end()) {
+                    if (auto* str = std::get_if<std::string>(&it->second)) {
+                        triggerCtx = *str;
+                    }
+                }
+                if (!triggerCtx.empty() && triggerCtx != triggerLabel) {
+                    const ImVec2 ctxLabelSize = ImGui::CalcTextSize(triggerCtx.c_str());
+                    if (ctxLabelSize.x < 0.75f * yPixelRange) {
+                        lastTextPixelX = plotVerticalTagLabel(triggerCtx, xTagPosition, plotLimits, false).x;
+                    }
+                }
+            }
+        }
+    });
+
+    ImGui::PopStyleColor();
+}
+
+template<typename T>
+inline void drawDataSetTimingEvents(const gr::DataSet<T>& dataSet, AxisScale axisScale, ImVec4 baseColor) {
+    if (dataSet.timing_events.empty() || dataSet.axisValues(0).empty()) {
+        return;
+    }
+
+    ImVec4 tagColor = baseColor;
+    tagColor.w *= 0.35f;
+
+    const auto&  xAxisSpan   = dataSet.axisValues(0);
+    const double xMin        = static_cast<double>(xAxisSpan.front());
+    const double xMax        = static_cast<double>(xAxisSpan.back());
+    const float  fontHeight  = ImGui::GetFontSize();
+    const auto   plotLimits  = ImPlot::GetPlotLimits(IMPLOT_AUTO, IMPLOT_AUTO);
+    const float  yPixelRange = std::abs(ImPlot::PlotToPixels(0.0, plotLimits.Y.Max).y - ImPlot::PlotToPixels(0.0, plotLimits.Y.Min).y);
+
+    ImGui::PushStyleColor(ImGuiCol_Text, tagColor);
+
+    float lastTextPixelX = ImPlot::PlotToPixels(transformX(std::min(xMin, xMax), axisScale, xMin, xMax, true), 0.0).x;
+    float lastAxisPixelX = ImPlot::PlotToPixels(transformX(std::max(xMin, xMax), axisScale, xMin, xMax, true), 0.0).x;
+
+    for (const auto& eventsForSig : dataSet.timing_events) {
+        for (const auto& [xIndex, tagMap] : eventsForSig) {
+            if (xIndex < 0 || static_cast<std::size_t>(xIndex) >= xAxisSpan.size()) {
+                continue;
+            }
+
+            double      xVal         = static_cast<double>(xAxisSpan[static_cast<std::size_t>(xIndex)]);
+            double      xTagPosition = transformX(xVal, axisScale, xMin, xMax, true);
+            const float xPixelPos    = ImPlot::PlotToPixels(xTagPosition, 0.0).x;
+
+            ImPlot::SetNextLineStyle(tagColor);
+            ImPlot::PlotInfLines("", &xTagPosition, 1, ImPlotInfLinesFlags_None);
+
+            if ((xPixelPos - lastTextPixelX) > 1.5f * fontHeight && (lastAxisPixelX - xPixelPos) > 2.0f * fontHeight) {
+                std::string triggerLabel = "TRIGGER";
+                if (auto it = tagMap.find(std::string(gr::tag::TRIGGER_NAME.shortKey())); it != tagMap.end()) {
+                    if (auto* str = std::get_if<std::string>(&it->second)) {
+                        triggerLabel = *str;
+                    }
+                }
+
+                const ImVec2 triggerLabelSize = ImGui::CalcTextSize(triggerLabel.c_str());
+                if (triggerLabelSize.x < 0.75f * yPixelRange) {
+                    lastTextPixelX = plotVerticalTagLabel(triggerLabel, xTagPosition, plotLimits, true).x;
+                } else {
+                    continue;
+                }
+
+                // Render CONTEXT tag label below trigger label if present and different
+                std::string triggerCtx;
+                if (auto it = tagMap.find(std::string(gr::tag::CONTEXT.shortKey())); it != tagMap.end()) {
+                    if (auto* str = std::get_if<std::string>(&it->second)) {
+                        triggerCtx = *str;
+                    }
+                }
+                if (!triggerCtx.empty() && triggerCtx != triggerLabel) {
+                    const ImVec2 triggerCtxLabelSize = ImGui::CalcTextSize(triggerCtx.c_str());
+                    if (triggerCtxLabelSize.x < 0.75f * yPixelRange) {
+                        lastTextPixelX = plotVerticalTagLabel(triggerCtx, xTagPosition, plotLimits, false).x;
+                    }
+                }
+            }
+        }
+    }
+
+    ImGui::PopStyleColor();
+}
+
+} // namespace tags
+
+namespace tooltip {
+
+inline void showPlotMouseTooltip(double onDelay = 1.0, double offDelay = 30.0) {
+    if (!ImPlot::IsPlotHovered()) {
+        return;
+    }
+
+    ImPlotContext* ctx  = ImPlot::GetCurrentContext();
+    ImPlotPlot*    plot = ImPlot::GetCurrentPlot();
+    if (!ctx || !plot) {
+        return;
+    }
+
+    const ImVec2  px = ImGui::GetMousePos();
+    static ImVec2 lastPX{0, 0};
+    static double lastTime = 0.0;
+    const double  now      = ImGui::GetTime();
+
+    constexpr float epsilon = 10.0f;
+    const bool      samePos = std::abs(px.x - lastPX.x) < epsilon && std::abs(px.y - lastPX.y) < epsilon;
+
+    if (!samePos) {
+        lastPX   = px;
+        lastTime = now;
+        return;
+    }
+
+    if ((now - lastTime) < onDelay || (now - lastTime) > offDelay) {
+        return;
+    }
+
+    // Format axis value according to axis scale/formatter
+    const auto formatAxisValue = [](const ImPlotAxis& axis, double value, char* buf, int size) {
+        if (axis.Scale == ImPlotScale_Time) {
+            using Clock                                                                                = std::chrono::system_clock;
+            const auto timePoint                                                                       = Clock::time_point(std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(value)));
+            const auto secs                                                                            = std::chrono::time_point_cast<std::chrono::seconds>(timePoint);
+            const auto ms                                                                              = std::chrono::duration_cast<std::chrono::milliseconds>(timePoint - secs).count();
+            auto       result                                                                          = std::format_to_n(buf, static_cast<int>(size) - 1, "{:%Y-%m-%dT%H:%M:%S}.{:03}", secs, ms);
+            buf[std::min(static_cast<std::size_t>(result.size), static_cast<std::size_t>(size) - 1UZ)] = '\0';
+        } else if (axis.Formatter) {
+            axis.Formatter(value, buf, size, axis.FormatterData);
+        } else {
+            auto result = std::format_to_n(buf, static_cast<std::ptrdiff_t>(size) - 1, "{:.6g}", value);
+            *result.out = '\0';
+        }
+    };
+
+    auto drawAxisTooltip = [&formatAxisValue](ImPlotPlot* plot_, ImAxis axisIdx) {
+        ImPlotAxis& axis = plot_->Axes[axisIdx];
+        if (!axis.Enabled) {
+            return;
+        }
+
+        const auto mousePos = ImPlot::GetPlotMousePos(axis.Vertical ? IMPLOT_AUTO : axisIdx, axis.Vertical ? axisIdx : IMPLOT_AUTO);
+
+        char buf[128];
+        formatAxisValue(axis, axis.Vertical ? mousePos.y : mousePos.x, buf, sizeof(buf));
+
+        std::string_view label = plot_->GetAxisLabel(axis);
+        if (label.empty()) {
+            ImGui::Text("%s", buf);
+        } else {
+            ImGui::Text("%s: %s", label.data(), buf);
+        }
+    };
+
+    {
+        DigitizerUi::IMW::ToolTip tooltip;
+        for (int i = 0; i < 3; ++i) {
+            drawAxisTooltip(plot, ImAxis_X1 + i);
+        }
+        for (int i = 0; i < 3; ++i) {
+            drawAxisTooltip(plot, ImAxis_Y1 + i);
+        }
+    }
+}
+
+} // namespace tooltip
+
+inline constexpr std::string_view kDefaultChartType = "opendigitizer::charts::XYChart";
+
+inline std::vector<std::string> registeredChartTypes() {
+    std::vector<std::string> chartTypes;
+    for (const auto& blockName : gr::globalBlockRegistry().keys()) {
+        // Case-insensitive check for "chart" in the block name
+        std::string lowerName = blockName;
+        std::transform(lowerName.begin(), lowerName.end(), lowerName.begin(), [](unsigned char c) { return std::tolower(c); });
+        if (lowerName.find("chart") != std::string::npos && lowerName.find("chartmonitor") == std::string::npos) {
+            chartTypes.push_back(blockName);
+        }
+    }
+    std::ranges::sort(chartTypes);
+    return chartTypes;
+}
+
+/// D&D protocol for signal sink transfers between charts and legend.
+namespace dnd {
+
+constexpr const char* kPayloadType = "SIGNAL_SINK_DND";
+
+template<std::size_t N>
+constexpr void copyToBuffer(char (&dest)[N], std::string_view src) noexcept {
+    const auto count = std::min(src.size(), N - 1);
+    std::copy(src.data(), src.data() + count, dest);
+    dest[count] = '\0';
+}
+
+struct Payload {
+    char sink_name[256]      = {};
+    char source_chart_id[64] = {};
+
+    [[nodiscard]] bool hasSource() const noexcept { return source_chart_id[0] != '\0'; }
+    [[nodiscard]] bool isValid() const noexcept { return sink_name[0] != '\0'; }
+};
+
+struct State {
+    bool        accepted = false;
+    std::string source_chart_id;
+    std::string sink_name;
+
+    void reset() {
+        accepted = false;
+        source_chart_id.clear();
+        sink_name.clear();
+    }
+
+    [[nodiscard]] bool isAcceptedFrom(std::string_view chartId) const { return accepted && source_chart_id == chartId; }
+};
+inline State g_state;
+
+inline bool handleLegendDropTarget(const char* payloadType = kPayloadType) {
+    bool dropped = false;
+    if (ImGui::BeginDragDropTarget()) {
+        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(payloadType)) {
+            const auto* dnd = static_cast<const Payload*>(payload->Data);
+            if (dnd && dnd->isValid() && dnd->hasSource()) {
+                g_state.accepted = true;
+                dropped          = true;
+            }
+        }
+        ImGui::EndDragDropTarget();
+    }
+    return dropped;
+}
+
+inline void setupPayload(const std::shared_ptr<SignalSink>& sink, std::string_view sourceChartId, const char* payloadType = kPayloadType) {
+    if (!sink) {
+        return;
+    }
+    Payload           dnd{};
+    const std::string sinkIdentifier = sink->signalName().empty() ? std::string(sink->name()) : std::string(sink->signalName());
+    dnd::copyToBuffer(dnd.sink_name, sinkIdentifier);
+    if (!sourceChartId.empty()) {
+        dnd::copyToBuffer(dnd.source_chart_id, sourceChartId);
+    }
+    ImGui::SetDragDropPayload(payloadType, &dnd, sizeof(dnd));
+
+    g_state.accepted        = false;
+    g_state.source_chart_id = sourceChartId;
+    g_state.sink_name       = sinkIdentifier;
+}
+
+inline void renderDragTooltip(const std::shared_ptr<SignalSink>& sink) {
+    if (!sink) {
+        return;
+    }
+    const ImVec2 cursorPos = ImGui::GetCursorScreenPos();
+    const float  boxSize   = ImGui::GetTextLineHeight();
+    ImGui::GetWindowDrawList()->AddRectFilled(cursorPos, ImVec2(cursorPos.x + boxSize, cursorPos.y + boxSize), rgbToImGuiABGR(sink->color()));
+    ImGui::Dummy(ImVec2(boxSize, boxSize));
+    ImGui::SameLine();
+    const auto signalName = sink->signalName();
+    ImGui::TextUnformatted(signalName.data(), signalName.data() + signalName.size());
+}
+
+using AddSinkToChartCallback                   = std::function<void(std::string_view chartId, std::string_view sinkName)>;
+inline AddSinkToChartCallback g_addSinkToChart = nullptr;
+
+} // namespace dnd
+
+/// Callback for requesting chart type transmutation.
+using TransmuteChartCallback                              = std::function<bool(std::string_view chartId, std::string_view newChartType)>;
+inline TransmuteChartCallback g_requestChartTransmutation = nullptr;
+
+/// Callback for requesting chart duplication.
+using DuplicateChartCallback                            = std::function<void(std::string_view chartId)>;
+inline DuplicateChartCallback g_requestChartDuplication = nullptr;
+
+/// Callback for requesting chart removal.
+using RemoveChartCallback                        = std::function<void(std::string_view chartId)>;
+inline RemoveChartCallback g_requestChartRemoval = nullptr;
+
+/// Font Awesome icon constants for context menus.
+namespace menu_icons {
+inline constexpr const char* kXAxis      = "\uf547"; // ruler-horizontal
+inline constexpr const char* kYAxis      = "\uf548"; // ruler-vertical
+inline constexpr const char* kSettings   = "\uf013"; // gear
+inline constexpr const char* kMore       = "\uf141"; // ellipsis
+inline constexpr const char* kChangeType = "\uf0ec"; // arrows-rotate
+inline constexpr const char* kDuplicate  = "\uf0c5"; // copy
+inline constexpr const char* kRemove     = "\uf2ed"; // trash-can
+inline constexpr const char* kAutoFit    = "\uf0b2"; // arrows-maximize
+inline constexpr const char* kLegend     = "\uf0ca"; // list-ul
+inline constexpr const char* kTags       = "\uf02b"; // tag
+inline constexpr const char* kGrid       = "\uf00a"; // table-cells
+inline constexpr const char* kAntiAlias  = "\uf7d9"; // wave-square
+inline constexpr const char* kScale      = "\uf545"; // ruler-combined
+inline constexpr const char* kMin        = "\uf068"; // minus
+inline constexpr const char* kMax        = "\uf067"; // plus
+inline constexpr const char* kCheckOn    = "\uf14a"; // square-check
+inline constexpr const char* kCheckOff   = "\uf0c8"; // square
+inline constexpr const char* kHistory    = "\uf1da"; // clock-rotate-left
+inline constexpr const char* kArrow      = "\uf061"; // arrow-right
+
+/// Renders icon followed by text, using fontIconsSolid for the icon portion.
+inline void iconText(const char* icon, const char* text) {
+    {
+        DigitizerUi::IMW::Font iconFont(DigitizerUi::LookAndFeel::instance().fontIconsSolid);
+        ImGui::TextUnformatted(icon);
+    }
+    ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+    ImGui::TextUnformatted(text);
+}
+
+/// Creates a menu item label with icon prefix (icon rendered in fontIconsSolid).
+/// Returns the combined label string for use with ImGui::MenuItem or ImGui::BeginMenu.
+inline std::string makeIconLabel(const char* icon, std::string_view text) { return std::format("{} {}", icon, text); }
+
+/// MenuItem with icon (icon rendered with fontIconsSolid font).
+inline bool menuItemWithIcon(const char* icon, const char* label, bool selected = false, bool enabled = true) {
+    bool clicked = false;
+    {
+        DigitizerUi::IMW::Font iconFont(DigitizerUi::LookAndFeel::instance().fontIconsSolid);
+        ImGui::TextUnformatted(icon);
+    }
+    ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+    if (ImGui::MenuItem(label, nullptr, selected, enabled)) {
+        clicked = true;
+    }
+    return clicked;
+}
+
+/// BeginMenu with icon (icon rendered with fontIconsSolid font).
+/// Returns true if menu is open - caller must call ImGui::EndMenu() when done.
+inline bool beginMenuWithIcon(const char* icon, const char* label, bool enabled = true) {
+    // Draw icon with icon font
+    {
+        DigitizerUi::IMW::Font iconFont(DigitizerUi::LookAndFeel::instance().fontIconsSolid);
+        ImGui::TextUnformatted(icon);
+    }
+    ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+    // BeginMenu handles its own ID - don't add extra PushID/PopID
+    return ImGui::BeginMenu(label, enabled);
+}
+
+} // namespace menu_icons
+
+struct DrawPrologue {
+    ImPlotFlags plotFlags;
+    ImVec2      plotSize;
+    bool        showLegend;
+    bool        layoutMode;
+    bool        showGrid;
+};
+
+namespace detail {
+
+inline constexpr bool isExcludedFromAutoSettings(std::string_view name) {
+    using namespace std::string_view_literals;
+    constexpr std::array kExcluded = {
+        "chart_name"sv,
+        "chart_title"sv,
+        "data_sinks"sv,
+        "x_min"sv,
+        "x_max"sv,
+        "y_min"sv,
+        "y_max"sv,
+        "x_auto_scale"sv,
+        "y_auto_scale"sv,
+        "n_history"sv,
+        "x_axis_mode"sv,
+        "x_axis_scale"sv,
+        "y_axis_scale"sv,
+        "input_chunk_size"sv,
+        "output_chunk_size"sv,
+        "stride"sv,
+        "disconnect_on_done"sv,
+        "compute_domain"sv,
+        "unique_name"sv,
+        "name"sv,
+        "ui_constraints"sv,
+    };
+    return std::ranges::contains(kExcluded, name);
+}
+
+inline void onScrollWheel(auto&& apply) {
+    if (ImGui::IsItemHovered()) {
+        if (float wheel = ImGui::GetIO().MouseWheel; wheel != 0.0f) {
+            apply(wheel);
+        }
+    }
+}
+
+} // namespace detail
+
+/// Non-polymorphic CRTP mixin for chart signal sink storage and D&D using C++23 deducing this.
+/// Derived classes must: inherit gr::Block<Derived>, define kChartTypeName, data_sinks.
+struct Chart {
+    static constexpr std::size_t kDefaultHistorySize             = 4096;
+    static constexpr double      kCapacityRefreshIntervalSeconds = 30.0; // refresh before 60s timeout
+    static constexpr double      kCapacityDebounceSeconds        = 0.3;  // debounce resize to avoid discontinuities
+
+protected:
+    std::vector<std::shared_ptr<SignalSink>> _signalSinks;
+    double                                   _lastCapacityRefreshTime = 0.0;
+    double                                   _pendingResizeTime       = 0.0;                  // 0 = no pending resize
+    HistoryUnit                              _historyDisplayUnit      = HistoryUnit::seconds; // UI-only, not persisted
+
+public:
+    template<typename Self>
+    void addSignalSink(this Self& self, std::shared_ptr<SignalSink> sink) {
+        if (!sink) {
+            return;
+        }
+        auto it = std::find(self._signalSinks.begin(), self._signalSinks.end(), sink);
+        if (it == self._signalSinks.end()) {
+            std::size_t capacity = kDefaultHistorySize;
+            if constexpr (requires { self.n_history.value; }) {
+                capacity = static_cast<std::size_t>(self.n_history.value);
+            }
+            sink->requestCapacity(std::string(self.unique_name), capacity);
+            self._signalSinks.push_back(std::move(sink));
+        }
+    }
+
+    void removeSignalSink(std::string_view name) {
+        std::erase_if(_signalSinks, [&name](const auto& sink) { return sink && (sink->name() == name || sink->signalName() == name); });
+    }
+
+    void clearSignalSinks() { _signalSinks.clear(); }
+
+    [[nodiscard]] std::size_t                                     signalSinkCount() const noexcept { return _signalSinks.size(); }
+    [[nodiscard]] const std::vector<std::shared_ptr<SignalSink>>& signalSinks() const noexcept { return _signalSinks; }
+    [[nodiscard]] std::vector<std::shared_ptr<SignalSink>>&       signalSinks() noexcept { return _signalSinks; }
+
+    void syncSinksFromNames(const std::vector<std::string>& sinkNames) {
+        std::set<std::string> desired(sinkNames.begin(), sinkNames.end());
+        std::erase_if(_signalSinks, [&desired](const auto& sink) { return sink && !desired.contains(std::string(sink->name())) && !desired.contains(std::string(sink->signalName())); });
+
+        std::set<std::string> current;
+        for (const auto& sink : _signalSinks) {
+            if (sink) {
+                current.insert(std::string(sink->name()));
+                current.insert(std::string(sink->signalName()));
+            }
+        }
+
+        auto& registry = SinkRegistry::instance();
+        for (const auto& name : sinkNames) {
+            if (!current.contains(name)) {
+                if (auto sink = registry.findSink([&name](const auto& s) { return s.signalName() == name || s.name() == name; })) {
+                    _signalSinks.push_back(sink);
+                }
+            }
+        }
+    }
+
+    [[nodiscard]] std::vector<std::string> getSinkNames() const {
+        std::vector<std::string> names;
+        names.reserve(_signalSinks.size());
+        for (const auto& sink : _signalSinks) {
+            if (sink) {
+                names.push_back(std::string(sink->name()));
+            }
+        }
+        return names;
+    }
+
+    template<typename Self>
+    void onDataSinksChanged(this Self& self, const std::vector<std::string>& sinkNames) {
+        self.syncSinksFromNames(sinkNames);
+        std::size_t capacity = kDefaultHistorySize;
+        if constexpr (requires { self.n_history.value; }) {
+            capacity = static_cast<std::size_t>(self.n_history.value);
+        }
+        for (auto& sink : self._signalSinks) {
+            if (sink) {
+                sink->requestCapacity(std::string(self.unique_name), capacity);
+            }
+        }
+    }
+
+    void syncSinksIfNeeded(const std::vector<std::string>& dataSinks) {
+        if (_signalSinks.size() != dataSinks.size()) {
+            syncSinksFromNames(dataSinks);
+            return;
+        }
+        for (std::size_t i = 0; i < dataSinks.size(); ++i) {
+            if (!_signalSinks[i] || (_signalSinks[i]->name() != dataSinks[i] && _signalSinks[i]->signalName() != dataSinks[i])) {
+                syncSinksFromNames(dataSinks);
+                return;
+            }
+        }
+    }
+
+    template<typename Self>
+    void onSinkRemovedFromDnd(this Self& self, std::string_view sinkName) {
+        // resolve the canonical block name for the sink being removed, since
+        // data_sinks may store either name() or signalName()
+        std::string blockName;
+        for (const auto& sink : self._signalSinks) {
+            if (sink && (sink->signalName() == sinkName || sink->name() == sinkName)) {
+                blockName = std::string(sink->name());
+                break;
+            }
+        }
+        // erase by both the DnD name and the resolved block name
+        std::erase_if(self.data_sinks.value, [&sinkName, &blockName](const std::string& entry) { return entry == sinkName || (!blockName.empty() && entry == blockName); });
+        std::ignore = self.settings().set({{"data_sinks", self.data_sinks.value}});
+        std::ignore = self.settings().applyStagedParameters();
+    }
+
+    template<typename Self>
+    void onSinkAddedFromDnd(this Self& self, std::string_view sinkName, std::shared_ptr<SignalSink> sink) {
+        // normalise to block name for consistent data_sinks storage
+        std::string canonicalName = sink ? std::string(sink->name()) : std::string(sinkName);
+        if (std::find(self.data_sinks.value.begin(), self.data_sinks.value.end(), canonicalName) == self.data_sinks.value.end()) {
+            self.data_sinks.value.push_back(canonicalName);
+            std::ignore = self.settings().set({{"data_sinks", self.data_sinks.value}});
+            std::ignore = self.settings().applyStagedParameters();
+        }
+        self.addSignalSink(std::move(sink));
+    }
+
+    template<typename Self>
+    void processAcceptedDndRemoval(this Self& self) {
+        if (dnd::g_state.isAcceptedFrom(self.unique_name)) {
+            self.onSinkRemovedFromDnd(dnd::g_state.sink_name);
+            self.removeSignalSink(dnd::g_state.sink_name);
+            dnd::g_state.reset();
+        }
+    }
+
+    template<typename Self>
+    void setupLegendDragSources(this Self& self) {
+        for (const auto& sink : self._signalSinks) {
+            std::string signalNameStr(sink->signalName());
+            if (signalNameStr.empty()) {
+                signalNameStr = std::string(sink->name());
+            }
+            if (ImPlot::BeginDragDropSourceItem(signalNameStr.c_str())) {
+                dnd::setupPayload(sink, self.unique_name);
+                dnd::renderDragTooltip(sink);
+                ImPlot::EndDragDropSource();
+            }
+        }
+    }
+
+    template<typename Self>
+    bool handlePlotDropTarget(this Self& self, const char* payloadType = dnd::kPayloadType) {
+        bool dropped = false;
+        if (ImPlot::BeginDragDropTargetPlot()) {
+            if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(payloadType)) {
+                const auto* dndPayload = static_cast<const dnd::Payload*>(payload->Data);
+                if (dndPayload && dndPayload->isValid()) {
+                    std::string sinkName(dndPayload->sink_name);
+                    auto        sinkSharedPtr = SinkRegistry::instance().findSink([&sinkName](const auto& s) { return s.signalName() == sinkName || s.name() == sinkName; });
+                    if (sinkSharedPtr) {
+                        self.onSinkAddedFromDnd(sinkName, sinkSharedPtr);
+                        if (dndPayload->hasSource()) {
+                            dnd::g_state.accepted = true;
+                        }
+                        dropped = true;
+                    }
+                }
+            }
+            ImPlot::EndDragDropTarget();
+        }
+        return dropped;
+    }
+
+    template<typename Self>
+    void drawChartTypeSubmenu(this Self& self) {
+        if (menu_icons::beginMenuWithIcon(menu_icons::kChangeType, "Change Type")) {
+            for (const auto& type : registeredChartTypes()) {
+                bool isCurrent = type.ends_with(std::remove_cvref_t<Self>::kChartTypeName);
+                if (ImGui::MenuItem(type.c_str(), nullptr, isCurrent)) {
+                    if (!isCurrent && g_requestChartTransmutation) {
+                        g_requestChartTransmutation(self.unique_name, type);
+                    }
+                }
+            }
+            ImGui::EndMenu();
+        }
+    }
+
+    template<typename Self>
+    void drawDuplicateChartMenuItem(this Self const& self) {
+        if (menu_icons::menuItemWithIcon(menu_icons::kDuplicate, "Duplicate")) {
+            if (g_requestChartDuplication) {
+                g_requestChartDuplication(self.unique_name);
+            }
+        }
+    }
+
+    template<typename Self>
+    void drawRemoveChartMenuItem(this Self const& self) {
+        if (menu_icons::menuItemWithIcon(menu_icons::kRemove, "Remove")) {
+            if (g_requestChartRemoval) {
+                g_requestChartRemoval(self.unique_name);
+            }
+        }
+    }
+
+    /// draws axis submenu (scale selector, auto-fit toggle, min/max editors)
+    template<typename Self>
+    void drawAxisSubmenu(this Self& self, bool isXAxis) {
+        const char* label = isXAxis ? "x-Axis" : "y-Axis";
+        const char* icon  = isXAxis ? menu_icons::kXAxis : menu_icons::kYAxis;
+
+        if (menu_icons::beginMenuWithIcon(icon, label)) {
+            self.drawAxisSubmenuContent(isXAxis);
+            ImGui::EndMenu();
+        }
+    }
+
+    /// Axis submenu content with scale, auto-fit, and min/max controls
+    template<typename Self>
+    void drawAxisSubmenuContent(this Self& self, bool isXAxis) {
+        constexpr float kDragWidth = 70.0f;
+
+        // Get current plot limits from ImPlot (actual displayed range)
+        const auto   plotLimits = ImPlot::GetPlotLimits();
+        const auto&  axisLimits = isXAxis ? plotLimits.X : plotLimits.Y;
+        const double plotMin    = axisLimits.Min;
+        const double plotMax    = axisLimits.Max;
+
+        // Row 1: Scale/transform combo (alone)
+        if constexpr (requires {
+                          self.getAxisScale(true);
+                          self.setAxisScale(true, AxisScale::Linear);
+                      }) {
+            AxisScale currentScale = self.getAxisScale(isXAxis);
+            {
+                DigitizerUi::IMW::Font iconFont(DigitizerUi::LookAndFeel::instance().fontIconsSolid);
+                ImGui::TextUnformatted(menu_icons::kScale);
+            }
+            ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+            ImGui::TextUnformatted("scale:");
+            ImGui::SameLine();
+
+            static const float comboWidth = [] {
+                float maxWidth = 0.0f;
+                for (auto scale : magic_enum::enum_values<AxisScale>()) {
+                    float w  = ImGui::CalcTextSize(magic_enum::enum_name(scale).data()).x;
+                    maxWidth = std::max(maxWidth, w);
+                }
+                return maxWidth + ImGui::GetStyle().FramePadding.x * 2.0f + ImGui::GetFrameHeight();
+            }();
+            ImGui::SetNextItemWidth(comboWidth);
+            if (ImGui::BeginCombo("##scale", magic_enum::enum_name(currentScale).data())) {
+                for (auto scale : magic_enum::enum_values<AxisScale>()) {
+                    bool isSelected = (scale == currentScale);
+                    if (ImGui::Selectable(magic_enum::enum_name(scale).data(), isSelected)) {
+                        self.setAxisScale(isXAxis, scale);
+                    }
+                    if (isSelected) {
+                        ImGui::SetItemDefaultFocus();
+                    }
+                }
+                ImGui::EndCombo();
+            }
+            detail::onScrollWheel([&](float wheel) {
+                auto values = magic_enum::enum_values<AxisScale>();
+                auto it     = std::ranges::find(values, currentScale);
+                if (it != values.end()) {
+                    if (wheel > 0.0f && std::next(it) != values.end()) {
+                        self.setAxisScale(isXAxis, *std::next(it));
+                    } else if (wheel < 0.0f && it != values.begin()) {
+                        self.setAxisScale(isXAxis, *std::prev(it));
+                    }
+                }
+            });
+        }
+
+        // Row 2: Auto-fit checkbox (icon only) + min/max spinners with +/- buttons
+        if constexpr (requires {
+                          self.x_min;
+                          self.x_max;
+                          self.y_min;
+                          self.y_max;
+                          self.x_auto_scale;
+                          self.y_auto_scale;
+                      }) {
+            bool       autoFit    = isXAxis ? self.x_auto_scale.value : self.y_auto_scale.value;
+            const bool wasAutoFit = autoFit;
+
+            // Auto-fit checkbox with icon (no text label)
+            {
+                DigitizerUi::IMW::Font iconFont(DigitizerUi::LookAndFeel::instance().fontIconsSolid);
+                ImGui::TextUnformatted(menu_icons::kAutoFit);
+            }
+            ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+            if (ImGui::Checkbox("##auto", &autoFit)) {
+                if (isXAxis) {
+                    self.x_auto_scale = autoFit;
+                } else {
+                    self.y_auto_scale = autoFit;
+                }
+                // When switching from auto-fit to manual, initialize limits from current plot
+                if (wasAutoFit && !autoFit) {
+                    if (isXAxis) {
+                        self.x_min = plotMin;
+                        self.x_max = plotMax;
+                    } else {
+                        self.y_min = plotMin;
+                        self.y_max = plotMax;
+                    }
+                }
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Auto-fit axis range");
+            }
+
+            // Min/max spinners (disabled when auto-fit is on)
+            ImGui::SameLine();
+            if (autoFit) {
+                ImGui::BeginDisabled();
+            }
+
+            // Use current plot limits when in auto-fit mode, otherwise use stored values
+            double minVal = autoFit ? plotMin : static_cast<double>(isXAxis ? self.x_min.value : self.y_min.value);
+            double maxVal = autoFit ? plotMax : static_cast<double>(isXAxis ? self.x_max.value : self.y_max.value);
+
+            // Calculate increment based on current range (1% of range, or 0.1 if range is invalid)
+            const double range     = std::abs(maxVal - minVal);
+            const double increment = (range > 0.0 && range < 1e10) ? range * 0.01 : 0.1;
+            const float  dragSpeed = static_cast<float>(increment * 0.1);
+
+            // Min value with +/- buttons (same pattern as Block settings)
+            {
+                DigitizerUi::IMW::Font iconFont(DigitizerUi::LookAndFeel::instance().fontIconsSolid);
+                if (ImGui::Button("\uf146##minDec")) { // minus-square
+                    minVal -= increment;
+                    if (isXAxis) {
+                        self.x_min = minVal;
+                    } else {
+                        self.y_min = minVal;
+                    }
+                }
+            }
+            ImGui::SameLine(0.0f, 2.0f);
+            ImGui::SetNextItemWidth(kDragWidth);
+            if (ImGui::DragScalar("##min", ImGuiDataType_Double, &minVal, dragSpeed, nullptr, nullptr, "%.4g")) {
+                if (isXAxis) {
+                    self.x_min = minVal;
+                } else {
+                    self.y_min = minVal;
+                }
+            }
+            detail::onScrollWheel([&](float wheel) {
+                minVal += static_cast<double>(wheel) * increment;
+                if (isXAxis) {
+                    self.x_min = minVal;
+                } else {
+                    self.y_min = minVal;
+                }
+            });
+            ImGui::SameLine(0.0f, 2.0f);
+            {
+                DigitizerUi::IMW::Font iconFont(DigitizerUi::LookAndFeel::instance().fontIconsSolid);
+                if (ImGui::Button("\uf0fe##minInc")) { // plus-square
+                    minVal += increment;
+                    if (isXAxis) {
+                        self.x_min = minVal;
+                    } else {
+                        self.y_min = minVal;
+                    }
+                }
+            }
+
+            ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+            menu_icons::iconText(menu_icons::kArrow, "");
+
+            // Max value with +/- buttons
+            ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+            {
+                DigitizerUi::IMW::Font iconFont(DigitizerUi::LookAndFeel::instance().fontIconsSolid);
+                if (ImGui::Button("\uf146##maxDec")) { // minus-square
+                    maxVal -= increment;
+                    if (isXAxis) {
+                        self.x_max = maxVal;
+                    } else {
+                        self.y_max = maxVal;
+                    }
+                }
+            }
+            ImGui::SameLine(0.0f, 2.0f);
+            ImGui::SetNextItemWidth(kDragWidth);
+            if (ImGui::DragScalar("##max", ImGuiDataType_Double, &maxVal, dragSpeed, nullptr, nullptr, "%.4g")) {
+                if (isXAxis) {
+                    self.x_max = maxVal;
+                } else {
+                    self.y_max = maxVal;
+                }
+            }
+            detail::onScrollWheel([&](float wheel) {
+                maxVal += static_cast<double>(wheel) * increment;
+                if (isXAxis) {
+                    self.x_max = maxVal;
+                } else {
+                    self.y_max = maxVal;
+                }
+            });
+            ImGui::SameLine(0.0f, 2.0f);
+            {
+                DigitizerUi::IMW::Font iconFont(DigitizerUi::LookAndFeel::instance().fontIconsSolid);
+                if (ImGui::Button("\uf0fe##maxInc")) { // plus-square
+                    maxVal += increment;
+                    if (isXAxis) {
+                        self.x_max = maxVal;
+                    } else {
+                        self.y_max = maxVal;
+                    }
+                }
+            }
+
+            if (autoFit) {
+                ImGui::EndDisabled();
+            }
+        }
+
+        // History depth control (only for x-axis)
+        if constexpr (requires { self.n_history; }) {
+            if (isXAxis) {
+                ImGui::Separator();
+                self.drawHistoryDepthWidget();
+            }
+        }
+    }
+
+    /// draws the full history depth control widget: value input + unit combo + log slider + status line
+    /// n_history (gr::Size_t, samples) is the persistent property; display unit is UI-only state
+    template<typename Self>
+    void drawHistoryDepthWidget(this Self& self) {
+        constexpr float      kDragWidth  = 90.0f;
+        constexpr float      kComboWidth = 80.0f;
+        constexpr gr::Size_t kMinSamples = 4U;
+        constexpr gr::Size_t kMaxSamples = 1'000'000U;
+
+        // canonical 1-2-5 decade stops for time and sample count
+        constexpr std::array kTimeStops     = {0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1800.0, 3600.0};
+        constexpr float      kTimeSliderMin = 0.0f;
+        constexpr float      kTimeSliderMax = static_cast<float>(kTimeStops.size() - 1);
+
+        constexpr std::array<gr::Size_t, 22> kSampleStops     = {4U, 10U, 20U, 50U, 100U, 200U, 500U, 1'000U, 2'000U, 5'000U, 10'000U, 20'000U, 50'000U, 100'000U, 200'000U, 500'000U, 1'000'000U, 2'000'000U, 5'000'000U, 10'000'000U, 50'000'000U, 100'000'000U};
+        constexpr float                      kSampleSliderMin = 0.0f;
+        constexpr float                      kSampleSliderMax = static_cast<float>(kSampleStops.size() - 1);
+
+        gr::Size_t nSamples = self.n_history.value;
+
+        // get sample rate from first available sink
+        float sampleRate = 0.0f;
+        for (const auto& sink : self._signalSinks) {
+            if (sink) {
+                sampleRate = sink->sampleRate();
+                break;
+            }
+        }
+        const bool rateKnown = sampleRate > 0.0f;
+
+        // compute display value in the user's chosen unit
+        double displayValue = static_cast<double>(nSamples);
+        if (self._historyDisplayUnit == HistoryUnit::seconds && rateKnown) {
+            displayValue = static_cast<double>(nSamples) / static_cast<double>(sampleRate);
+        }
+
+        // helper: convert display value back to samples
+        auto toSamples = [&](double val) -> gr::Size_t {
+            if (self._historyDisplayUnit == HistoryUnit::seconds && rateKnown) {
+                double samples = std::ceil(std::max(val, 0.0) * static_cast<double>(sampleRate));
+                return static_cast<gr::Size_t>(std::clamp(samples, static_cast<double>(kMinSamples), static_cast<double>(kMaxSamples)));
+            }
+            return static_cast<gr::Size_t>(std::clamp(std::max(val, 0.0), static_cast<double>(kMinSamples), static_cast<double>(kMaxSamples)));
+        };
+
+        // helper: schedule a debounced resize
+        auto scheduleResize = [&]() { self._pendingResizeTime = ImGui::GetTime() + kCapacityDebounceSeconds; };
+
+        // --- Row 1: Icon + [- value +] [unit combo] ---
+        {
+            DigitizerUi::IMW::Font iconFont(DigitizerUi::LookAndFeel::instance().fontIconsSolid);
+            ImGui::TextUnformatted(menu_icons::kHistory);
+        }
+        ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+
+        // decrease button
+        {
+            DigitizerUi::IMW::Font iconFont(DigitizerUi::LookAndFeel::instance().fontIconsSolid);
+            if (ImGui::Button("\uf146##depthDec")) { // minus-square
+                double step    = std::max(self._historyDisplayUnit == HistoryUnit::seconds ? 0.1 : 100.0, displayValue * 0.1);
+                displayValue   = std::max(displayValue - step, self._historyDisplayUnit == HistoryUnit::seconds ? 0.001 : static_cast<double>(kMinSamples));
+                self.n_history = toSamples(displayValue);
+                scheduleResize();
+            }
+        }
+        ImGui::SameLine(0.0f, 2.0f);
+
+        // value drag input with logarithmic speed
+        ImGui::SetNextItemWidth(kDragWidth);
+        float       dragSpeed = static_cast<float>(std::max(displayValue * 0.01, 0.001));
+        const char* format    = (self._historyDisplayUnit == HistoryUnit::seconds) ? "%.3g" : "%.0f";
+        if (ImGui::DragScalar("##historyValue", ImGuiDataType_Double, &displayValue, dragSpeed, nullptr, nullptr, format)) {
+            self.n_history = toSamples(displayValue);
+            scheduleResize();
+        }
+        detail::onScrollWheel([&](float wheel) {
+            double step = std::max(self._historyDisplayUnit == HistoryUnit::seconds ? 0.1 : 100.0, displayValue * 0.1);
+            displayValue += static_cast<double>(wheel) * step;
+            displayValue   = std::max(displayValue, self._historyDisplayUnit == HistoryUnit::seconds ? 0.001 : static_cast<double>(kMinSamples));
+            self.n_history = toSamples(displayValue);
+            scheduleResize();
+        });
+
+        ImGui::SameLine(0.0f, 2.0f);
+        // increase button
+        {
+            DigitizerUi::IMW::Font iconFont(DigitizerUi::LookAndFeel::instance().fontIconsSolid);
+            if (ImGui::Button("\uf0fe##depthInc")) { // plus-square
+                double step    = std::max(self._historyDisplayUnit == HistoryUnit::seconds ? 0.1 : 100.0, displayValue * 0.1);
+                displayValue   = displayValue + step;
+                self.n_history = toSamples(displayValue);
+                scheduleResize();
+            }
+        }
+
+        ImGui::SameLine();
+
+        // unit combo (display unit only, not persisted)
+        ImGui::SetNextItemWidth(kComboWidth);
+        auto currentUnitName = magic_enum::enum_name(self._historyDisplayUnit);
+        if (ImGui::BeginCombo("##historyUnit", currentUnitName.data())) {
+            for (auto unit : magic_enum::enum_values<HistoryUnit>()) {
+                bool enabled  = (unit != HistoryUnit::seconds) || rateKnown;
+                bool selected = (unit == self._historyDisplayUnit);
+
+                if (!enabled) {
+                    ImGui::BeginDisabled();
+                }
+                if (ImGui::Selectable(magic_enum::enum_name(unit).data(), selected)) {
+                    self._historyDisplayUnit = unit; // just change display, n_history stays unchanged
+                }
+                if (selected) {
+                    ImGui::SetItemDefaultFocus();
+                }
+                if (!enabled) {
+                    ImGui::EndDisabled();
+                }
+            }
+            ImGui::EndCombo();
+        }
+        detail::onScrollWheel([&](float wheel) {
+            auto values = magic_enum::enum_values<HistoryUnit>();
+            auto it     = std::ranges::find(values, self._historyDisplayUnit);
+            if (it != values.end()) {
+                if (wheel > 0.0f && std::next(it) != values.end()) {
+                    self._historyDisplayUnit = *std::next(it);
+                } else if (wheel < 0.0f && it != values.begin()) {
+                    self._historyDisplayUnit = *std::prev(it);
+                }
+            }
+        });
+
+        // --- Row 2: Quick-adjust slider ---
+        nSamples = self.n_history.value; // re-read after potential changes above
+        ImGui::SetNextItemWidth(std::max(ImGui::GetContentRegionAvail().x, 60.0f));
+
+        if (self._historyDisplayUnit == HistoryUnit::seconds && rateKnown) {
+            // seconds mode: snap to canonical time stops
+            double currentSeconds = static_cast<double>(nSamples) / static_cast<double>(sampleRate);
+            // find nearest stop index
+            float  bestIdx  = 0.0f;
+            double bestDist = std::abs(std::log(currentSeconds) - std::log(kTimeStops[0]));
+            for (std::size_t i = 1; i < kTimeStops.size(); ++i) {
+                double dist = std::abs(std::log(currentSeconds) - std::log(kTimeStops[i]));
+                if (dist < bestDist) {
+                    bestDist = dist;
+                    bestIdx  = static_cast<float>(i);
+                }
+            }
+
+            auto formatTimeStop = [](double seconds) -> std::string {
+                if (seconds >= 60.0) {
+                    return std::format("{:.0f} min", seconds / 60.0);
+                }
+                if (seconds >= 1.0) {
+                    return std::format("{:.0f} s", seconds);
+                }
+                if (seconds >= 0.01) {
+                    return std::format("{:.0f} ms", seconds * 1e3);
+                }
+                return std::format("{:.1f} ms", seconds * 1e3);
+            };
+
+            if (ImGui::SliderFloat("##historySlider", &bestIdx, kTimeSliderMin, kTimeSliderMax, formatTimeStop(kTimeStops[static_cast<std::size_t>(std::round(bestIdx))]).c_str(), ImGuiSliderFlags_NoInput)) {
+                std::size_t idx        = static_cast<std::size_t>(std::clamp(std::round(bestIdx), kTimeSliderMin, kTimeSliderMax));
+                double      seconds    = kTimeStops[idx];
+                gr::Size_t  newSamples = static_cast<gr::Size_t>(std::ceil(seconds * static_cast<double>(sampleRate)));
+                self.n_history         = std::clamp(newSamples, kMinSamples, kMaxSamples);
+                scheduleResize();
+            }
+            detail::onScrollWheel([&](float wheel) {
+                bestIdx               = std::clamp(std::round(bestIdx) + ((wheel > 0.0f) ? 1.0f : -1.0f), kTimeSliderMin, kTimeSliderMax);
+                auto       idx        = static_cast<std::size_t>(bestIdx);
+                double     seconds    = kTimeStops[idx];
+                gr::Size_t newSamples = static_cast<gr::Size_t>(std::ceil(seconds * static_cast<double>(sampleRate)));
+                self.n_history        = std::clamp(newSamples, kMinSamples, kMaxSamples);
+                scheduleResize();
+            });
+        } else {
+            // samples mode: 1-2-5 decade stop sequence
+            float  bestIdx  = 0.0f;
+            double bestDist = std::abs(std::log(static_cast<double>(nSamples)) - std::log(static_cast<double>(kSampleStops[0])));
+            for (std::size_t i = 1; i < kSampleStops.size(); ++i) {
+                double dist = std::abs(std::log(static_cast<double>(nSamples)) - std::log(static_cast<double>(kSampleStops[i])));
+                if (dist < bestDist) {
+                    bestDist = dist;
+                    bestIdx  = static_cast<float>(i);
+                }
+            }
+
+            auto formatSampleStop = [](gr::Size_t samples) -> std::string {
+                if (samples >= 1'000'000U) {
+                    return std::format("{:.0f}M", static_cast<double>(samples) / 1e6);
+                }
+                if (samples >= 1'000U) {
+                    return std::format("{:.0f}k", static_cast<double>(samples) / 1e3);
+                }
+                return std::format("{}", samples);
+            };
+
+            if (ImGui::SliderFloat("##historySlider", &bestIdx, kSampleSliderMin, kSampleSliderMax, formatSampleStop(kSampleStops[static_cast<std::size_t>(std::round(bestIdx))]).c_str(), ImGuiSliderFlags_NoInput)) {
+                auto idx       = static_cast<std::size_t>(std::clamp(std::round(bestIdx), kSampleSliderMin, kSampleSliderMax));
+                self.n_history = std::clamp(kSampleStops[idx], kMinSamples, kMaxSamples);
+                scheduleResize();
+            }
+            detail::onScrollWheel([&](float wheel) {
+                bestIdx        = std::clamp(std::round(bestIdx) + ((wheel > 0.0f) ? 1.0f : -1.0f), kSampleSliderMin, kSampleSliderMax);
+                auto idx       = static_cast<std::size_t>(bestIdx);
+                self.n_history = std::clamp(kSampleStops[idx], kMinSamples, kMaxSamples);
+                scheduleResize();
+            });
+        }
+
+        // --- Row 3: Status line ---
+        nSamples = self.n_history.value;
+        if (self._historyDisplayUnit == HistoryUnit::seconds) {
+            if (rateKnown) {
+                ImGui::TextDisabled("= %zu samples @ %.0f Hz", static_cast<std::size_t>(nSamples), static_cast<double>(sampleRate));
+            } else {
+                ImGui::TextDisabled("sample rate unknown");
+            }
+        } else {
+            if (rateKnown) {
+                double      durationSeconds = static_cast<double>(nSamples) / static_cast<double>(sampleRate);
+                std::string durationStr;
+                if (durationSeconds >= 1.0) {
+                    durationStr = std::format("{:.2f} s", durationSeconds);
+                } else if (durationSeconds >= 0.001) {
+                    durationStr = std::format("{:.2f} ms", durationSeconds * 1000.0);
+                } else {
+                    durationStr = std::format("{:.2f} \xc2\xb5s", durationSeconds * 1'000'000.0); // µs
+                }
+                ImGui::TextDisabled("\xe2\x89\x88 %s @ %.0f Hz", durationStr.c_str(), static_cast<double>(sampleRate)); // ≈
+            }
+        }
+    }
+
+    template<typename Self>
+    void updateAllSinksCapacity(this Self& self) {
+        std::size_t capacity = kDefaultHistorySize;
+        if constexpr (requires { self.n_history.value; }) {
+            capacity = static_cast<std::size_t>(self.n_history.value);
+        }
+        for (auto& sink : self._signalSinks) {
+            if (sink) {
+                sink->requestCapacity(std::string(self.unique_name), capacity);
+            }
+        }
+        self._lastCapacityRefreshTime = ImGui::GetTime();
+    }
+
+    /// processes pending debounced resize and periodic capacity refresh
+    template<typename Self>
+    void refreshCapacityIfNeeded(this Self& self) {
+        const double now = ImGui::GetTime();
+
+        // debounced resize: apply pending capacity change after user stops adjusting
+        if (self._pendingResizeTime > 0.0 && now >= self._pendingResizeTime) {
+            self._pendingResizeTime = 0.0;
+            self.updateAllSinksCapacity();
+        }
+
+        // periodic refresh to keep capacity requests alive (before 60s expiry)
+        if ((now - self._lastCapacityRefreshTime) >= kCapacityRefreshIntervalSeconds) {
+            self.updateAllSinksCapacity();
+        }
+    }
+
+    template<typename Self>
+    DrawPrologue prepareDrawPrologue(this Self& self, const gr::property_map& config) {
+        self.processAcceptedDndRemoval();
+        self.syncSinksIfNeeded(self.data_sinks.value);
+        self.refreshCapacityIfNeeded();
+
+        bool layoutMode = false;
+        if (auto it = config.find("layoutMode"); it != config.end()) {
+            if (const auto* val = std::get_if<bool>(&it->second)) {
+                layoutMode = *val;
+            }
+        }
+
+        bool effectiveShowLegend = false;
+        if constexpr (requires { self.show_legend; }) {
+            effectiveShowLegend = self.show_legend.value || layoutMode;
+        }
+
+        float       layoutOffset = layoutMode ? 5.f : 0.f;
+        ImVec2      plotSize     = ImGui::GetContentRegionAvail() - ImVec2(2 * layoutOffset, 2 * layoutOffset);
+        ImPlotFlags plotFlags    = ImPlotFlags_NoChild | ImPlotFlags_NoMouseText | ImPlotFlags_NoTitle;
+        if (!effectiveShowLegend) {
+            plotFlags |= ImPlotFlags_NoLegend;
+        }
+
+        bool effectiveShowGrid = true;
+        if constexpr (requires { self.show_grid; }) {
+            effectiveShowGrid = self.show_grid.value;
+        }
+
+        return DrawPrologue{plotFlags, plotSize, effectiveShowLegend, layoutMode, effectiveShowGrid};
+    }
+
+    template<typename Self>
+    void handleSettingsChanged(this Self& self, const gr::property_map& newSettings) {
+        if (newSettings.contains("data_sinks")) {
+            self.onDataSinksChanged(self.data_sinks.value);
+        }
+        if constexpr (requires { self.n_history; }) {
+            if (newSettings.contains("n_history")) {
+                self.updateAllSinksCapacity();
+            }
+        }
+    }
+
+    template<typename Self>
+    [[nodiscard]] AxisScale getAxisScale(this const Self& self, bool isX) noexcept {
+        if (auto cfg = parseAxisConfig(self.ui_constraints.value, isX)) {
+            return cfg->scale;
+        }
+        return AxisScale::Linear;
+    }
+
+    template<typename Self>
+    void setAxisScale(this Self& self, bool isX, AxisScale scale) {
+        auto& constraints = self.ui_constraints.value;
+        auto  axesIt      = constraints.find("axes");
+
+        std::vector<pmtv::pmt> axesVec;
+        if (axesIt != constraints.end()) {
+            if (const auto* existing = std::get_if<std::vector<pmtv::pmt>>(&axesIt->second)) {
+                axesVec = *existing;
+            }
+        }
+
+        std::string targetAxis = isX ? "X" : "Y";
+        bool        found      = false;
+        for (auto& axisPmt : axesVec) {
+            auto* axisMap = std::get_if<gr::property_map>(&axisPmt);
+            if (!axisMap) {
+                continue;
+            }
+            auto axisStrIt = axisMap->find("axis");
+            if (axisStrIt == axisMap->end()) {
+                continue;
+            }
+            const auto* axisStr = std::get_if<std::string>(&axisStrIt->second);
+            if (axisStr && (*axisStr == targetAxis || *axisStr == (isX ? "x" : "y"))) {
+                (*axisMap)["scale"] = std::string(magic_enum::enum_name(scale));
+                found               = true;
+                break;
+            }
+        }
+        if (!found) {
+            gr::property_map newAxis;
+            newAxis["axis"]  = targetAxis;
+            newAxis["scale"] = std::string(magic_enum::enum_name(scale));
+            axesVec.push_back(newAxis);
+        }
+        constraints["axes"] = axesVec;
+        std::ignore         = self.settings().set({{"ui_constraints", constraints}});
+    }
+
+    template<typename Self>
+    void handleCommonInteractions(this Self& self) {
+        std::string popupId = std::string(std::remove_cvref_t<Self>::kChartTypeName) + "ContextMenu";
+        self.drawContextMenu(popupId.c_str());
+        self.setupLegendDragSources();
+        self.handlePlotDropTarget();
+    }
+
+    template<typename Self>
+    void drawEmptyPlot(this Self& self, const char* message, ImPlotFlags plotFlags, const ImVec2& size) {
+        if (DigitizerUi::TouchHandler<>::BeginZoomablePlot(self.chart_name.value, size, plotFlags)) {
+            ImPlot::SetupAxis(ImAxis_X1, "X", ImPlotAxisFlags_None);
+            ImPlot::SetupAxis(ImAxis_Y1, "Y", ImPlotAxisFlags_None);
+            ImPlot::SetupAxisLimits(ImAxis_X1, -1.0, 1.0, ImPlotCond_Once);
+            ImPlot::SetupAxisLimits(ImAxis_Y1, -1.0, 1.0, ImPlotCond_Once);
+            ImPlot::SetupFinish();
+            auto limits = ImPlot::GetPlotLimits();
+            ImPlot::PlotText(message, (limits.X.Min + limits.X.Max) / 2, (limits.Y.Min + limits.Y.Max) / 2);
+            tooltip::showPlotMouseTooltip();
+            self.handleCommonInteractions();
+            DigitizerUi::TouchHandler<>::EndZoomablePlot();
+        }
+    }
+
+    template<typename FieldType>
+    static void drawAutoSettingWidget(FieldType& field, std::string_view fieldName) {
+        using ValueType              = FieldType::value_type;
+        using LimitType              = FieldType::LimitType;
+        constexpr float kWidgetWidth = 120.0f;
+        constexpr bool  hasLimits    = (LimitType::MinRange != LimitType::MaxRange);
+        constexpr bool  useLog       = hasLimits && (static_cast<double>(LimitType::MaxRange) - static_cast<double>(LimitType::MinRange)) > 100'000.0;
+
+        const auto             label       = std::format("##{}", fieldName);
+        const ImGuiSliderFlags sliderFlags = useLog ? ImGuiSliderFlags_Logarithmic : ImGuiSliderFlags_None;
+
+        if constexpr (std::is_same_v<ValueType, bool>) {
+            bool val = field.value;
+            if (ImGui::Checkbox(label.c_str(), &val)) {
+                field = val;
+            }
+            ImGui::SameLine();
+            ImGui::TextUnformatted(FieldType::description().data());
+        } else if constexpr (std::is_floating_point_v<ValueType>) {
+            ImGui::SetNextItemWidth(kWidgetWidth);
+            float val = static_cast<float>(field.value);
+            if constexpr (hasLimits) {
+                constexpr float lo = static_cast<float>(LimitType::MinRange);
+                constexpr float hi = static_cast<float>(LimitType::MaxRange);
+                if (ImGui::SliderFloat(label.c_str(), &val, lo, hi, "%.2f", sliderFlags)) {
+                    field = static_cast<ValueType>(val);
+                }
+                detail::onScrollWheel([&](float wheel) {
+                    if constexpr (useLog) {
+                        val *= std::pow(1.1f, wheel);
+                    } else {
+                        val += wheel * (hi - lo) * 0.01f;
+                    }
+                    field = static_cast<ValueType>(std::clamp(val, lo, hi));
+                });
+            } else {
+                if (ImGui::DragFloat(label.c_str(), &val, 0.01f, 0.0f, 0.0f, "%.2f")) {
+                    field = static_cast<ValueType>(val);
+                }
+                detail::onScrollWheel([&](float wheel) {
+                    val += wheel * std::max(0.01f, std::abs(val) * 0.05f);
+                    field = static_cast<ValueType>(val);
+                });
+            }
+            ImGui::SameLine();
+            ImGui::TextUnformatted(FieldType::description().data());
+        } else if constexpr (std::is_integral_v<ValueType> && !std::is_same_v<ValueType, bool>) {
+            ImGui::SetNextItemWidth(kWidgetWidth);
+            int val = static_cast<int>(field.value);
+            if constexpr (hasLimits) {
+                constexpr int lo = static_cast<int>(LimitType::MinRange);
+                constexpr int hi = static_cast<int>(LimitType::MaxRange);
+                if (ImGui::SliderInt(label.c_str(), &val, lo, hi, "%d", sliderFlags)) {
+                    field = static_cast<ValueType>(val);
+                }
+                detail::onScrollWheel([&](float wheel) {
+                    if constexpr (useLog) {
+                        int newVal = static_cast<int>(std::round(static_cast<float>(val) * std::pow(1.1f, wheel)));
+                        if (newVal == val) {
+                            newVal += (wheel > 0.0f) ? 1 : -1;
+                        }
+                        val = std::clamp(newVal, lo, hi);
+                    } else {
+                        val = std::clamp(val + static_cast<int>(wheel) * std::max(1, (hi - lo) / 100), lo, hi);
+                    }
+                    field = static_cast<ValueType>(val);
+                });
+            } else {
+                if (ImGui::DragInt(label.c_str(), &val, 1.0f)) {
+                    field = static_cast<ValueType>(val);
+                }
+                detail::onScrollWheel([&](float wheel) {
+                    val += static_cast<int>(wheel) * std::max(1, std::abs(val) / 20);
+                    field = static_cast<ValueType>(val);
+                });
+            }
+            ImGui::SameLine();
+            ImGui::TextUnformatted(FieldType::description().data());
+        } else if constexpr (std::is_enum_v<ValueType>) {
+            ImGui::SetNextItemWidth(kWidgetWidth);
+            auto current = field.value;
+            if (ImGui::BeginCombo(label.c_str(), magic_enum::enum_name(current).data())) {
+                for (auto e : magic_enum::enum_values<ValueType>()) {
+                    bool selected = (e == current);
+                    if (ImGui::Selectable(magic_enum::enum_name(e).data(), selected)) {
+                        field = e;
+                    }
+                    if (selected) {
+                        ImGui::SetItemDefaultFocus();
+                    }
+                }
+                ImGui::EndCombo();
+            }
+            ImGui::SameLine();
+            ImGui::TextUnformatted(FieldType::description().data());
+        } else if constexpr (std::is_same_v<ValueType, std::string>) {
+            ImGui::SetNextItemWidth(kWidgetWidth);
+            std::array<char, 256> buf{};
+            std::ranges::copy(field.value | std::views::take(buf.size() - 1), buf.begin());
+            if (ImGui::InputText(label.c_str(), buf.data(), buf.size())) {
+                field = std::string(buf.data());
+            }
+            ImGui::SameLine();
+            ImGui::TextUnformatted(FieldType::description().data());
+        }
+    }
+
+    template<typename Self>
+    void drawAutoGeneratedSettings(this Self& self, bool visibleOnly) {
+        using SelfType = std::remove_cvref_t<Self>;
+        gr::refl::for_each_data_member_index<SelfType>([&](auto kIdx) {
+            constexpr std::size_t idx = decltype(kIdx)::value;
+            using MemberType          = gr::refl::data_member_type<SelfType, idx>;
+            using RawType             = std::remove_cvref_t<MemberType>;
+
+            if constexpr (gr::AnnotatedType<RawType>) {
+                constexpr std::string_view name = gr::refl::data_member_name<SelfType, idx>;
+                if constexpr (!detail::isExcludedFromAutoSettings(name)) {
+                    constexpr bool isVisible = RawType::visible();
+                    if (isVisible == visibleOnly) {
+                        auto& field = gr::refl::data_member<idx>(self);
+                        drawAutoSettingWidget(field, name);
+                    }
+                }
+            }
+        });
+    }
+
+    template<typename Self>
+    void drawSettingsSubmenu(this Self& self) {
+        if (menu_icons::beginMenuWithIcon(menu_icons::kSettings, "Settings")) {
+            self.drawAutoGeneratedSettings(/*visibleOnly=*/false);
+            if constexpr (requires { self.customMenuCallback; }) {
+                if (self.customMenuCallback) {
+                    ImGui::Separator();
+                    self.customMenuCallback();
+                }
+            }
+            ImGui::EndMenu();
+        }
+    }
+
+    template<typename Self>
+    void drawCommonContextMenuItems(this Self& self) {
+        self.drawAxisSubmenu(true);
+        self.drawAxisSubmenu(false);
+        ImGui::Separator();
+
+        self.drawSettingsSubmenu();
+        self.drawAutoGeneratedSettings(/*visibleOnly=*/true);
+
+        ImGui::Separator();
+        self.drawChartTypeSubmenu();
+        self.drawDuplicateChartMenuItem();
+        self.drawRemoveChartMenuItem();
+    }
+
+    /// draws context menu as a standard linear popup
+    template<typename Self>
+    void drawContextMenu(this Self& self, const char* popupId = "ChartContextMenu") {
+        // Only open our menu when hovering the plot area, NOT when hovering an axis
+        // (ImPlot provides its own axis context menus for Auto-Fit, Invert, etc.)
+        const bool anyAxisHovered = ImPlot::IsAxisHovered(ImAxis_X1) || ImPlot::IsAxisHovered(ImAxis_X2) || ImPlot::IsAxisHovered(ImAxis_X3) || ImPlot::IsAxisHovered(ImAxis_Y1) || ImPlot::IsAxisHovered(ImAxis_Y2) || ImPlot::IsAxisHovered(ImAxis_Y3);
+
+        const bool rightClicked = ImPlot::IsPlotHovered() && !anyAxisHovered && ImGui::IsMouseClicked(ImGuiMouseButton_Right);
+
+        if (rightClicked) {
+            ImGui::OpenPopup(popupId);
+        }
+        if (ImGui::BeginPopup(popupId)) {
+            self.drawCommonContextMenuItems();
+            ImGui::EndPopup();
+        }
+    }
+};
+
+} // namespace opendigitizer::charts
+
+#endif // OPENDIGITIZER_CHARTS_CHART_HPP

--- a/src/ui/charts/Charts.hpp
+++ b/src/ui/charts/Charts.hpp
@@ -1,0 +1,11 @@
+#ifndef OPENDIGITIZER_CHARTS_HPP
+#define OPENDIGITIZER_CHARTS_HPP
+
+/// Convenience header that includes all chart-related headers.
+
+#include "Chart.hpp"
+#include "SignalSink.hpp"
+#include "XYChart.hpp"
+#include "YYChart.hpp"
+
+#endif // OPENDIGITIZER_CHARTS_HPP

--- a/src/ui/charts/SignalSink.hpp
+++ b/src/ui/charts/SignalSink.hpp
@@ -1,0 +1,776 @@
+#ifndef OPENDIGITIZER_SIGNALSINK_HPP
+#define OPENDIGITIZER_SIGNALSINK_HPP
+
+#include "gnuradio-4.0/basic/ConverterBlocks.hpp"
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/DataSet.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <span>
+#include <string_view>
+#include <vector>
+
+namespace opendigitizer {
+
+// ImPlot-compatible point struct (mirrors ImPlotPoint but library-independent)
+struct PlotPoint {
+    double x;
+    double y;
+};
+
+// Function pointer type compatible with ImPlotGetter
+using PlotGetter = PlotPoint (*)(int idx, void* userData);
+
+// Data accessor struct that can be directly passed to ImPlot's PlotLineG
+struct PlotData {
+    PlotGetter getter;
+    void*      user_data;
+    int        count;
+
+    [[nodiscard]] bool empty() const noexcept { return count <= 0 || getter == nullptr; }
+};
+
+/**
+ * @brief Line drawing style for signal rendering.
+ *
+ * Controls how the signal line is rendered in charts.
+ */
+enum class LineStyle : std::uint8_t {
+    Solid,   ///< Continuous solid line (default)
+    Dashed,  ///< Dashed line pattern (e.g., "- - - -")
+    Dotted,  ///< Dotted line pattern (e.g., ". . . .")
+    DashDot, ///< Alternating dash-dot pattern (e.g., "- . - .")
+    None     ///< No line drawn (markers only)
+};
+
+/**
+ * @brief RAII guard for thread-safe data access to signal sink buffers.
+ *
+ * Holds a lock on the sink's data mutex for the duration of its lifetime.
+ * Data access methods on SignalSink are only safe to call while holding this guard.
+ *
+ * Usage:
+ * @code
+ * {
+ *     auto guard = sink->dataGuard();
+ *     // Safe to access sink data here
+ *     for (std::size_t i = 0; i < sink->size(); ++i) {
+ *         double x = sink->xAt(i);
+ *         float y = sink->yAt(i);
+ *     }
+ * } // Lock released when guard goes out of scope
+ * @endcode
+ */
+class DataGuard {
+    std::unique_lock<std::mutex> _lock;
+
+public:
+    DataGuard() = default; // empty guard (no mutex locked)
+    explicit DataGuard(std::mutex& mutex) : _lock(mutex) {}
+
+    // Move-only (like unique_lock)
+    DataGuard(DataGuard&&) noexcept            = default;
+    DataGuard& operator=(DataGuard&&) noexcept = default;
+    DataGuard(const DataGuard&)                = delete;
+    DataGuard& operator=(const DataGuard&)     = delete;
+
+    /// Release the lock early (before destruction)
+    void release() { _lock.unlock(); }
+
+    /// Check if lock is still held
+    [[nodiscard]] bool ownsLock() const noexcept { return _lock.owns_lock(); }
+};
+
+/**
+ * @brief Abstract interface for signal sink data access.
+ *
+ * This is a pure interface - it does NOT extend BlockModel.
+ * Concrete implementations (like SinkAdapter<T>) hold a non-owning
+ * pointer to the underlying block and delegate calls.
+ *
+ * Signal sinks are flowgraph endpoints that:
+ * - Receive data via processBulk() (implemented in concrete Block<T>)
+ * - Store data in internal buffers with mutex protection
+ * - Provide thread-safe data access for rendering
+ */
+struct SignalSink {
+    virtual ~SignalSink() = default;
+
+    [[nodiscard]] virtual std::string_view name() const noexcept       = 0;
+    [[nodiscard]] virtual std::string_view uniqueName() const noexcept = 0;
+
+    [[nodiscard]] virtual std::string_view signalName() const noexcept = 0;
+    [[nodiscard]] virtual std::uint32_t    color() const noexcept      = 0;
+    [[nodiscard]] virtual float            sampleRate() const noexcept = 0;
+
+    [[nodiscard]] virtual LineStyle lineStyle() const noexcept = 0;
+
+    [[nodiscard]] virtual float lineWidth() const noexcept = 0;
+
+    [[nodiscard]] virtual std::size_t size() const noexcept        = 0;
+    [[nodiscard]] virtual double      xAt(std::size_t index) const = 0;
+    [[nodiscard]] virtual float       yAt(std::size_t index) const = 0;
+
+    [[nodiscard]] virtual PlotData plotData() const = 0;
+
+    [[nodiscard]] virtual bool                                hasDataSets() const noexcept  = 0;
+    [[nodiscard]] virtual std::size_t                         dataSetCount() const noexcept = 0;
+    [[nodiscard]] virtual std::span<const gr::DataSet<float>> dataSets() const              = 0;
+
+    [[nodiscard]] virtual bool                      hasStreamingTags() const noexcept                                                                    = 0;
+    [[nodiscard]] virtual std::pair<double, double> tagTimeRange() const noexcept                                                                        = 0;
+    virtual void                                    forEachTag(std::function<void(double timestamp, const gr::property_map& properties)> callback) const = 0;
+
+    [[nodiscard]] virtual double timeFirst() const noexcept = 0;
+    [[nodiscard]] virtual double timeLast() const noexcept  = 0;
+
+    /// total number of samples received since creation (not just those in current buffer)
+    [[nodiscard]] virtual std::size_t totalSampleCount() const noexcept = 0;
+
+    [[nodiscard]] virtual std::size_t bufferCapacity() const noexcept = 0;
+
+    /// request minimum history capacity from a named source (auto-expires after timeout)
+    virtual void requestCapacity(std::string_view source, std::size_t capacity, std::chrono::seconds timeout = std::chrono::seconds{60}) = 0;
+
+    /// expire old capacity requests and resize buffer if needed
+    virtual void expireCapacityRequests() = 0;
+
+    struct DataRange {
+        std::size_t start_index; // index of first element in range
+        std::size_t count;       // number of elements in range
+
+        [[nodiscard]] bool empty() const noexcept { return count == 0; }
+    };
+
+    [[nodiscard]] virtual DataRange getXRange(double tMin, double tMax) const = 0;
+
+    [[nodiscard]] virtual DataRange getTagRange(double tMin, double tMax) const = 0;
+
+    struct XRangeResult {
+        std::span<const double> data;         // X values in the requested range
+        double                  actual_t_min; // actual start time of returned data
+        double                  actual_t_max; // actual end time of returned data
+
+        [[nodiscard]] bool empty() const noexcept { return data.empty(); }
+    };
+
+    struct YRangeResult {
+        std::span<const float> data;         // Y values in the requested range
+        double                 actual_t_min; // actual start time of returned data
+        double                 actual_t_max; // actual end time of returned data
+
+        [[nodiscard]] bool empty() const noexcept { return data.empty(); }
+    };
+
+    struct TagEntry {
+        double           timestamp;  // time of the tag in seconds (UTC)
+        gr::property_map properties; // tag properties
+    };
+
+    struct TagRangeResult {
+        std::vector<TagEntry> tags;         // tags in the requested range
+        double                actual_t_min; // actual start time of returned data
+        double                actual_t_max; // actual end time of returned data
+
+        [[nodiscard]] bool empty() const noexcept { return tags.empty(); }
+    };
+
+    /// get X values within a time range as a span (caller must hold dataGuard())
+    [[nodiscard]] virtual XRangeResult getX(double tMin = -std::numeric_limits<double>::infinity(), double tMax = +std::numeric_limits<double>::infinity()) const = 0;
+
+    /// get Y values within a time range as a span (caller must hold dataGuard())
+    [[nodiscard]] virtual YRangeResult getY(double tMin = -std::numeric_limits<double>::infinity(), double tMax = +std::numeric_limits<double>::infinity()) const = 0;
+
+    /// get tags within a time range (tags are copied for safe access without data guard)
+    [[nodiscard]] virtual TagRangeResult getTags(double tMin = -std::numeric_limits<double>::infinity(), double tMax = +std::numeric_limits<double>::infinity()) const = 0;
+
+    struct SampleWithTags {
+        double                            x;    // X value (time)
+        float                             y;    // Y value
+        std::span<const gr::property_map> tags; // tags at this sample (empty if none)
+    };
+
+    /// forward iterator for lazy (x, y, tags) range traversal
+    struct XYTagIterator {
+        using iterator_category = std::forward_iterator_tag;
+        using value_type        = SampleWithTags;
+        using difference_type   = std::ptrdiff_t;
+        using pointer           = const SampleWithTags*;
+        using reference         = SampleWithTags;
+
+        const SignalSink* _sink  = nullptr;
+        std::size_t       _index = 0;
+        std::size_t       _end   = 0;
+
+        // Tag lookup cache (for tags at current index)
+        mutable std::vector<gr::property_map> _tagCache;
+        mutable std::size_t                   _cachedIndex = std::numeric_limits<std::size_t>::max();
+
+        void updateTagCache() const {
+            if (!_sink || _cachedIndex == _index) {
+                return;
+            }
+            _tagCache.clear();
+            _cachedIndex = _index;
+
+            // Get the X value at current index to find matching tags
+            double xVal = _sink->xAt(_index);
+
+            // Use forEachTag to find tags near this X value (within tolerance)
+            constexpr double kTagTolerance = 1e-9; // nanosecond precision
+            _sink->forEachTag([this, xVal](double timestamp, const gr::property_map& props) {
+                if (std::abs(timestamp - xVal) < kTagTolerance) {
+                    _tagCache.push_back(props);
+                }
+            });
+        }
+
+        XYTagIterator() = default;
+
+        XYTagIterator(const SignalSink* sink, std::size_t index, std::size_t end) : _sink(sink), _index(index), _end(end) {}
+
+        reference operator*() const {
+            if (_index >= _end) {
+                return SampleWithTags{0.0, 0.0f, {}};
+            }
+            updateTagCache();
+            return SampleWithTags{_sink->xAt(_index), _sink->yAt(_index), std::span<const gr::property_map>(_tagCache)};
+        }
+
+        XYTagIterator& operator++() {
+            ++_index;
+            return *this;
+        }
+
+        XYTagIterator operator++(int) {
+            XYTagIterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        bool operator==(const XYTagIterator& other) const { return _index == other._index; }
+        bool operator!=(const XYTagIterator& other) const { return _index != other._index; }
+    };
+
+    /// range wrapper for XYTagIterator (satisfies std::ranges::range)
+    struct XYTagRange {
+        XYTagIterator _begin;
+        XYTagIterator _end;
+
+        XYTagRange() = default;
+        XYTagRange(XYTagIterator begin, XYTagIterator end) : _begin(begin), _end(end) {}
+
+        [[nodiscard]] XYTagIterator begin() const { return _begin; }
+        [[nodiscard]] XYTagIterator end() const { return _end; }
+        [[nodiscard]] bool          empty() const { return _begin == _end; }
+    };
+
+    /// get a lazy range over (x, y, tags) tuples (caller must hold dataGuard())
+    [[nodiscard]] virtual XYTagRange xyTagRange(double tMin = -std::numeric_limits<double>::infinity(), double tMax = +std::numeric_limits<double>::infinity()) const = 0;
+
+    /// remove tags with timestamp < minX (called after rendering to prevent unbounded growth)
+    virtual void pruneTags(double minX) = 0;
+
+    /// acquire a guard for thread-safe data access
+    [[nodiscard]] virtual DataGuard dataGuard() const = 0;
+
+    virtual gr::work::Status draw(const gr::property_map& config = {}) = 0;
+
+    [[nodiscard]] virtual bool drawEnabled() const noexcept = 0;
+
+    virtual void setDrawEnabled(bool enabled) = 0;
+
+    [[nodiscard]] virtual std::string_view signalQuantity() const noexcept   = 0;
+    [[nodiscard]] virtual std::string_view signalUnit() const noexcept       = 0;
+    [[nodiscard]] virtual std::string_view abscissaQuantity() const noexcept = 0;
+    [[nodiscard]] virtual std::string_view abscissaUnit() const noexcept     = 0;
+    [[nodiscard]] virtual float            signalMin() const noexcept        = 0;
+    [[nodiscard]] virtual float            signalMax() const noexcept        = 0;
+};
+
+/**
+ * @brief Non-owning adapter that implements SignalSink for a concrete sink Block<T>.
+ *
+ * This adapter holds a pointer to an existing block (owned by the graph) and
+ * delegates all SignalSink calls to the block's methods.
+ *
+ * The underlying block T must provide the following methods for full functionality:
+ * - signalName(), color(), sampleRate()
+ * - signalQuantity(), signalUnit(), abscissaQuantity(), abscissaUnit()
+ * - signalMin(), signalMax()
+ * - size(), xAt(index), yAt(index)
+ * - dataMutex() returning std::mutex& for thread-safe access
+ * - requestCapacity(consumer, capacity), releaseCapacity(consumer), bufferCapacity()
+ */
+template<gr::BlockLike T>
+struct SinkAdapter : public SignalSink {
+    std::atomic<T*>   _block;             // non-owning pointer to the underlying block (nulled on invalidation)
+    std::atomic<bool> _drawEnabled{true}; // UI visibility state (independent of block)
+
+    // cached identity (stable after invalidation)
+    std::string _cachedName;
+    std::string _cachedUniqueName;
+
+    // shared mutex that outlives the block — prevents TOCTOU between blockPtr() and dataMutex()
+    std::shared_ptr<std::mutex> _sharedMutex;
+
+    explicit SinkAdapter(T& block) : _block(&block), _cachedName(block.name.value), _cachedUniqueName(block.unique_name) {
+        if constexpr (requires { block.sharedDataMutex(); }) {
+            _sharedMutex = block.sharedDataMutex();
+        }
+    }
+
+    ~SinkAdapter() override = default;
+
+    // Non-copyable, non-movable (pointer to external block)
+    SinkAdapter(const SinkAdapter&)            = delete;
+    SinkAdapter& operator=(const SinkAdapter&) = delete;
+    SinkAdapter(SinkAdapter&&)                 = delete;
+    SinkAdapter& operator=(SinkAdapter&&)      = delete;
+
+    /// called by the owning block's destructor to prevent dangling access
+    void invalidate() noexcept { _block.store(nullptr, std::memory_order_release); }
+
+    [[nodiscard]] T* blockPtr() const noexcept { return _block.load(std::memory_order_acquire); }
+
+    [[nodiscard]] std::string_view name() const noexcept override { return _cachedName; }
+
+    [[nodiscard]] std::string_view uniqueName() const noexcept override { return _cachedUniqueName; }
+
+    [[nodiscard]] std::string_view signalName() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return _cachedName;
+        }
+        if constexpr (requires { b->signalName(); }) {
+            return b->signalName();
+        } else {
+            return b->name.value;
+        }
+    }
+
+    [[nodiscard]] std::uint32_t color() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return 0xFFFFFF;
+        }
+        if constexpr (requires { b->color.value; }) {
+            return b->color.value;
+        }
+        return 0xFFFFFF;
+    }
+
+    [[nodiscard]] float sampleRate() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return 1.0f;
+        }
+        if constexpr (requires { b->sampleRate(); }) {
+            return b->sampleRate();
+        } else if constexpr (requires { b->sample_rate.value; }) {
+            return static_cast<float>(b->sample_rate.value);
+        }
+        return 1.0f;
+    }
+
+    [[nodiscard]] LineStyle lineStyle() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return LineStyle::Solid;
+        }
+        if constexpr (requires { b->lineStyle(); }) {
+            return b->lineStyle();
+        } else if constexpr (requires { b->line_style.value; }) {
+            return static_cast<LineStyle>(b->line_style.value);
+        }
+        return LineStyle::Solid;
+    }
+
+    [[nodiscard]] float lineWidth() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return 1.0f;
+        }
+        if constexpr (requires { b->lineWidth(); }) {
+            return b->lineWidth();
+        } else if constexpr (requires { b->line_width.value; }) {
+            return static_cast<float>(b->line_width.value);
+        }
+        return 1.0f;
+    }
+
+    [[nodiscard]] std::string_view signalQuantity() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return "";
+        }
+        if constexpr (requires { b->signalQuantity(); }) {
+            return b->signalQuantity();
+        } else if constexpr (requires { b->signal_quantity; }) {
+            return b->signal_quantity.value;
+        }
+        return "";
+    }
+
+    [[nodiscard]] std::string_view signalUnit() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return "";
+        }
+        if constexpr (requires { b->signalUnit(); }) {
+            return b->signalUnit();
+        } else if constexpr (requires { b->signal_unit; }) {
+            return b->signal_unit.value;
+        }
+        return "";
+    }
+
+    [[nodiscard]] std::string_view abscissaQuantity() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return "time";
+        }
+        if constexpr (requires { b->abscissaQuantity(); }) {
+            return b->abscissaQuantity();
+        } else if constexpr (requires { b->abscissa_quantity; }) {
+            return b->abscissa_quantity.value;
+        }
+        return "time";
+    }
+
+    [[nodiscard]] std::string_view abscissaUnit() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return "s";
+        }
+        if constexpr (requires { b->abscissaUnit(); }) {
+            return b->abscissaUnit();
+        } else if constexpr (requires { b->abscissa_unit; }) {
+            return b->abscissa_unit.value;
+        }
+        return "s";
+    }
+
+    [[nodiscard]] float signalMin() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return std::numeric_limits<float>::lowest();
+        }
+        if constexpr (requires { b->signalMin(); }) {
+            return b->signalMin();
+        } else if constexpr (requires { b->signal_min; }) {
+            return static_cast<float>(b->signal_min);
+        }
+        return std::numeric_limits<float>::lowest();
+    }
+
+    [[nodiscard]] float signalMax() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return std::numeric_limits<float>::max();
+        }
+        if constexpr (requires { b->signalMax(); }) {
+            return b->signalMax();
+        } else if constexpr (requires { b->signal_max; }) {
+            return static_cast<float>(b->signal_max);
+        }
+        return std::numeric_limits<float>::max();
+    }
+
+    [[nodiscard]] std::size_t size() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return 0;
+        }
+        if constexpr (requires { b->size(); }) {
+            return b->size();
+        }
+        return 0;
+    }
+
+    [[nodiscard]] double xAt(std::size_t index) const override {
+        auto* b = blockPtr();
+        if (!b) {
+            return 0.0;
+        }
+        if constexpr (requires { b->xAt(index); }) {
+            return b->xAt(index);
+        }
+        return 0.0;
+    }
+
+    [[nodiscard]] float yAt(std::size_t index) const override {
+        auto* b = blockPtr();
+        if (!b) {
+            return 0.0f;
+        }
+        if constexpr (requires { b->yAt(index); }) {
+            return b->yAt(index);
+        }
+        return 0.0f;
+    }
+
+    [[nodiscard]] PlotData plotData() const override {
+        auto* b = blockPtr();
+        if (!b) {
+            return {nullptr, nullptr, 0};
+        }
+        if constexpr (requires { b->plotData(); }) {
+            return b->plotData();
+        }
+        return {nullptr, nullptr, 0};
+    }
+
+    [[nodiscard]] bool hasDataSets() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return false;
+        }
+        if constexpr (requires { b->hasDataSets(); }) {
+            return b->hasDataSets();
+        }
+        return false;
+    }
+
+    [[nodiscard]] std::size_t dataSetCount() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return 0;
+        }
+        if constexpr (requires { b->dataSetCount(); }) {
+            return b->dataSetCount();
+        }
+        return 0;
+    }
+
+    [[nodiscard]] std::span<const gr::DataSet<float>> dataSets() const override {
+        auto* b = blockPtr();
+        if (!b) {
+            return {};
+        }
+        if constexpr (requires { b->dataSets(); }) {
+            return b->dataSets();
+        }
+        return {};
+    }
+
+    [[nodiscard]] bool hasStreamingTags() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return false;
+        }
+        if constexpr (requires { b->hasStreamingTags(); }) {
+            return b->hasStreamingTags();
+        }
+        return false;
+    }
+
+    [[nodiscard]] std::pair<double, double> tagTimeRange() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return {0.0, 0.0};
+        }
+        if constexpr (requires { b->tagTimeRange(); }) {
+            return b->tagTimeRange();
+        }
+        return {0.0, 0.0};
+    }
+
+    void forEachTag(std::function<void(double, const gr::property_map&)> callback) const override {
+        auto* b = blockPtr();
+        if (!b) {
+            return;
+        }
+        if constexpr (requires { b->forEachTag(callback); }) {
+            b->forEachTag(callback);
+        }
+    }
+
+    [[nodiscard]] double timeFirst() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return 0.0;
+        }
+        if constexpr (requires { b->timeFirst(); }) {
+            return b->timeFirst();
+        }
+        return 0.0;
+    }
+
+    [[nodiscard]] double timeLast() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return 0.0;
+        }
+        if constexpr (requires { b->timeLast(); }) {
+            return b->timeLast();
+        }
+        return 0.0;
+    }
+
+    [[nodiscard]] std::size_t totalSampleCount() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return 0;
+        }
+        if constexpr (requires { b->totalSampleCount(); }) {
+            return b->totalSampleCount();
+        } else if constexpr (requires { b->_sample_count; }) {
+            return b->_sample_count;
+        }
+        return 0;
+    }
+
+    [[nodiscard]] std::size_t bufferCapacity() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return 0;
+        }
+        if constexpr (requires { b->bufferCapacity(); }) {
+            return b->bufferCapacity();
+        }
+        return 0;
+    }
+
+    void requestCapacity(std::string_view source, std::size_t capacity, std::chrono::seconds timeout = std::chrono::seconds{60}) override {
+        auto* b = blockPtr();
+        if (!b) {
+            return;
+        }
+        if constexpr (requires { b->requestCapacity(source, capacity, timeout); }) {
+            b->requestCapacity(source, capacity, timeout);
+        }
+    }
+
+    void expireCapacityRequests() override {
+        auto* b = blockPtr();
+        if (!b) {
+            return;
+        }
+        if constexpr (requires { b->expireCapacityRequests(); }) {
+            b->expireCapacityRequests();
+        }
+    }
+
+    [[nodiscard]] DataRange getXRange(double tMin, double tMax) const override {
+        auto* b = blockPtr();
+        if (!b) {
+            return {0, 0};
+        }
+        if constexpr (requires { b->getXRange(tMin, tMax); }) {
+            return b->getXRange(tMin, tMax);
+        }
+        return {0, 0};
+    }
+
+    [[nodiscard]] DataRange getTagRange(double tMin, double tMax) const override {
+        auto* b = blockPtr();
+        if (!b) {
+            return {0, 0};
+        }
+        if constexpr (requires { b->getTagRange(tMin, tMax); }) {
+            return b->getTagRange(tMin, tMax);
+        }
+        return {0, 0};
+    }
+
+    [[nodiscard]] XRangeResult getX(double tMin = -std::numeric_limits<double>::infinity(), double tMax = +std::numeric_limits<double>::infinity()) const override {
+        auto* b = blockPtr();
+        if (!b) {
+            return {{}, 0.0, 0.0};
+        }
+        if constexpr (requires { b->getX(tMin, tMax); }) {
+            return b->getX(tMin, tMax);
+        }
+        return {{}, 0.0, 0.0};
+    }
+
+    [[nodiscard]] YRangeResult getY(double tMin = -std::numeric_limits<double>::infinity(), double tMax = +std::numeric_limits<double>::infinity()) const override {
+        auto* b = blockPtr();
+        if (!b) {
+            return {{}, 0.0, 0.0};
+        }
+        if constexpr (requires { b->getY(tMin, tMax); }) {
+            return b->getY(tMin, tMax);
+        }
+        return {{}, 0.0, 0.0};
+    }
+
+    [[nodiscard]] TagRangeResult getTags(double tMin = -std::numeric_limits<double>::infinity(), double tMax = +std::numeric_limits<double>::infinity()) const override {
+        auto* b = blockPtr();
+        if (!b) {
+            return {{}, 0.0, 0.0};
+        }
+        if constexpr (requires { b->getTags(tMin, tMax); }) {
+            return b->getTags(tMin, tMax);
+        }
+        return {{}, 0.0, 0.0};
+    }
+
+    [[nodiscard]] XYTagRange xyTagRange(double tMin = -std::numeric_limits<double>::infinity(), double tMax = +std::numeric_limits<double>::infinity()) const override {
+        auto range = getXRange(tMin, tMax);
+        if (range.empty()) {
+            return XYTagRange{};
+        }
+        return XYTagRange{XYTagIterator{this, range.start_index, range.start_index + range.count}, XYTagIterator{this, range.start_index + range.count, range.start_index + range.count}};
+    }
+
+    void pruneTags(double minX) override {
+        auto* b = blockPtr();
+        if (!b) {
+            return;
+        }
+        if constexpr (requires { b->pruneTags(minX); }) {
+            b->pruneTags(minX);
+        }
+    }
+
+    [[nodiscard]] DataGuard dataGuard() const override {
+        if (_sharedMutex) {
+            return DataGuard(*_sharedMutex);
+        }
+        return DataGuard(_fallbackMutex);
+    }
+
+    gr::work::Status draw(const gr::property_map& config = {}) override {
+        auto* b = blockPtr();
+        if (!b) {
+            return gr::work::Status::OK;
+        }
+        if constexpr (requires { b->draw(config); }) {
+            return b->draw(config);
+        }
+        return gr::work::Status::OK;
+    }
+
+    [[nodiscard]] bool drawEnabled() const noexcept override { return _drawEnabled.load(std::memory_order_relaxed); }
+
+    void setDrawEnabled(bool enabled) override { _drawEnabled.store(enabled, std::memory_order_relaxed); }
+
+private:
+    mutable std::mutex _fallbackMutex; // per-instance fallback (replaces former static dummy)
+};
+
+} // namespace opendigitizer
+
+// Backward compatibility aliases
+namespace opendigitizer::charts {
+using SignalSink = opendigitizer::SignalSink;
+using DataGuard  = opendigitizer::DataGuard;
+using PlotPoint  = opendigitizer::PlotPoint;
+using PlotData   = opendigitizer::PlotData;
+using PlotGetter = opendigitizer::PlotGetter;
+using LineStyle  = opendigitizer::LineStyle;
+
+template<gr::BlockLike T>
+using SinkAdapter = opendigitizer::SinkAdapter<T>;
+} // namespace opendigitizer::charts
+
+#endif // OPENDIGITIZER_SIGNALSINK_HPP

--- a/src/ui/charts/SinkRegistry.hpp
+++ b/src/ui/charts/SinkRegistry.hpp
@@ -1,0 +1,221 @@
+#ifndef OPENDIGITIZER_CHARTS_SINKREGISTRY_HPP
+#define OPENDIGITIZER_CHARTS_SINKREGISTRY_HPP
+
+#include "SignalSink.hpp"
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace opendigitizer::charts {
+
+/**
+ * @brief Global registry for all SignalSink instances.
+ *
+ * Manages the lifetime of signal sinks and provides lookup by name.
+ * Charts hold shared_ptr references to sinks from this registry.
+ *
+ * Thread-safe: all operations are protected by mutex.
+ */
+class SinkRegistry {
+public:
+    using Listener = std::function<void(SignalSink&, bool /*isAdded*/)>;
+
+    static SinkRegistry& instance() {
+        static SinkRegistry s_instance;
+        return s_instance;
+    }
+
+    bool registerSink(std::shared_ptr<SignalSink> sink) {
+        if (!sink) {
+            return false;
+        }
+
+        std::shared_ptr<SignalSink> sinkToNotify;
+        std::vector<Listener>       listenersSnapshot;
+        bool                        inserted = false;
+        {
+            std::lock_guard lock(_mutex);
+            std::string     name(sink->uniqueName());
+            auto [it, didInsert] = _sinks.try_emplace(name, std::move(sink));
+            inserted             = didInsert;
+            if (inserted) {
+                sinkToNotify      = it->second;
+                listenersSnapshot = snapshotListeners();
+            }
+        }
+
+        if (inserted) {
+            for (const auto& listener : listenersSnapshot) {
+                listener(*sinkToNotify, true);
+            }
+        }
+
+        return inserted;
+    }
+
+    bool unregisterSink(std::string_view uniqueName) {
+        std::shared_ptr<SignalSink> sinkToNotify;
+        std::vector<Listener>       listenersSnapshot;
+        {
+            std::lock_guard lock(_mutex);
+            auto            it = _sinks.find(std::string(uniqueName));
+            if (it == _sinks.end()) {
+                return false;
+            }
+            sinkToNotify      = it->second;
+            listenersSnapshot = snapshotListeners();
+            _sinks.erase(it);
+        }
+
+        for (const auto& listener : listenersSnapshot) {
+            listener(*sinkToNotify, false);
+        }
+        return true;
+    }
+
+    [[nodiscard]] std::shared_ptr<SignalSink> getSink(std::string_view uniqueName) const {
+        std::lock_guard lock(_mutex);
+
+        auto it = _sinks.find(std::string(uniqueName));
+        if (it != _sinks.end()) {
+            return it->second;
+        }
+
+        return nullptr;
+    }
+
+    template<typename Pred>
+    [[nodiscard]] std::shared_ptr<SignalSink> findSink(Pred predicate) const {
+        std::lock_guard lock(_mutex);
+
+        for (const auto& [_, sink] : _sinks) {
+            if (predicate(*sink)) {
+                return sink;
+            }
+        }
+
+        return nullptr;
+    }
+
+    template<typename Pred>
+    [[nodiscard]] std::vector<std::shared_ptr<SignalSink>> findSinks(Pred predicate) const {
+        std::lock_guard lock(_mutex);
+
+        std::vector<std::shared_ptr<SignalSink>> result;
+        for (const auto& [_, sink] : _sinks) {
+            if (predicate(*sink)) {
+                result.push_back(sink);
+            }
+        }
+
+        return result;
+    }
+
+    [[nodiscard]] bool hasSink(std::string_view uniqueName) const {
+        std::lock_guard lock(_mutex);
+        return _sinks.contains(std::string(uniqueName));
+    }
+
+    [[nodiscard]] std::vector<std::string> sinkNames() const {
+        std::lock_guard lock(_mutex);
+
+        std::vector<std::string> names;
+        names.reserve(_sinks.size());
+        for (const auto& [name, _] : _sinks) {
+            names.push_back(name);
+        }
+
+        return names;
+    }
+
+    [[nodiscard]] std::vector<std::shared_ptr<SignalSink>> allSinks() const {
+        std::lock_guard lock(_mutex);
+
+        std::vector<std::shared_ptr<SignalSink>> sinks;
+        sinks.reserve(_sinks.size());
+        for (const auto& [_, sink] : _sinks) {
+            sinks.push_back(sink);
+        }
+
+        return sinks;
+    }
+
+    [[nodiscard]] std::size_t sinkCount() const {
+        std::lock_guard lock(_mutex);
+        return _sinks.size();
+    }
+
+    void clear() {
+        std::vector<std::shared_ptr<SignalSink>> sinksToNotify;
+        std::vector<Listener>                    listenersSnapshot;
+        {
+            std::lock_guard lock(_mutex);
+            listenersSnapshot = snapshotListeners();
+            sinksToNotify.reserve(_sinks.size());
+            for (auto& [_, sink] : _sinks) {
+                sinksToNotify.push_back(sink);
+            }
+            _sinks.clear();
+        }
+
+        for (const auto& sink : sinksToNotify) {
+            for (const auto& listener : listenersSnapshot) {
+                listener(*sink, false);
+            }
+        }
+    }
+
+    void addListener(void* owner, Listener listener) {
+        std::lock_guard lock(_mutex);
+        _listeners[owner] = std::move(listener);
+    }
+
+    void removeListener(void* owner) {
+        std::lock_guard lock(_mutex);
+        _listeners.erase(owner);
+    }
+
+    template<typename Fn>
+    void forEach(Fn&& fn) const {
+        std::vector<std::shared_ptr<SignalSink>> sinksSnapshot;
+        {
+            std::lock_guard lock(_mutex);
+            sinksSnapshot.reserve(_sinks.size());
+            for (const auto& [_, sink] : _sinks) {
+                sinksSnapshot.push_back(sink);
+            }
+        }
+        for (const auto& sink : sinksSnapshot) {
+            fn(*sink);
+        }
+    }
+
+private:
+    SinkRegistry() = default;
+    ~SinkRegistry() { clear(); }
+
+    SinkRegistry(const SinkRegistry&)            = delete;
+    SinkRegistry& operator=(const SinkRegistry&) = delete;
+
+    [[nodiscard]] std::vector<Listener> snapshotListeners() const {
+        std::vector<Listener> snapshot;
+        snapshot.reserve(_listeners.size());
+        for (const auto& [_, listener] : _listeners) {
+            snapshot.push_back(listener);
+        }
+        return snapshot;
+    }
+
+    mutable std::mutex                                           _mutex;
+    std::unordered_map<std::string, std::shared_ptr<SignalSink>> _sinks;
+    std::unordered_map<void*, Listener>                          _listeners;
+};
+
+} // namespace opendigitizer::charts
+
+#endif // OPENDIGITIZER_CHARTS_SINKREGISTRY_HPP

--- a/src/ui/charts/XYChart.hpp
+++ b/src/ui/charts/XYChart.hpp
@@ -1,0 +1,342 @@
+#ifndef OPENDIGITIZER_CHARTS_XYCHART_HPP
+#define OPENDIGITIZER_CHARTS_XYCHART_HPP
+
+#include "Chart.hpp"
+#include "SignalSink.hpp"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
+
+#include "../common/LookAndFeel.hpp"
+#include "../common/TouchHandler.hpp"
+#include <imgui.h>
+#include <implot.h>
+
+namespace opendigitizer::charts {
+
+struct PlotLineContext {
+    const SignalSink* sink;
+    AxisScale         axis_scale;
+    double            x_min;
+    double            x_max;
+    float             y_offset{0.0f};
+    std::size_t       offset{0};
+};
+
+struct DataSetPlotContext {
+    const gr::DataSet<float>* data_set;
+    std::size_t               signal_index{0}; // which signal within the DataSet to plot
+};
+
+/// XYChart - standard X-Y line/scatter chart as a GR4 block.
+/// Plots Y-values against a common X-axis with support for multiple axes, automatic signal grouping,
+/// various X-axis modes (UTC/relative time, sample index), tag rendering, and DataSet history fading.
+struct XYChart : gr::Block<XYChart, gr::BlockingIO<false>, gr::Drawable<gr::UICategory::ChartPane, "ImGui">>, Chart {
+    // annotated type alias for cleaner declarations
+    template<typename T, gr::meta::fixed_string description = "", typename... Arguments>
+    using A = gr::Annotated<T, description, Arguments...>;
+
+    A<std::string, "chart name", gr::Visible>                                       chart_name;
+    A<std::string, "chart title">                                                   chart_title;
+    A<std::vector<std::string>, "data sinks", gr::Visible>                          data_sinks              = {};
+    A<int, "X-axis mode", gr::Visible>                                              x_axis_mode             = static_cast<int>(XAxisMode::RelativeTime);
+    A<bool, "show legend", gr::Visible>                                             show_legend             = false;
+    A<bool, "show tags", gr::Visible>                                               show_tags               = true;
+    A<bool, "show grid", gr::Visible>                                               show_grid               = true;
+    A<bool, "anti-aliasing">                                                        anti_aliasing           = true;
+    A<gr::Size_t, "max history count", gr::Limits<1U, 128U>>                        max_history_count       = 3U;
+    A<float, "history opacity decay", gr::Limits<0.001f, 1.f>>                      history_opacity_decay   = 0.3f;
+    A<float, "history vertical offset", gr::Limits<0.f, 100.f>>                     history_vertical_offset = 0.0f;
+    A<bool, "X auto-scale">                                                         x_auto_scale            = true;
+    A<bool, "Y auto-scale">                                                         y_auto_scale            = true;
+    A<double, "X-axis min">                                                         x_min                   = std::numeric_limits<double>::lowest();
+    A<double, "X-axis max">                                                         x_max                   = std::numeric_limits<double>::max();
+    A<double, "Y-axis min">                                                         y_min                   = std::numeric_limits<double>::lowest();
+    A<double, "Y-axis max">                                                         y_max                   = std::numeric_limits<double>::max();
+    A<gr::Size_t, "history depth", gr::Unit<"samples">, gr::Limits<4U, 2'000'000U>> n_history               = kDefaultHistorySize;
+
+    GR_MAKE_REFLECTABLE(XYChart, chart_name, chart_title, data_sinks, x_axis_mode, show_legend, show_tags, show_grid, anti_aliasing, max_history_count, history_opacity_decay, history_vertical_offset, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max, n_history);
+
+    std::array<std::optional<AxisCategory>, 3UZ> _xCategories{};
+    std::array<std::optional<AxisCategory>, 3UZ> _yCategories{};
+    std::array<std::vector<std::string>, 3UZ>    _xAxisGroups{};
+    std::array<std::vector<std::string>, 3UZ>    _yAxisGroups{};
+    mutable std::array<std::string, 6UZ>         _unitStringStorage{};
+
+    static constexpr std::string_view kChartTypeName = "XYChart";
+
+    [[nodiscard]] static constexpr std::string_view chartTypeName() noexcept { return kChartTypeName; }
+    [[nodiscard]] std::string_view                  uniqueId() const noexcept { return this->unique_name; }
+
+    explicit XYChart(gr::property_map initParameters = {}) : gr::Block<XYChart, gr::BlockingIO<false>, gr::Drawable<gr::UICategory::ChartPane, "ImGui">>(std::move(initParameters)) {}
+
+    void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) { handleSettingsChanged(newSettings); }
+
+    gr::work::Status draw(const gr::property_map& config = {}) {
+        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, layoutMode, showGrid] = prepareDrawPrologue(config);
+
+        if (_signalSinks.empty()) {
+            drawEmptyPlot("No signals", plotFlags, plotSize);
+            return gr::work::Status::OK;
+        }
+
+        buildAxisCategoriesWithFallback();
+
+        if (!DigitizerUi::TouchHandler<>::BeginZoomablePlot(chart_name.value, plotSize, plotFlags)) {
+            return gr::work::Status::OK;
+        }
+
+        setupAxes(showGrid);
+        ImPlot::SetupFinish();
+        drawSignals();
+        tooltip::showPlotMouseTooltip();
+        handleCommonInteractions();
+        DigitizerUi::TouchHandler<>::EndZoomablePlot();
+
+        return gr::work::Status::OK;
+    }
+
+    void buildAxisCategoriesWithFallback() {
+        axis::buildAxisCategories(_signalSinks, _xCategories, _yCategories, _xAxisGroups, _yAxisGroups);
+
+        // Set default categories if none were created (fallback for XYChart)
+        if (!_signalSinks.empty() && !_xCategories[0].has_value()) {
+            _xCategories[0] = AxisCategory{"time", "s", _signalSinks[0]->color()};
+            for (const auto& sink : _signalSinks) {
+                _xAxisGroups[0].push_back(std::string(sink->uniqueName()));
+            }
+        }
+        if (!_signalSinks.empty() && !_yCategories[0].has_value()) {
+            _yCategories[0] = AxisCategory{"signal", "", _signalSinks[0]->color()};
+            for (const auto& sink : _signalSinks) {
+                _yAxisGroups[0].push_back(std::string(sink->uniqueName()));
+            }
+        }
+    }
+
+    void setupAxes(bool showGrid = true) {
+        constexpr float   xAxisWidth = 100.f;
+        constexpr float   yAxisWidth = 100.f;
+        const std::size_t nAxesX     = axis::activeAxisCount(_xCategories);
+        const std::size_t nAxesY     = axis::activeAxisCount(_yCategories);
+
+        for (std::size_t i = 0; i < _xCategories.size(); ++i) {
+            const auto dashCfg = parseAxisConfig(this->ui_constraints.value, true, i);
+
+            // Use direct properties for primary axis (i==0), fallback to dashboard config
+            double minLimit, maxLimit;
+            if (i == 0 && !x_auto_scale.value) {
+                minLimit = x_min.value;
+                maxLimit = x_max.value;
+            } else {
+                minLimit = dashCfg ? static_cast<double>(dashCfg->min) : std::numeric_limits<double>::quiet_NaN();
+                maxLimit = dashCfg ? static_cast<double>(dashCfg->max) : std::numeric_limits<double>::quiet_NaN();
+            }
+
+            const LabelFormat format = dashCfg ? dashCfg->format : LabelFormat::Auto;
+            const float       width  = dashCfg && std::isfinite(dashCfg->width) ? dashCfg->width : xAxisWidth;
+            const AxisScale   scale  = dashCfg ? dashCfg->scale : AxisScale::Linear;
+
+            // Update category scale to match dashboard config (used by drawStreamingSignal)
+            if (_xCategories[i].has_value()) {
+                _xCategories[i]->scale = scale;
+            }
+
+            axis::setupAxis(ImAxis_X1 + static_cast<int>(i), _xCategories[i], format, width, minLimit, maxLimit, nAxesX, scale, _unitStringStorage, showGrid);
+        }
+
+        for (std::size_t i = 0; i < _yCategories.size(); ++i) {
+            const auto dashCfg = parseAxisConfig(this->ui_constraints.value, false, i);
+
+            // Use direct properties for primary axis (i==0), fallback to dashboard config
+            double minLimit, maxLimit;
+            if (i == 0 && !y_auto_scale.value) {
+                minLimit = y_min.value;
+                maxLimit = y_max.value;
+            } else {
+                minLimit = dashCfg ? static_cast<double>(dashCfg->min) : std::numeric_limits<double>::quiet_NaN();
+                maxLimit = dashCfg ? static_cast<double>(dashCfg->max) : std::numeric_limits<double>::quiet_NaN();
+            }
+
+            const LabelFormat format = dashCfg ? dashCfg->format : LabelFormat::Auto;
+            const float       width  = dashCfg && std::isfinite(dashCfg->width) ? dashCfg->width : yAxisWidth;
+            const AxisScale   scale  = dashCfg ? dashCfg->scale : AxisScale::Linear;
+
+            // Update category scale to match dashboard config
+            if (_yCategories[i].has_value()) {
+                _yCategories[i]->scale = scale;
+            }
+
+            axis::setupAxis(ImAxis_Y1 + static_cast<int>(i), _yCategories[i], format, width, minLimit, maxLimit, nAxesY, scale, _unitStringStorage, showGrid);
+        }
+    }
+
+    void drawSignals() {
+        bool tagsDrawnForFirstSink = false;
+
+        for (std::size_t i = 0; i < _signalSinks.size(); ++i) {
+            const std::shared_ptr<SignalSink>& sink = _signalSinks[i];
+
+            // Skip drawing if signal is hidden (data consumption is handled elsewhere)
+            if (!sink->drawEnabled()) {
+                continue;
+            }
+
+            std::string_view sinkUniqueName = sink->uniqueName();
+            std::size_t      xAxisIdx       = axis::findAxisForSink(sinkUniqueName, true, _xAxisGroups, _yAxisGroups);
+            std::size_t      yAxisIdx       = axis::findAxisForSink(sinkUniqueName, false, _xAxisGroups, _yAxisGroups);
+
+            ImPlot::SetAxes(static_cast<ImAxis>(ImAxis_X1 + xAxisIdx), static_cast<ImAxis>(ImAxis_Y1 + yAxisIdx));
+
+            // Acquire lock for thread-safe data access during rendering
+            auto dataLock = sink->dataGuard();
+
+            if (sink->size() > 0) {
+                ImVec4 baseColor = ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(sink->color()));
+
+                if (sink->hasDataSets()) {
+                    drawDataSetSignal(*sink);
+
+                    // Draw timing events for DataSets (only for first sink to avoid clutter)
+                    if (show_tags.value && !tagsDrawnForFirstSink) {
+                        auto allDataSets = sink->dataSets();
+                        if (!allDataSets.empty()) {
+                            tags::drawDataSetTimingEvents(allDataSets[0], _xCategories[xAxisIdx].has_value() ? _xCategories[xAxisIdx]->scale : AxisScale::Linear, baseColor);
+                        }
+                        tagsDrawnForFirstSink = true;
+                    }
+                } else {
+                    drawStreamingSignal(*sink);
+
+                    // Draw streaming tags (only for first sink to avoid clutter)
+                    if (show_tags.value && !tagsDrawnForFirstSink) {
+                        std::size_t totalCount = sink->size();
+                        std::size_t dataCount  = std::min(totalCount, static_cast<std::size_t>(n_history.value));
+                        std::size_t offset     = totalCount - dataCount;
+                        double      xMin       = sink->xAt(offset);
+                        double      xMax       = sink->xAt(offset + dataCount - 1);
+                        AxisScale   xAxisScale = _xCategories[xAxisIdx].has_value() ? _xCategories[xAxisIdx]->scale : AxisScale::Linear;
+                        ImVec4      tagColor   = baseColor;
+                        tagColor.w *= 0.35f;
+                        tags::drawTags([&](auto&& fn) { sink->forEachTag(fn); }, xAxisScale, xMin, xMax, tagColor);
+                        sink->pruneTags(std::min(xMin, xMax));
+                        tagsDrawnForFirstSink = true;
+                    }
+                }
+            }
+        }
+    }
+
+    void drawStreamingSignal(const SignalSink& sink) {
+        // Note: Caller must hold data lock via sink.dataGuard()
+        std::size_t totalCount = sink.size();
+        if (totalCount == 0) {
+            return;
+        }
+
+        // clamp to n_history: show only the most recent samples
+        std::size_t dataCount = totalCount;
+        std::size_t offset    = 0;
+        if (dataCount > static_cast<std::size_t>(n_history.value)) {
+            dataCount = static_cast<std::size_t>(n_history.value);
+            offset    = totalCount - dataCount;
+        }
+
+        ImVec4 lineColor = ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(sink.color()));
+        ImPlot::SetNextLineStyle(lineColor);
+
+        double xMin = sink.xAt(offset);
+        double xMax = sink.xAt(offset + dataCount - 1);
+
+        AxisScale       xAxisScale = _xCategories[0].has_value() ? _xCategories[0]->scale : AxisScale::Linear;
+        PlotLineContext ctx{&sink, xAxisScale, xMin, xMax, 0.0f, offset};
+
+        std::string signalLabel{sink.signalName()};
+        ImPlot::PlotLineG(
+            signalLabel.c_str(),
+            [](int idx, void* user_data) -> ImPlotPoint {
+                auto*       context   = static_cast<PlotLineContext*>(user_data);
+                std::size_t actualIdx = context->offset + static_cast<std::size_t>(idx);
+                double      xVal      = context->sink->xAt(actualIdx);
+                double      yVal      = static_cast<double>(context->sink->yAt(actualIdx)) + static_cast<double>(context->y_offset);
+
+                switch (context->axis_scale) {
+                case AxisScale::Time: break;
+                case AxisScale::LinearReverse: xVal = xVal - context->x_max; break;
+                default: xVal = xVal - context->x_min; break;
+                }
+
+                return ImPlotPoint(xVal, yVal);
+            },
+            &ctx, static_cast<int>(dataCount));
+    }
+
+    void drawDataSetSignal(const SignalSink& sink) {
+        // DataSet signals: x values are absolute (e.g., frequency), no transformation needed
+        // Supports history rendering with fading opacity for older DataSets
+        auto allDataSets = sink.dataSets();
+        if (allDataSets.empty()) {
+            return;
+        }
+
+        ImVec4      baseColor   = ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(sink.color()));
+        std::size_t historySize = std::min(allDataSets.size(), static_cast<std::size_t>(max_history_count.value));
+        std::string baseName    = std::string(sink.signalName());
+
+        // Draw from oldest to newest (so newest renders on top)
+        // DataSets are ordered oldest-first in the span (push_back appends newest at the end)
+        const std::size_t spanSize = allDataSets.size();
+        const std::size_t offset   = spanSize - historySize; // skip older entries
+        for (std::size_t i = 0; i < historySize; ++i) {
+            const auto&        ds = allDataSets[offset + i]; // i=0 is oldest of selected, i=historySize-1 is newest
+            DataSetPlotContext ctx{&ds, 0};
+
+            const bool isNewest = (i == historySize - 1);
+            float      opacity  = isNewest ? 1.0f : (0.2f + (static_cast<float>(i) / static_cast<float>(historySize - 1)) * 0.8f);
+
+            ImVec4 lineColor = baseColor;
+            lineColor.w      = opacity;
+            ImPlot::SetNextLineStyle(lineColor);
+
+            std::string label = isNewest ? baseName : ("##" + baseName + "_hist_" + std::to_string(i));
+
+            // Get data count from DataSet's axis_values
+            if (ds.axis_values.empty() || ds.axis_values[0].empty()) {
+                continue;
+            }
+            int dataCount = static_cast<int>(ds.axis_values[0].size());
+
+            ImPlot::PlotLineG(
+                label.c_str(),
+                [](int idx, void* user_data) -> ImPlotPoint {
+                    auto*       context  = static_cast<DataSetPlotContext*>(user_data);
+                    const auto& data_set = *context->data_set;
+                    double      xVal     = static_cast<double>(data_set.axis_values[0][static_cast<std::size_t>(idx)]);
+                    double      yVal     = 0.0;
+                    auto        sigVals  = data_set.signalValues(context->signal_index);
+                    if (static_cast<std::size_t>(idx) < sigVals.size()) {
+                        yVal = static_cast<double>(sigVals[static_cast<std::size_t>(idx)]);
+                    }
+                    return ImPlotPoint(xVal, yVal);
+                },
+                &ctx, dataCount);
+        }
+    }
+};
+
+} // namespace opendigitizer::charts
+
+// register XYChart with the GR4 block registry
+// GR_REGISTER_BLOCK is a marker macro for build tools; actual registration via gr::registerBlock
+GR_REGISTER_BLOCK("opendigitizer::charts::XYChart", opendigitizer::charts::XYChart)
+inline auto registerXYChart = gr::registerBlock<opendigitizer::charts::XYChart>(gr::globalBlockRegistry());
+
+#endif // OPENDIGITIZER_CHARTS_XYCHART_HPP

--- a/src/ui/charts/YYChart.hpp
+++ b/src/ui/charts/YYChart.hpp
@@ -1,0 +1,432 @@
+#ifndef OPENDIGITIZER_CHARTS_YYCHART_HPP
+#define OPENDIGITIZER_CHARTS_YYCHART_HPP
+
+#include "Chart.hpp"
+#include "SignalSink.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
+
+#include "../common/LookAndFeel.hpp"
+#include "../common/TouchHandler.hpp"
+#include <imgui.h>
+#include <implot.h>
+
+namespace opendigitizer::charts {
+
+/// YYChart - Correlation plot (Y1 vs Y2) as a GR4 block.
+/// Plots Y-values from one signal against another for Lissajous figures, phase plots, I-Q diagrams.
+/// Signal modes: 1 signal = XY fallback, 2 signals = Y1 vs Y2, 3+ signals = first as X, rest as Y.
+struct YYChart : gr::Block<YYChart, gr::BlockingIO<false>, gr::Drawable<gr::UICategory::ChartPane, "ImGui">>, Chart {
+    // Annotated type alias for cleaner declarations
+    template<typename T, gr::meta::fixed_string description = "", typename... Arguments>
+    using A = gr::Annotated<T, description, Arguments...>;
+
+    A<std::string, "chart name", gr::Visible>              chart_name;
+    A<std::string, "chart title">                          chart_title;
+    A<std::vector<std::string>, "data sinks", gr::Visible> data_sinks    = {};
+    A<bool, "show legend", gr::Visible>                    show_legend   = false;
+    A<bool, "show grid", gr::Visible>                      show_grid     = true;
+    A<bool, "anti-aliasing">                               anti_aliasing = true;
+    A<int, "X-axis scale">                                 x_axis_scale  = static_cast<int>(AxisScale::Linear);
+    A<int, "Y-axis scale">                                 y_axis_scale  = static_cast<int>(AxisScale::Linear);
+    A<bool, "X auto-scale">                                x_auto_scale  = true;
+    A<bool, "Y auto-scale">                                y_auto_scale  = true;
+    A<double, "X-axis min">                                x_min         = std::numeric_limits<double>::lowest();
+    A<double, "X-axis max">                                x_max         = std::numeric_limits<double>::max();
+    A<double, "Y-axis min">                                y_min         = std::numeric_limits<double>::lowest();
+    A<double, "Y-axis max">                                y_max         = std::numeric_limits<double>::max();
+    A<gr::Size_t, "history depth", gr::Unit<"samples">>    n_history     = kDefaultHistorySize;
+
+    GR_MAKE_REFLECTABLE(YYChart, chart_name, chart_title, data_sinks, show_legend, show_grid, anti_aliasing, x_axis_scale, y_axis_scale, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max, n_history);
+
+    mutable std::array<std::string, 6> _unitStringStorage{};
+
+    static constexpr std::string_view kChartTypeName = "YYChart";
+
+    [[nodiscard]] static constexpr std::string_view chartTypeName() noexcept { return kChartTypeName; }
+    [[nodiscard]] std::string_view                  uniqueId() const noexcept { return this->unique_name; }
+
+    explicit YYChart(gr::property_map initParameters = {}) : gr::Block<YYChart, gr::BlockingIO<false>, gr::Drawable<gr::UICategory::ChartPane, "ImGui">>(std::move(initParameters)) {}
+
+    void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) { handleSettingsChanged(newSettings); }
+
+    gr::work::Status draw(const gr::property_map& config = {}) {
+        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, layoutMode, showGrid] = prepareDrawPrologue(config);
+
+        if (_signalSinks.empty()) {
+            drawEmptyPlot("No signals", plotFlags, plotSize);
+            return gr::work::Status::OK;
+        }
+
+        if (_signalSinks.size() == 1) {
+            drawXYFallback(plotFlags, plotSize, showGrid);
+            return gr::work::Status::OK;
+        }
+
+        if (_signalSinks.size() == 2) {
+            drawCorrelation(plotFlags, plotSize, showGrid);
+            return gr::work::Status::OK;
+        }
+
+        drawMultiCorrelation(plotFlags, plotSize, showGrid);
+        return gr::work::Status::OK;
+    }
+
+    [[nodiscard]] AxisScale getAxisScale(bool isX) const noexcept { return static_cast<AxisScale>(isX ? x_axis_scale.value : y_axis_scale.value); }
+
+    void setAxisScale(bool isX, AxisScale scale) {
+        if (isX) {
+            x_axis_scale = static_cast<int>(scale);
+            std::ignore  = this->settings().set({{"x_axis_scale", x_axis_scale.value}});
+        } else {
+            y_axis_scale = static_cast<int>(scale);
+            std::ignore  = this->settings().set({{"y_axis_scale", y_axis_scale.value}});
+        }
+    }
+
+    void setupAxesWithAutoFit(const char* xLabel, const char* yLabel, bool showGrid = true) {
+        ImPlotAxisFlags xFlags = x_auto_scale ? ImPlotAxisFlags_AutoFit : ImPlotAxisFlags_None;
+        ImPlotAxisFlags yFlags = y_auto_scale ? ImPlotAxisFlags_AutoFit : ImPlotAxisFlags_None;
+        if (!showGrid) {
+            xFlags |= ImPlotAxisFlags_NoGridLines;
+            yFlags |= ImPlotAxisFlags_NoGridLines;
+        }
+        ImPlot::SetupAxis(ImAxis_X1, xLabel, xFlags);
+        ImPlot::SetupAxis(ImAxis_Y1, yLabel, yFlags);
+    }
+
+    /// Build axis label from signal name and unit ("SignalName [unit]" or just "SignalName")
+    static std::string buildAxisLabel(const SignalSink* sink) {
+        if (!sink) {
+            return "";
+        }
+        std::string      label(sink->signalName());
+        std::string_view unit = sink->signalUnit();
+        if (!unit.empty()) {
+            label += " [";
+            label += unit;
+            label += "]";
+        }
+        return label;
+    }
+
+    void drawXYFallback(ImPlotFlags plotFlags, const ImVec2& size, bool showGrid = true) {
+        const std::shared_ptr<SignalSink>& sinkPtr = _signalSinks[0];
+        if (!sinkPtr) {
+            drawEmptyPlot("No data", plotFlags, size);
+            return;
+        }
+
+        // Skip if signal is hidden
+        if (!sinkPtr->drawEnabled()) {
+            drawEmptyPlot("Signal hidden", plotFlags, size);
+            return;
+        }
+
+        // Acquire lock for thread-safe data access
+        DataGuard dataLock = sinkPtr->dataGuard();
+        if (sinkPtr->size() == 0) {
+            drawEmptyPlot("No data", plotFlags, size);
+            return;
+        }
+
+        if (!DigitizerUi::TouchHandler<>::BeginZoomablePlot(chart_name.value, size, plotFlags)) {
+            return;
+        }
+
+        // X-axis: Time, Y-axis: signal name with unit
+        setupAxesWithAutoFit("Time", buildAxisLabel(sinkPtr.get()).c_str(), showGrid);
+        setupAxisScales();
+        ImPlot::SetupFinish();
+
+        ImVec4 lineColor = ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(sinkPtr->color()));
+        ImPlot::SetNextLineStyle(lineColor);
+
+        // clamp to n_history: show only the most recent samples
+        std::size_t totalCount = sinkPtr->size();
+        std::size_t dataCount  = totalCount;
+        std::size_t offset     = 0;
+        if (dataCount > static_cast<std::size_t>(n_history.value)) {
+            dataCount = static_cast<std::size_t>(n_history.value);
+            offset    = totalCount - dataCount;
+        }
+
+        struct XYContext {
+            const SignalSink* sink;
+            std::size_t       offset;
+        };
+        XYContext   ctx{sinkPtr.get(), offset};
+        std::string signalLabel{sinkPtr->signalName()};
+
+        ImPlot::PlotLineG(
+            signalLabel.c_str(),
+            [](int idx, void* user_data) -> ImPlotPoint {
+                auto*       c         = static_cast<XYContext*>(user_data);
+                std::size_t actualIdx = c->offset + static_cast<std::size_t>(idx);
+                double      x         = c->sink->xAt(actualIdx);
+                double      y         = static_cast<double>(c->sink->yAt(actualIdx));
+                return ImPlotPoint(x, y);
+            },
+            &ctx, static_cast<int>(dataCount));
+
+        tooltip::showPlotMouseTooltip();
+        handleCommonInteractions();
+        DigitizerUi::TouchHandler<>::EndZoomablePlot();
+    }
+
+    void drawCorrelation(ImPlotFlags plotFlags, const ImVec2& size, bool showGrid = true) {
+        const auto& sinkXPtr = _signalSinks[0];
+        const auto& sinkYPtr = _signalSinks[1];
+
+        if (!sinkXPtr || !sinkYPtr) {
+            drawEmptyPlot("Invalid sinks", plotFlags, size);
+            return;
+        }
+
+        // Skip if any signal is hidden
+        if (!sinkXPtr->drawEnabled() || !sinkYPtr->drawEnabled()) {
+            drawEmptyPlot("Signal hidden", plotFlags, size);
+            return;
+        }
+
+        // Acquire locks in canonical pointer order to prevent ABBA deadlock
+        const auto& [first, second] = (sinkXPtr.get() < sinkYPtr.get()) ? std::tie(sinkXPtr, sinkYPtr) : std::tie(sinkYPtr, sinkXPtr);
+        DataGuard lockFirst         = first->dataGuard();
+        DataGuard lockSecond        = second->dataGuard();
+
+        std::size_t totalCount = std::min(sinkXPtr->size(), sinkYPtr->size());
+        if (totalCount == 0) {
+            drawEmptyPlot("No data", plotFlags, size);
+            return;
+        }
+
+        // clamp to n_history: show only the most recent samples
+        std::size_t count  = std::min(totalCount, static_cast<std::size_t>(n_history.value));
+        std::size_t offset = totalCount - count;
+
+        if (!DigitizerUi::TouchHandler<>::BeginZoomablePlot(chart_name.value, size, plotFlags)) {
+            return;
+        }
+
+        // Build axis labels with signal name and unit
+        std::string xLabel = buildAxisLabel(sinkXPtr.get());
+        std::string yLabel = buildAxisLabel(sinkYPtr.get());
+        setupAxesWithAutoFit(xLabel.c_str(), yLabel.c_str(), showGrid);
+        setupAxisScales();
+        ImPlot::SetupFinish();
+
+        // Plot X signal as dummy to create legend entry for D&D
+        {
+            ImVec4 xColor = ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(sinkXPtr->color()));
+            ImPlot::SetNextLineStyle(xColor);
+            double      dummyX = static_cast<double>(sinkXPtr->yAt(offset));
+            double      dummyY = static_cast<double>(sinkYPtr->yAt(offset));
+            std::string xLegendLabel{sinkXPtr->signalName()};
+            ImPlot::PlotLine(xLegendLabel.c_str(), &dummyX, &dummyY, 1, ImPlotLineFlags_NoClip);
+        }
+
+        // Plot correlation line with Y signal's name as legend entry
+        ImVec4 lineColor = ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(sinkYPtr->color()));
+        ImPlot::SetNextLineStyle(lineColor);
+
+        struct CorrelationContext {
+            const SignalSink* sink_x;
+            const SignalSink* sink_y;
+            std::size_t       offset;
+        };
+        CorrelationContext ctx{sinkXPtr.get(), sinkYPtr.get(), offset};
+        std::string        yLegendLabel{sinkYPtr->signalName()};
+
+        ImPlot::PlotLineG(
+            yLegendLabel.c_str(),
+            [](int idx, void* user_data) -> ImPlotPoint {
+                auto*       c         = static_cast<CorrelationContext*>(user_data);
+                std::size_t actualIdx = c->offset + static_cast<std::size_t>(idx);
+                double      x         = static_cast<double>(c->sink_x->yAt(actualIdx));
+                double      y         = static_cast<double>(c->sink_y->yAt(actualIdx));
+                return ImPlotPoint(x, y);
+            },
+            &ctx, static_cast<int>(count));
+
+        tooltip::showPlotMouseTooltip();
+        handleCommonInteractions();
+        DigitizerUi::TouchHandler<>::EndZoomablePlot();
+    }
+
+    struct MultiYCategories {
+        std::array<std::optional<AxisCategory>, 3> yCategories{};
+        std::array<std::vector<std::string>, 3>    yAxisGroups{};
+        std::vector<std::size_t>                   overflowSinkIndices;
+    };
+
+    MultiYCategories buildMultiYCategories() const {
+        MultiYCategories result;
+        for (std::size_t i = 1; i < _signalSinks.size(); ++i) {
+            const std::shared_ptr<SignalSink>& sink = _signalSinks[i];
+            if (!sink) {
+                continue;
+            }
+            auto idx = axis::findOrCreateCategory(result.yCategories, sink->signalQuantity(), sink->signalUnit(), sink->color());
+            if (idx.has_value()) {
+                result.yAxisGroups[*idx].push_back(std::string(sink->uniqueName()));
+            } else {
+                result.overflowSinkIndices.push_back(i);
+            }
+        }
+        return result;
+    }
+
+    void drawMultiCorrelation(ImPlotFlags plotFlags, const ImVec2& size, bool showGrid = true) {
+        const auto& sinkXPtr = _signalSinks[0];
+        if (!sinkXPtr) {
+            drawEmptyPlot("No X data", plotFlags, size);
+            return;
+        }
+        if (!sinkXPtr->drawEnabled()) {
+            drawEmptyPlot("X signal hidden", plotFlags, size);
+            return;
+        }
+
+        // Check X has data (brief scoped lock)
+        {
+            DataGuard lockX = sinkXPtr->dataGuard();
+            if (sinkXPtr->size() == 0) {
+                drawEmptyPlot("No X data", plotFlags, size);
+                return;
+            }
+        }
+
+        auto [yCategories, yAxisGroups, overflowSinkIndices] = buildMultiYCategories();
+        std::size_t nYAxes                                   = axis::activeAxisCount(yCategories);
+
+        if (!DigitizerUi::TouchHandler<>::BeginZoomablePlot(chart_name.value, size, plotFlags)) {
+            return;
+        }
+
+        // X-axis from sink[0]'s signal metadata (no data lock needed for metadata accessors)
+        {
+            std::optional<AxisCategory> xCategory = AxisCategory{.quantity = sinkXPtr->signalQuantity().empty() ? std::string(sinkXPtr->signalName()) : std::string(sinkXPtr->signalQuantity()), .unit = std::string(sinkXPtr->signalUnit()), .color = sinkXPtr->color()};
+            AxisScale                   xScale    = static_cast<AxisScale>(x_axis_scale.value);
+            double                      xMinLimit = x_auto_scale ? std::numeric_limits<double>::quiet_NaN() : static_cast<double>(x_min.value);
+            double                      xMaxLimit = x_auto_scale ? std::numeric_limits<double>::quiet_NaN() : static_cast<double>(x_max.value);
+            axis::setupAxis(ImAxis_X1, xCategory, LabelFormat::Auto, 100.f, xMinLimit, xMaxLimit, 1, xScale, _unitStringStorage, showGrid);
+        }
+
+        // Y-axes (up to 3) grouped by quantity+unit
+        AxisScale yScale = static_cast<AxisScale>(y_axis_scale.value);
+        for (std::size_t i = 0; i < yCategories.size(); ++i) {
+            if (!yCategories[i].has_value()) {
+                continue;
+            }
+            double yMinLimit = (i == 0 && !y_auto_scale) ? static_cast<double>(y_min.value) : std::numeric_limits<double>::quiet_NaN();
+            double yMaxLimit = (i == 0 && !y_auto_scale) ? static_cast<double>(y_max.value) : std::numeric_limits<double>::quiet_NaN();
+            axis::setupAxis(ImAxis_Y1 + static_cast<int>(i), yCategories[i], LabelFormat::Auto, 100.f, yMinLimit, yMaxLimit, nYAxes, yScale, _unitStringStorage, showGrid);
+        }
+
+        ImPlot::SetupFinish();
+
+        if (!overflowSinkIndices.empty()) {
+            auto        limits  = ImPlot::GetPlotLimits();
+            std::string warning = std::format("{} signal(s) hidden (max 3 Y-axes)", overflowSinkIndices.size());
+            ImPlot::PlotText(warning.c_str(), (limits.X.Min + limits.X.Max) / 2, limits.Y.Max - (limits.Y.Max - limits.Y.Min) * 0.05);
+        }
+
+        // dummy plot for sink[0] legend entry (D&D support)
+        {
+            auto   lockX  = sinkXPtr->dataGuard();
+            ImVec4 xColor = ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(sinkXPtr->color()));
+            ImPlot::SetNextLineStyle(xColor);
+            double      dummyX = static_cast<double>(sinkXPtr->yAt(0));
+            double      dummyY = static_cast<double>(sinkXPtr->yAt(0));
+            std::string xLegendLabel{sinkXPtr->signalName()};
+            ImPlot::PlotLine(xLegendLabel.c_str(), &dummyX, &dummyY, 1, ImPlotLineFlags_NoClip);
+        }
+
+        struct PlotContext {
+            const SignalSink* sinkX;
+            const SignalSink* sinkY;
+            std::size_t       offset;
+        };
+
+        for (std::size_t i = 1; i < _signalSinks.size(); ++i) {
+            if (std::ranges::contains(overflowSinkIndices, i)) {
+                continue;
+            }
+
+            const auto& sinkYPtr = _signalSinks[i];
+            if (!sinkYPtr || !sinkYPtr->drawEnabled()) {
+                continue;
+            }
+
+            // Acquire locks in canonical pointer order to prevent ABBA deadlock
+            const auto& [first, second] = (sinkXPtr.get() < sinkYPtr.get()) ? std::tie(sinkXPtr, sinkYPtr) : std::tie(sinkYPtr, sinkXPtr);
+            auto lockFirst              = first->dataGuard();
+            auto lockSecond             = (first.get() != second.get()) ? second->dataGuard() : DataGuard{};
+
+            std::size_t totalCount = std::min(sinkXPtr->size(), sinkYPtr->size());
+            if (totalCount == 0) {
+                continue;
+            }
+
+            std::size_t count  = std::min(totalCount, static_cast<std::size_t>(n_history.value));
+            std::size_t offset = totalCount - count;
+
+            std::size_t yAxisIdx = axis::findAxisForSink(sinkYPtr->uniqueName(), false, std::array<std::vector<std::string>, 3>{}, yAxisGroups);
+            ImPlot::SetAxes(ImAxis_X1, static_cast<ImAxis>(ImAxis_Y1 + yAxisIdx));
+
+            ImVec4 lineColor = ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(sinkYPtr->color()));
+            ImPlot::SetNextLineStyle(lineColor);
+
+            PlotContext ctx{sinkXPtr.get(), sinkYPtr.get(), offset};
+            std::string yLabel{sinkYPtr->signalName()};
+            ImPlot::PlotLineG(
+                yLabel.c_str(),
+                [](int idx, void* user_data) -> ImPlotPoint {
+                    auto*       c         = static_cast<PlotContext*>(user_data);
+                    std::size_t actualIdx = c->offset + static_cast<std::size_t>(idx);
+                    double      x         = static_cast<double>(c->sinkX->yAt(actualIdx));
+                    double      y         = static_cast<double>(c->sinkY->yAt(actualIdx));
+                    return ImPlotPoint(x, y);
+                },
+                &ctx, static_cast<int>(count));
+        }
+
+        tooltip::showPlotMouseTooltip();
+        handleCommonInteractions();
+        DigitizerUi::TouchHandler<>::EndZoomablePlot();
+    }
+
+    void setupAxisScales() {
+        // Set axis scale (log10 if configured)
+        if (static_cast<AxisScale>(x_axis_scale.value) == AxisScale::Log10) {
+            ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Log10);
+        }
+        if (static_cast<AxisScale>(y_axis_scale.value) == AxisScale::Log10) {
+            ImPlot::SetupAxisScale(ImAxis_Y1, ImPlotScale_Log10);
+        }
+
+        // Set axis limits (only when auto-scale is disabled)
+        // Use ImPlotCond_Always to ensure limits from context menu are applied every frame
+        if (!x_auto_scale) {
+            ImPlot::SetupAxisLimits(ImAxis_X1, static_cast<double>(x_min.value), static_cast<double>(x_max.value), ImPlotCond_Always);
+        }
+        if (!y_auto_scale) {
+            ImPlot::SetupAxisLimits(ImAxis_Y1, static_cast<double>(y_min.value), static_cast<double>(y_max.value), ImPlotCond_Always);
+        }
+    }
+};
+
+} // namespace opendigitizer::charts
+
+// Register YYChart with the GR4 block registry
+// GR_REGISTER_BLOCK is a marker macro for build tools; actual registration via gr::registerBlock
+GR_REGISTER_BLOCK("opendigitizer::charts::YYChart", opendigitizer::charts::YYChart)
+inline auto registerYYChart = gr::registerBlock<opendigitizer::charts::YYChart>(gr::globalBlockRegistry());
+
+#endif // OPENDIGITIZER_CHARTS_YYCHART_HPP

--- a/src/ui/common/ImGuiHelperSDL.hpp
+++ b/src/ui/common/ImGuiHelperSDL.hpp
@@ -2,6 +2,9 @@
 #define IMGUIHELPERSDL_HPP
 
 #include <SDL3/SDL.h>
+#ifndef GL_GLEXT_PROTOTYPES
+#define GL_GLEXT_PROTOTYPES // required by ImguiXKCD.hpp for GL 2.0+ function prototypes
+#endif
 #include <SDL3/SDL_opengl.h>
 #include <SDL3/SDL_video.h>
 
@@ -14,6 +17,9 @@
 
 #include "Events.hpp"
 #include "TouchHandler.hpp"
+
+#define IMGUI_XKCD_IMPLEMENTATION
+#include "ImguiXKCD.hpp"
 
 #include <format>
 #include <print>
@@ -129,6 +135,7 @@ inline bool initImGui(const std::string& glslVersion) {
         SDL_Quit();
         return false;
     }
+    ImXkcd::Init();
     g_ImGuiSDL3Initialised = true;
     return true;
 }
@@ -219,6 +226,9 @@ inline bool isWindowEventForOtherWindow(const SDL_Event& e, SDL_Window* w) {
 
 [[maybe_unused]] inline bool renderFrame() {
     ImGui::Render();
+    if (DigitizerUi::LookAndFeel::instance().prototypeMode) {
+        ImXkcd::Apply(ImGui::GetDrawData());
+    }
     if (!SDL_GL_MakeCurrent(g_Window, g_GLContext)) {
         std::println("[Main] SDL_GL_MakeCurrent failed: '{}'", SDL_GetError());
         return false;
@@ -240,7 +250,7 @@ inline bool teardownSDL() {
     if (g_GLContext == nullptr) {
         return false;
     }
-    // IMGUI & SDL Cleanup
+    ImXkcd::Shutdown();
     ImGui_ImplOpenGL3_Shutdown();
     ImGui_ImplSDL3_Shutdown();
     ImGui::DestroyContext();

--- a/src/ui/common/ImguiXKCD.hpp
+++ b/src/ui/common/ImguiXKCD.hpp
@@ -1,0 +1,262 @@
+#ifndef IMGUI_XKCD_HPP
+#define IMGUI_XKCD_HPP
+
+// xkcd-style hand-drawn rendering for ImGui/ImPlot.
+// Single-header library. Injects a custom vertex shader via ImDrawList callbacks.
+// Requires: OpenGL 3.x+ or OpenGL ES 3.0+ (WebGL2).
+//
+// Only untextured geometry (lines, fills, grids) is wobbled — text is preserved
+// because text vertices use font atlas UVs, not the white-pixel UV near (0,0).
+
+#include "imgui.h"
+
+#ifndef GLuint
+using GLuint = unsigned int;
+using GLint  = int;
+#endif
+
+namespace ImXkcd {
+
+void Init();
+void Apply(ImDrawData* drawData);
+void Shutdown();
+
+inline bool  enabled   = true;
+inline float amplitude = 7.f;    // pixel displacement strength
+inline float frequency = 0.002f; // noise frequency (lower = smoother wobble)
+inline float seed      = 42.0f;  // deterministic noise seed
+
+} // namespace ImXkcd
+
+#ifdef IMGUI_XKCD_IMPLEMENTATION
+
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
+#ifndef GL_GLEXT_PROTOTYPES
+#define GL_GLEXT_PROTOTYPES
+#endif
+#include <SDL3/SDL_opengl.h>
+#endif
+
+#include <array>
+#include <print>
+
+namespace ImXkcd {
+namespace detail {
+
+inline GLuint g_program = 0;
+inline GLint  g_locProj = -1;
+inline GLint  g_locAmp  = -1;
+inline GLint  g_locFreq = -1;
+inline GLint  g_locSeed = -1;
+inline GLint  g_locTex  = -1;
+
+#ifdef __EMSCRIPTEN__
+static constexpr auto* kGlslPrefix = "#version 300 es\nprecision mediump float;\n";
+#else
+static constexpr auto* kGlslPrefix = "#version 330 core\n";
+#endif
+
+static constexpr auto* kVertBody = R"glsl(
+layout(location = 0) in vec2 Position;
+layout(location = 1) in vec2 UV;
+layout(location = 2) in vec4 Color;
+
+uniform mat4  ProjMtx;
+uniform float u_amplitude;
+uniform float u_frequency;
+uniform float u_seed;
+
+out vec2 Frag_UV;
+out vec4 Frag_Color;
+
+float hash(vec2 p) {
+    vec3 p3 = fract(vec3(p.xyx) * 0.1031);
+    p3 += dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+float vnoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    return mix(
+        mix(hash(i),              hash(i + vec2(1, 0)), f.x),
+        mix(hash(i + vec2(0, 1)), hash(i + vec2(1, 1)), f.x),
+        f.y
+    );
+}
+
+void main() {
+    Frag_UV    = UV;
+    Frag_Color = Color;
+    vec2 pos   = Position;
+
+    // only wobble untextured geometry — ImGui's white pixel at UV near (0,0)
+    // is used for all solid-color primitives (lines, fills, grid).
+    // text vertices have font atlas UVs well above this threshold.
+    if (UV.x < 0.01 && UV.y < 0.01) {
+        // vertex-ID noise: travels with the line (dominant for dense polylines)
+        float lineSeed = dot(Color.rgb, vec3(7.13, 157.7, 1117.3));
+        float t = float(gl_VertexID) * u_frequency + lineSeed;
+        float vtxNx = vnoise(vec2(t, u_seed)) - 0.5;
+        float vtxNy = vnoise(vec2(t + 57.0, u_seed + 113.0)) - 0.5;
+
+        // position noise: axis/grid lines have only 2-4 vertices with adjacent
+        // IDs — position noise gives their endpoints different offsets
+        vec2  nc    = pos * u_frequency * 0.4 + u_seed;
+        float posNx = vnoise(nc) - 0.5;
+        float posNy = vnoise(nc + vec2(57.0, 113.0)) - 0.5;
+
+        pos.x += (vtxNx + posNx) * u_amplitude;
+        pos.y += (vtxNy + posNy) * u_amplitude;
+    }
+
+    gl_Position = ProjMtx * vec4(pos, 0.0, 1.0);
+}
+)glsl";
+
+static constexpr auto* kFragBody = R"glsl(
+in vec2 Frag_UV;
+in vec4 Frag_Color;
+uniform sampler2D Texture;
+layout(location = 0) out vec4 Out_Color;
+void main() {
+    Out_Color = Frag_Color * texture(Texture, Frag_UV.st);
+}
+)glsl";
+
+inline GLuint compileShader(GLenum type, const char* prefix, const char* body) {
+    GLuint                     shader  = glCreateShader(type);
+    std::array<const char*, 2> sources = {prefix, body};
+    glShaderSource(shader, static_cast<GLsizei>(sources.size()), sources.data(), nullptr);
+    glCompileShader(shader);
+    GLint ok = 0;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+    if (!ok) {
+        std::array<char, 1024> log{};
+        glGetShaderInfoLog(shader, static_cast<GLsizei>(log.size()), nullptr, log.data());
+        std::println(stderr, "[ImXkcd] {} shader compile error:\n{}", type == GL_VERTEX_SHADER ? "vertex" : "fragment", log.data());
+    }
+    return shader;
+}
+
+inline void enableCallback(const ImDrawList*, const ImDrawCmd*) {
+    GLint currentProg = 0;
+    glGetIntegerv(GL_CURRENT_PROGRAM, &currentProg);
+
+    std::array<float, 16> proj{};
+    GLint                 projLoc = glGetUniformLocation(static_cast<GLuint>(currentProg), "ProjMtx");
+    if (projLoc >= 0) {
+        glGetUniformfv(static_cast<GLuint>(currentProg), projLoc, proj.data());
+    }
+
+    glUseProgram(g_program);
+
+    // ImGui's GLSL 130 variant has no layout qualifiers — locations are driver-assigned
+    glEnableVertexAttribArray(0);
+    glEnableVertexAttribArray(1);
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(ImDrawVert), reinterpret_cast<void*>(offsetof(ImDrawVert, pos)));
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(ImDrawVert), reinterpret_cast<void*>(offsetof(ImDrawVert, uv)));
+    glVertexAttribPointer(2, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(ImDrawVert), reinterpret_cast<void*>(offsetof(ImDrawVert, col)));
+
+    glUniformMatrix4fv(g_locProj, 1, GL_FALSE, proj.data());
+    glUniform1f(g_locAmp, amplitude);
+    glUniform1f(g_locFreq, frequency);
+    glUniform1f(g_locSeed, seed);
+    glUniform1i(g_locTex, 0);
+}
+
+} // namespace detail
+
+inline void Init() {
+    using namespace detail;
+
+    GLuint vs = compileShader(GL_VERTEX_SHADER, kGlslPrefix, kVertBody);
+    GLuint fs = compileShader(GL_FRAGMENT_SHADER, kGlslPrefix, kFragBody);
+
+    g_program = glCreateProgram();
+    glAttachShader(g_program, vs);
+    glAttachShader(g_program, fs);
+
+    // must match ImGui's vertex layout
+    glBindAttribLocation(g_program, 0, "Position");
+    glBindAttribLocation(g_program, 1, "UV");
+    glBindAttribLocation(g_program, 2, "Color");
+
+    glLinkProgram(g_program);
+
+    GLint ok = 0;
+    glGetProgramiv(g_program, GL_LINK_STATUS, &ok);
+    if (!ok) {
+        std::array<char, 1024> log{};
+        glGetProgramInfoLog(g_program, static_cast<GLsizei>(log.size()), nullptr, log.data());
+        std::println(stderr, "[ImXkcd] program link error:\n{}", log.data());
+        glDeleteProgram(g_program);
+        g_program = 0;
+        glDeleteShader(vs);
+        glDeleteShader(fs);
+        return;
+    }
+
+    g_locProj = glGetUniformLocation(g_program, "ProjMtx");
+    g_locAmp  = glGetUniformLocation(g_program, "u_amplitude");
+    g_locFreq = glGetUniformLocation(g_program, "u_frequency");
+    g_locSeed = glGetUniformLocation(g_program, "u_seed");
+    g_locTex  = glGetUniformLocation(g_program, "Texture");
+
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+
+    std::println("[ImXkcd] initialised (program={}, uniforms: proj={} amp={} freq={} seed={} tex={})", g_program, g_locProj, g_locAmp, g_locFreq, g_locSeed, g_locTex);
+}
+
+inline void Apply(ImDrawData* drawData) {
+    using namespace detail;
+    if (!g_program || !drawData || !enabled) {
+        return;
+    }
+
+    for (int i = 0; i < drawData->CmdListsCount; ++i) {
+        ImDrawList* dl    = drawData->CmdLists[i];
+        const int   nCmds = dl->CmdBuffer.Size;
+
+        // each draw cmd becomes: [enable_callback] [original draw] [reset]
+        ImVector<ImDrawCmd> patched;
+        patched.reserve(nCmds * 3);
+
+        for (int j = 0; j < nCmds; ++j) {
+            const ImDrawCmd& cmd = dl->CmdBuffer[j];
+
+            if (cmd.UserCallback) {
+                patched.push_back(cmd);
+            } else {
+                ImDrawCmd enableCmd    = {};
+                enableCmd.UserCallback = enableCallback;
+                patched.push_back(enableCmd);
+
+                patched.push_back(cmd);
+
+                ImDrawCmd resetCmd    = {};
+                resetCmd.UserCallback = ImDrawCallback_ResetRenderState;
+                patched.push_back(resetCmd);
+            }
+        }
+
+        dl->CmdBuffer.swap(patched);
+    }
+}
+
+inline void Shutdown() {
+    if (detail::g_program) {
+        glDeleteProgram(detail::g_program);
+        detail::g_program = 0;
+    }
+}
+
+} // namespace ImXkcd
+
+#endif // IMGUI_XKCD_IMPLEMENTATION
+#endif // IMGUI_XKCD_HPP

--- a/src/ui/common/LookAndFeel.cpp
+++ b/src/ui/common/LookAndFeel.cpp
@@ -65,10 +65,10 @@ void LookAndFeel::loadFonts() {
 
     auto loadDefaultFont = [](auto primaryFont, auto secondaryFont, std::size_t index, const std::vector<ImWchar>& ranges = {}) {
         auto loadFont = [&primaryFont, &secondaryFont, &ranges](float loadFontSize) {
-            const auto resultFont = ImGui::GetIO().Fonts->AddFontFromMemoryTTF(const_cast<char*>(primaryFont.begin()), int(primaryFont.size()), loadFontSize, &config);
+            const auto resultFont = ImGui::GetIO().Fonts->AddFontFromMemoryTTF(const_cast<char*>(primaryFont.begin()), static_cast<int>(primaryFont.size()), loadFontSize, &config);
             if (!ranges.empty()) {
                 config.MergeMode = true;
-                ImGui::GetIO().Fonts->AddFontFromMemoryTTF(const_cast<char*>(secondaryFont.begin()), int(secondaryFont.size()), loadFontSize, &config, ranges.data());
+                ImGui::GetIO().Fonts->AddFontFromMemoryTTF(const_cast<char*>(secondaryFont.begin()), static_cast<int>(secondaryFont.size()), loadFontSize, &config, ranges.data());
                 config.MergeMode = false;
             }
             return resultFont;

--- a/src/ui/common/LookAndFeel.hpp
+++ b/src/ui/common/LookAndFeel.hpp
@@ -3,8 +3,22 @@
 
 #include <array>
 #include <chrono>
+#include <cstdint>
 
 enum class WindowMode { FULLSCREEN, MAXIMISED, MINIMISED, RESTORED };
+
+/**
+ * @brief Convert RGB color (0xRRGGBB) to ImGui's ABGR format (0xAABBGGRR).
+ * @param rgb Color in RGB format (0xRRGGBB)
+ * @param alpha Alpha value (default 0xFF for fully opaque)
+ * @return Color in ImGui's ABGR format
+ */
+constexpr std::uint32_t rgbToImGuiABGR(std::uint32_t rgb, std::uint8_t alpha = 0xFF) {
+    const std::uint32_t r = (rgb >> 16) & 0xFF;
+    const std::uint32_t g = (rgb >> 8) & 0xFF;
+    const std::uint32_t b = (rgb >> 0) & 0xFF;
+    return (static_cast<std::uint32_t>(alpha) << 24) | (b << 16) | (g << 8) | r;
+}
 
 struct ImFont;
 

--- a/src/ui/common/TouchHandler.hpp
+++ b/src/ui/common/TouchHandler.hpp
@@ -392,17 +392,24 @@ struct TouchHandler {
             }
         }
 
+        // Apply standard plot styles: no plot/label padding, 5% vertical fit padding
+        ImPlot::PushStyleVar(ImPlotStyleVar_PlotPadding, ImVec2{0, 0});
+        ImPlot::PushStyleVar(ImPlotStyleVar_LabelPadding, ImVec2{3, 1});
+        ImPlot::PushStyleVar(ImPlotStyleVar_FitPadding, ImVec2{0.0f, 0.05f});
+
         if (ImPlot::BeginPlot(plotName.c_str(), size, flags)) {
             return true;
         }
+        ImPlot::PopStyleVar(3);
         zoomablePlotInit = 0UL;
         return false;
     }
 
     static void EndZoomablePlot() {
         Digitizer::utils::scope_exit guard = [&] {
-            zoomablePlotInit = 0UL;
             ImPlot::EndPlot();
+            ImPlot::PopStyleVar(3);
+            zoomablePlotInit = 0UL;
         };
 
         if (!gestureActive || gestureDragActive || nFingers != 2) {

--- a/src/ui/components/Block.cpp
+++ b/src/ui/components/Block.cpp
@@ -2,6 +2,8 @@
 #include "BlockNeighboursPreview.hpp"
 #include "Keypad.hpp"
 
+#include <format>
+
 #include <gnuradio-4.0/Scheduler.hpp>
 #include <misc/cpp/imgui_stdlib.h>
 
@@ -216,7 +218,8 @@ void BlockSettingsControls(UiGraphBlock* block, const ImVec2& /*size*/) {
             // Column 2: Input
             ImGui::TableSetColumnIndex(1);
             char label[64];
-            snprintf(label, sizeof(label), "##parameter_%d", i);
+            auto labelResult = std::format_to_n(label, sizeof(label) - 1, "##parameter_{}", i);
+            *labelResult.out = '\0';
 
             auto sendSetSettingMessage = [block](auto blockUniqueName, auto keyToUpdate, auto updatedValue) {
                 gr::Message message;

--- a/src/ui/components/ColourManager.hpp
+++ b/src/ui/components/ColourManager.hpp
@@ -206,11 +206,7 @@ struct ColourManager {
         return p.size() - 1;
     }
 
-    static std::string toHex(std::uint32_t c) {
-        char buf[10];
-        std::snprintf(buf, sizeof(buf), "%06X", c);
-        return std::string(buf);
-    }
+    static std::string toHex(std::uint32_t c) { return std::format("{:06X}", c); }
 };
 
 struct ManagedColour {

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -286,6 +286,8 @@ int main(int argc, char** argv) {
     }
 #endif
 
+    app.closeDashboard();
+    app.restClient.reset();
     imgui_helper::teardownSDL();
     return 0;
 }

--- a/src/ui/test/CMakeLists.txt
+++ b/src/ui/test/CMakeLists.txt
@@ -1,5 +1,18 @@
 # define unit-tests
 
+# Headless chart abstraction tests (links opendigitizer-uilib for shared TestSinks.hpp)
+add_executable(qa_SignalSink qa_SignalSink.cpp)
+target_link_libraries(qa_SignalSink PRIVATE ut opendigitizer-uilib)
+target_include_directories(qa_SignalSink PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+add_test(NAME qa_SignalSink COMMAND qa_SignalSink)
+
+# Chart abstraction tests for SignalSink/SinkRegistry/Chart mixin APIs Note: links opendigitizer-uilib because Chart.hpp
+# menu helpers reference LookAndFeel
+add_executable(qa_ChartAbstraction qa_ChartAbstraction.cpp)
+target_link_libraries(qa_ChartAbstraction PRIVATE ut opendigitizer-uilib)
+target_include_directories(qa_ChartAbstraction PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+add_test(NAME qa_ChartAbstraction COMMAND qa_ChartAbstraction)
+
 add_executable(qa_play_stop_bar qa_play_stop_bar.cpp)
 target_include_directories(qa_play_stop_bar INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                       $<INSTALL_INTERFACE:include/>)

--- a/src/ui/test/ImGuiTestApp.cpp
+++ b/src/ui/test/ImGuiTestApp.cpp
@@ -90,17 +90,13 @@ inline static bool ImGuiApp_ImplGL_CaptureFramebuffer(ImGuiApp* /*app*/, ImGuiVi
     // Vertical flip
     const std::size_t bytes_per_pixel = 4UZ;
     const std::size_t row_stride      = static_cast<std::size_t>(w) * bytes_per_pixel;
-    auto*             line_tmp        = new unsigned char[row_stride];
-    auto*             line_a          = reinterpret_cast<unsigned char*>(pixels);
-    auto*             line_b          = line_a + (row_stride * static_cast<std::size_t>(h - 1));
-    while (line_a < line_b) {
-        std::memcpy(line_tmp, line_a, row_stride);
-        std::memcpy(line_a, line_b, row_stride);
-        std::memcpy(line_b, line_tmp, row_stride);
-        line_a += row_stride;
-        line_b -= row_stride;
+    auto*             lineA           = reinterpret_cast<unsigned char*>(pixels);
+    auto*             lineB           = lineA + (row_stride * static_cast<std::size_t>(h - 1));
+    while (lineA < lineB) {
+        std::swap_ranges(lineA, lineA + row_stride, lineB);
+        lineA += row_stride;
+        lineB -= row_stride;
     }
-    delete[] line_tmp;
 
     return true;
 }

--- a/src/ui/test/TestSinks.hpp
+++ b/src/ui/test/TestSinks.hpp
@@ -1,0 +1,319 @@
+#ifndef OPENDIGITIZER_TEST_TESTSINKS_HPP
+#define OPENDIGITIZER_TEST_TESTSINKS_HPP
+
+#include "../charts/Charts.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <deque>
+#include <limits>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace opendigitizer::test {
+
+class TestStreamingSink : public opendigitizer::SignalSink {
+    std::string         _uniqueName;
+    std::string         _signalName;
+    std::uint32_t       _color      = 0xFFFFFF;
+    float               _sampleRate = 1000.0f;
+    std::vector<double> _xValues;
+    std::vector<float>  _yValues;
+    std::size_t         _capacity;
+    std::size_t         _totalSampleCount = 0;
+    mutable std::mutex  _mutex;
+    bool                _drawEnabled      = true;
+    std::string         _signalQuantity   = "voltage";
+    std::string         _signalUnit       = "V";
+    std::string         _abscissaQuantity = "time";
+    std::string         _abscissaUnit     = "s";
+
+    struct CapacityRequest {
+        std::size_t                                        capacity;
+        std::chrono::time_point<std::chrono::steady_clock> expiry_time;
+    };
+    std::unordered_map<std::string, CapacityRequest> _capacityRequests;
+
+public:
+    explicit TestStreamingSink(std::string name, std::size_t capacity = 2048) : _uniqueName(std::move(name)), _signalName(_uniqueName), _capacity(capacity) {
+        _xValues.reserve(capacity);
+        _yValues.reserve(capacity);
+    }
+
+    [[nodiscard]] std::string_view         name() const noexcept override { return _uniqueName; }
+    [[nodiscard]] std::string_view         uniqueName() const noexcept override { return _uniqueName; }
+    [[nodiscard]] std::string_view         signalName() const noexcept override { return _signalName; }
+    [[nodiscard]] std::uint32_t            color() const noexcept override { return _color; }
+    [[nodiscard]] float                    sampleRate() const noexcept override { return _sampleRate; }
+    [[nodiscard]] opendigitizer::LineStyle lineStyle() const noexcept override { return opendigitizer::LineStyle::Solid; }
+    [[nodiscard]] float                    lineWidth() const noexcept override { return 1.0f; }
+
+    [[nodiscard]] std::size_t size() const noexcept override { return _xValues.size(); }
+    [[nodiscard]] double      xAt(std::size_t i) const override { return _xValues[i]; }
+    [[nodiscard]] float       yAt(std::size_t i) const override { return _yValues[i]; }
+
+    [[nodiscard]] opendigitizer::PlotData plotData() const override {
+        static auto getter = +[](int idx, void* userData) -> opendigitizer::PlotPoint {
+            auto* self = static_cast<const TestStreamingSink*>(userData);
+            return {self->_xValues[static_cast<std::size_t>(idx)], static_cast<double>(self->_yValues[static_cast<std::size_t>(idx)])};
+        };
+        return {getter, const_cast<TestStreamingSink*>(this), static_cast<int>(_xValues.size())};
+    }
+
+    [[nodiscard]] bool                                hasDataSets() const noexcept override { return false; }
+    [[nodiscard]] std::size_t                         dataSetCount() const noexcept override { return 0; }
+    [[nodiscard]] std::span<const gr::DataSet<float>> dataSets() const override { return {}; }
+
+    [[nodiscard]] bool                      hasStreamingTags() const noexcept override { return false; }
+    [[nodiscard]] std::pair<double, double> tagTimeRange() const noexcept override { return {0.0, 0.0}; }
+    void                                    forEachTag(std::function<void(double, const gr::property_map&)> /*callback*/) const override {}
+
+    [[nodiscard]] double timeFirst() const noexcept override { return _xValues.empty() ? 0.0 : _xValues.front(); }
+    [[nodiscard]] double timeLast() const noexcept override { return _xValues.empty() ? 0.0 : _xValues.back(); }
+
+    [[nodiscard]] std::size_t totalSampleCount() const noexcept override { return _totalSampleCount; }
+
+    [[nodiscard]] std::size_t bufferCapacity() const noexcept override { return _capacity; }
+
+    void requestCapacity(std::string_view source, std::size_t capacity, std::chrono::seconds timeout = std::chrono::seconds{60}) override {
+        auto expiry_time                       = std::chrono::steady_clock::now() + timeout;
+        _capacityRequests[std::string(source)] = CapacityRequest{capacity, expiry_time};
+        for (const auto& [_, request] : _capacityRequests) {
+            _capacity = std::max(_capacity, request.capacity);
+        }
+    }
+
+    void expireCapacityRequests() override {
+        auto now = std::chrono::steady_clock::now();
+        std::erase_if(_capacityRequests, [now](const auto& pair) { return pair.second.expiry_time < now; });
+        std::size_t maxCap = 2048;
+        for (const auto& [_, request] : _capacityRequests) {
+            maxCap = std::max(maxCap, request.capacity);
+        }
+        _capacity = maxCap;
+    }
+
+    [[nodiscard]] DataRange getXRange(double tMin, double tMax) const override {
+        if (_xValues.empty()) {
+            return {0, 0};
+        }
+        auto itBegin = std::lower_bound(_xValues.begin(), _xValues.end(), tMin);
+        auto itEnd   = std::upper_bound(_xValues.begin(), _xValues.end(), tMax);
+        if (itBegin >= itEnd) {
+            return {0, 0};
+        }
+        std::size_t startIdx = static_cast<std::size_t>(std::distance(_xValues.begin(), itBegin));
+        std::size_t count    = static_cast<std::size_t>(std::distance(itBegin, itEnd));
+        return {startIdx, count};
+    }
+
+    [[nodiscard]] DataRange getTagRange(double /*tMin*/, double /*tMax*/) const override { return {0, 0}; }
+
+    [[nodiscard]] XRangeResult getX(double tMin, double tMax) const override {
+        auto [startIdx, count] = getXRange(tMin, tMax);
+        if (count == 0) {
+            return {{}, 0.0, 0.0};
+        }
+        return {std::span<const double>(_xValues.data() + startIdx, count), _xValues[startIdx], _xValues[startIdx + count - 1]};
+    }
+    [[nodiscard]] YRangeResult getY(double tMin, double tMax) const override {
+        auto [startIdx, count] = getXRange(tMin, tMax);
+        if (count == 0) {
+            return {{}, 0.0, 0.0};
+        }
+        return {std::span<const float>(_yValues.data() + startIdx, count), _xValues[startIdx], _xValues[startIdx + count - 1]};
+    }
+    [[nodiscard]] TagRangeResult getTags(double /*tMin*/, double /*tMax*/) const override { return {{}, 0.0, 0.0}; }
+    [[nodiscard]] XYTagRange     xyTagRange(double tMin, double tMax) const override {
+        auto range = getXRange(tMin, tMax);
+        if (range.empty()) {
+            return XYTagRange{};
+        }
+        return XYTagRange{XYTagIterator{this, range.start_index, range.start_index + range.count}, XYTagIterator{this, range.start_index + range.count, range.start_index + range.count}};
+    }
+    void pruneTags(double /*minX*/) override {}
+
+    [[nodiscard]] opendigitizer::DataGuard dataGuard() const override { return opendigitizer::DataGuard(_mutex); }
+
+    gr::work::Status draw(const gr::property_map& /*config*/) override { return gr::work::Status::OK; }
+
+    [[nodiscard]] bool drawEnabled() const noexcept override { return _drawEnabled; }
+    void               setDrawEnabled(bool enabled) override { _drawEnabled = enabled; }
+
+    [[nodiscard]] std::string_view signalQuantity() const noexcept override { return _signalQuantity; }
+    [[nodiscard]] std::string_view signalUnit() const noexcept override { return _signalUnit; }
+    [[nodiscard]] std::string_view abscissaQuantity() const noexcept override { return _abscissaQuantity; }
+    [[nodiscard]] std::string_view abscissaUnit() const noexcept override { return _abscissaUnit; }
+    [[nodiscard]] float            signalMin() const noexcept override { return std::numeric_limits<float>::lowest(); }
+    [[nodiscard]] float            signalMax() const noexcept override { return std::numeric_limits<float>::max(); }
+
+    void setSignalName(std::string name) { _signalName = std::move(name); }
+    void setSampleRate(float rate) { _sampleRate = rate; }
+    void setColor(std::uint32_t c) { _color = c; }
+    void setSignalQuantity(std::string q) { _signalQuantity = std::move(q); }
+    void setSignalUnit(std::string u) { _signalUnit = std::move(u); }
+    void setAbscissaQuantity(std::string q) { _abscissaQuantity = std::move(q); }
+    void setAbscissaUnit(std::string u) { _abscissaUnit = std::move(u); }
+
+    void pushSample(double x, float y) {
+        if (_xValues.size() >= _capacity) {
+            _xValues.erase(_xValues.begin());
+            _yValues.erase(_yValues.begin());
+        }
+        _xValues.push_back(x);
+        _yValues.push_back(y);
+        ++_totalSampleCount;
+    }
+};
+
+class TestDataSetSink : public opendigitizer::SignalSink {
+    std::string                    _uniqueName;
+    std::deque<gr::DataSet<float>> _dataSets;
+    std::size_t                    _maxDataSets;
+    std::size_t                    _totalDataSetCount = 0;
+    mutable std::mutex             _mutex;
+    bool                           _drawEnabled = true;
+
+public:
+    explicit TestDataSetSink(std::string name, std::size_t maxDataSets = 10) : _uniqueName(std::move(name)), _maxDataSets(maxDataSets) {}
+
+    [[nodiscard]] std::string_view         name() const noexcept override { return _uniqueName; }
+    [[nodiscard]] std::string_view         uniqueName() const noexcept override { return _uniqueName; }
+    [[nodiscard]] std::string_view         signalName() const noexcept override { return _uniqueName; }
+    [[nodiscard]] std::uint32_t            color() const noexcept override { return 0xFFFFFF; }
+    [[nodiscard]] float                    sampleRate() const noexcept override { return 1.0f; }
+    [[nodiscard]] opendigitizer::LineStyle lineStyle() const noexcept override { return opendigitizer::LineStyle::Solid; }
+    [[nodiscard]] float                    lineWidth() const noexcept override { return 1.0f; }
+
+    [[nodiscard]] std::size_t size() const noexcept override {
+        if (_dataSets.empty()) {
+            return 0;
+        }
+        const auto& ds = _dataSets.front();
+        return ds.axis_values.empty() ? 0 : ds.axis_values[0].size();
+    }
+
+    [[nodiscard]] double xAt(std::size_t i) const override {
+        if (_dataSets.empty()) {
+            return 0.0;
+        }
+        const auto& ds = _dataSets.front();
+        return ds.axis_values.empty() ? 0.0 : static_cast<double>(ds.axis_values[0][i]);
+    }
+
+    [[nodiscard]] float yAt(std::size_t i) const override {
+        if (_dataSets.empty()) {
+            return 0.0f;
+        }
+        const auto& ds = _dataSets.front();
+        return i < ds.signal_values.size() ? ds.signal_values[i] : 0.0f;
+    }
+
+    [[nodiscard]] opendigitizer::PlotData plotData() const override {
+        static auto getter = +[](int idx, void* userData) -> opendigitizer::PlotPoint {
+            auto* self = static_cast<const TestDataSetSink*>(userData);
+            return {self->xAt(static_cast<std::size_t>(idx)), static_cast<double>(self->yAt(static_cast<std::size_t>(idx)))};
+        };
+        return {getter, const_cast<TestDataSetSink*>(this), static_cast<int>(size())};
+    }
+
+    [[nodiscard]] bool                                hasDataSets() const noexcept override { return !_dataSets.empty(); }
+    [[nodiscard]] std::size_t                         dataSetCount() const noexcept override { return _dataSets.size(); }
+    [[nodiscard]] std::span<const gr::DataSet<float>> dataSets() const override { return {}; }
+
+    [[nodiscard]] bool                      hasStreamingTags() const noexcept override { return false; }
+    [[nodiscard]] std::pair<double, double> tagTimeRange() const noexcept override { return {0.0, 0.0}; }
+    void                                    forEachTag(std::function<void(double, const gr::property_map&)> /*callback*/) const override {}
+
+    [[nodiscard]] double timeFirst() const noexcept override { return 0.0; }
+    [[nodiscard]] double timeLast() const noexcept override { return 0.0; }
+
+    [[nodiscard]] std::size_t totalSampleCount() const noexcept override { return _totalDataSetCount; }
+
+    [[nodiscard]] std::size_t bufferCapacity() const noexcept override { return _maxDataSets; }
+
+    void requestCapacity(std::string_view /*source*/, std::size_t /*capacity*/, std::chrono::seconds /*timeout*/ = std::chrono::seconds{60}) override {}
+
+    void expireCapacityRequests() override {}
+
+    [[nodiscard]] DataRange getXRange(double /*tMin*/, double /*tMax*/) const override { return {0, 0}; }
+    [[nodiscard]] DataRange getTagRange(double /*tMin*/, double /*tMax*/) const override { return {0, 0}; }
+
+    [[nodiscard]] XRangeResult   getX(double /*tMin*/, double /*tMax*/) const override { return {{}, 0.0, 0.0}; }
+    [[nodiscard]] YRangeResult   getY(double /*tMin*/, double /*tMax*/) const override { return {{}, 0.0, 0.0}; }
+    [[nodiscard]] TagRangeResult getTags(double /*tMin*/, double /*tMax*/) const override { return {{}, 0.0, 0.0}; }
+    [[nodiscard]] XYTagRange     xyTagRange(double /*tMin*/, double /*tMax*/) const override { return XYTagRange{}; }
+    void                         pruneTags(double /*minX*/) override {}
+
+    [[nodiscard]] opendigitizer::DataGuard dataGuard() const override { return opendigitizer::DataGuard(_mutex); }
+
+    gr::work::Status draw(const gr::property_map& /*config*/) override { return gr::work::Status::OK; }
+
+    [[nodiscard]] bool drawEnabled() const noexcept override { return _drawEnabled; }
+    void               setDrawEnabled(bool enabled) override { _drawEnabled = enabled; }
+
+    [[nodiscard]] std::string_view signalQuantity() const noexcept override { return ""; }
+    [[nodiscard]] std::string_view signalUnit() const noexcept override { return ""; }
+    [[nodiscard]] std::string_view abscissaQuantity() const noexcept override { return "time"; }
+    [[nodiscard]] std::string_view abscissaUnit() const noexcept override { return "s"; }
+    [[nodiscard]] float            signalMin() const noexcept override { return std::numeric_limits<float>::lowest(); }
+    [[nodiscard]] float            signalMax() const noexcept override { return std::numeric_limits<float>::max(); }
+
+    void pushDataSet(gr::DataSet<float> ds) {
+        if (_dataSets.size() >= _maxDataSets) {
+            _dataSets.pop_front();
+        }
+        _dataSets.push_back(std::move(ds));
+        ++_totalDataSetCount;
+    }
+
+    const std::deque<gr::DataSet<float>>& rawDataSets() const { return _dataSets; }
+};
+
+template<typename T = float>
+inline std::shared_ptr<TestStreamingSink> makeTestStreamingSink(std::string name, std::size_t capacity = 2048) {
+    return std::make_shared<TestStreamingSink>(std::move(name), capacity);
+}
+
+template<typename T = float>
+inline std::shared_ptr<TestDataSetSink> makeTestDataSetSink(std::string name, std::size_t maxDataSets = 10) {
+    return std::make_shared<TestDataSetSink>(std::move(name), maxDataSets);
+}
+
+inline std::shared_ptr<opendigitizer::charts::XYChart> makeXYChart(const std::string& name = "") {
+    gr::property_map initParams;
+    if (!name.empty()) {
+        initParams["chart_name"] = name;
+    }
+    return std::make_shared<opendigitizer::charts::XYChart>(std::move(initParams));
+}
+
+inline std::shared_ptr<opendigitizer::charts::YYChart> makeYYChart(const std::string& name = "") {
+    gr::property_map initParams;
+    if (!name.empty()) {
+        initParams["chart_name"] = name;
+    }
+    return std::make_shared<opendigitizer::charts::YYChart>(std::move(initParams));
+}
+
+inline std::variant<std::shared_ptr<opendigitizer::charts::XYChart>, std::shared_ptr<opendigitizer::charts::YYChart>, std::monostate> makeChartByType(std::string_view typeName, const std::string& name = "") {
+    using namespace opendigitizer::charts;
+    using Storage = std::variant<std::shared_ptr<XYChart>, std::shared_ptr<YYChart>, std::monostate>;
+
+    std::string lowerTypeName(typeName);
+    std::transform(lowerTypeName.begin(), lowerTypeName.end(), lowerTypeName.begin(), [](unsigned char c) { return std::tolower(c); });
+
+    if (lowerTypeName.find("xychart") != std::string::npos || typeName == "XYChart") {
+        return Storage{makeXYChart(name)};
+    }
+    if (lowerTypeName.find("yychart") != std::string::npos || typeName == "YYChart") {
+        return Storage{makeYYChart(name)};
+    }
+    return Storage{std::monostate{}};
+}
+
+} // namespace opendigitizer::test
+
+#endif // OPENDIGITIZER_TEST_TESTSINKS_HPP

--- a/src/ui/test/qa_ChartAbstraction.cpp
+++ b/src/ui/test/qa_ChartAbstraction.cpp
@@ -1,0 +1,381 @@
+#include "TestSinks.hpp"
+
+#include <boost/ut.hpp>
+
+#include <chrono>
+#include <cmath>
+#include <thread>
+
+int main() {
+    using namespace boost::ut;
+    using namespace opendigitizer::charts;
+    using namespace opendigitizer::test;
+
+    "XYChart creation via makeXYChart"_test = [] {
+        auto chart = makeXYChart("TestChart");
+
+        expect(eq(chart->chartTypeName(), std::string_view("XYChart")));
+        expect(!chart->uniqueId().empty());
+        expect(chart->uniqueId().find("XYChart") != std::string_view::npos);
+        expect(eq(chart->signalSinkCount(), 0UZ));
+    };
+
+    "XYChart signal sink management"_test = [] {
+        auto chart = makeXYChart();
+
+        auto sink1 = makeTestStreamingSink("sink1");
+        auto sink2 = makeTestStreamingSink("sink2");
+
+        chart->addSignalSink(sink1);
+        chart->addSignalSink(sink2);
+
+        expect(eq(chart->signalSinkCount(), 2UZ));
+
+        const auto& sinks = chart->signalSinks();
+        expect(eq(sinks[0]->uniqueName(), std::string_view("sink1")));
+        expect(eq(sinks[1]->uniqueName(), std::string_view("sink2")));
+
+        chart->removeSignalSink("sink1");
+        expect(eq(chart->signalSinkCount(), 1UZ));
+    };
+
+    "XYChart clear sinks"_test = [] {
+        auto chart = makeXYChart();
+
+        chart->addSignalSink(makeTestStreamingSink("sink1"));
+        chart->addSignalSink(makeTestStreamingSink("sink2"));
+
+        expect(eq(chart->signalSinkCount(), 2UZ));
+
+        chart->clearSignalSinks();
+        expect(eq(chart->signalSinkCount(), 0UZ));
+    };
+
+    "Chart mixin via concrete types"_test = [] {
+        auto xyChart = makeXYChart("MixinTest");
+
+        expect(eq(xyChart->chartTypeName(), std::string_view("XYChart")));
+
+        auto sink = makeTestStreamingSink("mixin_sink");
+        xyChart->addSignalSink(sink);
+        expect(eq(xyChart->signalSinkCount(), 1UZ));
+
+        xyChart->clearSignalSinks();
+        expect(eq(xyChart->signalSinkCount(), 0UZ));
+    };
+
+    "makeChartByType creates correct chart type"_test = [] {
+        auto xyStorage = makeChartByType("XYChart", "TestXY");
+        expect(std::holds_alternative<std::shared_ptr<XYChart>>(xyStorage));
+        auto& xyChart = std::get<std::shared_ptr<XYChart>>(xyStorage);
+        expect(eq(xyChart->chartTypeName(), std::string_view("XYChart")));
+
+        auto yyStorage = makeChartByType("YYChart", "TestYY");
+        expect(std::holds_alternative<std::shared_ptr<YYChart>>(yyStorage));
+        auto& yyChart = std::get<std::shared_ptr<YYChart>>(yyStorage);
+        expect(eq(yyChart->chartTypeName(), std::string_view("YYChart")));
+
+        auto unknownStorage = makeChartByType("UnknownChart");
+        expect(std::holds_alternative<std::monostate>(unknownStorage));
+    };
+
+    "registeredChartTypes queries block registry"_test = [] {
+        auto types = registeredChartTypes();
+
+        expect(std::is_sorted(types.begin(), types.end())) << "Types should be sorted";
+
+        for (const auto& type : types) {
+            std::string lowerType = type;
+            std::transform(lowerType.begin(), lowerType.end(), lowerType.begin(), [](unsigned char c) { return std::tolower(c); });
+            expect(lowerType.find("chart") != std::string::npos) << "All returned types should contain 'chart'";
+        }
+    };
+
+    "Helper functions"_test = [] {
+        auto streamingSink = makeTestStreamingSink("helper_streaming");
+        expect(streamingSink != nullptr);
+        expect(eq(streamingSink->uniqueName(), std::string_view("helper_streaming")));
+
+        auto datasetSink = makeTestDataSetSink("helper_dataset");
+        expect(datasetSink != nullptr);
+        expect(eq(datasetSink->uniqueName(), std::string_view("helper_dataset")));
+
+        auto xyChart = makeXYChart();
+        expect(xyChart != nullptr);
+        expect(eq(xyChart->chartTypeName(), std::string_view("XYChart")));
+
+        auto yyChart = makeYYChart();
+        expect(yyChart != nullptr);
+        expect(eq(yyChart->chartTypeName(), std::string_view("YYChart")));
+    };
+
+    "Signal shared between multiple charts"_test = [] {
+        auto sink = makeTestStreamingSink("shared_signal");
+
+        for (int i = 0; i < 100; ++i) {
+            sink->pushSample(static_cast<double>(i) * 0.01, std::sin(static_cast<float>(i) * 0.1f));
+        }
+
+        auto chart1 = makeXYChart();
+        auto chart2 = makeXYChart();
+
+        chart1->addSignalSink(sink);
+        chart2->addSignalSink(sink);
+
+        expect(eq(chart1->signalSinks()[0]->size(), chart2->signalSinks()[0]->size()));
+
+        sink->requestCapacity(chart1->uniqueId(), 3000);
+        sink->requestCapacity(chart2->uniqueId(), 5000);
+
+        expect(eq(sink->bufferCapacity(), 5000UZ));
+    };
+
+    "PlotData can be used for rendering"_test = [] {
+        auto sink = makeTestStreamingSink("plot_data_test");
+
+        for (int i = 0; i < 50; ++i) {
+            sink->pushSample(static_cast<double>(i), static_cast<float>(i * 2));
+        }
+
+        auto pd = sink->plotData();
+        expect(!pd.empty());
+        expect(eq(pd.count, 50));
+
+        auto p0 = pd.getter(0, pd.user_data);
+        expect(std::abs(p0.x - 0.0) < 1e-9);
+        expect(std::abs(p0.y - 0.0) < 1e-9);
+
+        auto p25 = pd.getter(25, pd.user_data);
+        expect(std::abs(p25.x - 25.0) < 1e-9);
+        expect(std::abs(p25.y - 50.0) < 1e-9);
+    };
+
+    "YYChart creation"_test = [] {
+        auto chart = makeYYChart();
+
+        expect(eq(chart->chartTypeName(), std::string_view("YYChart")));
+        expect(!chart->uniqueId().empty());
+        expect(chart->uniqueId().find("YYChart") != std::string_view::npos);
+    };
+
+    "YYChart with two sinks"_test = [] {
+        auto chart = makeYYChart();
+        auto sink1 = makeTestStreamingSink("yy_sink1");
+        auto sink2 = makeTestStreamingSink("yy_sink2");
+
+        chart->addSignalSink(sink1);
+        chart->addSignalSink(sink2);
+
+        expect(eq(chart->signalSinks().size(), 2UZ));
+
+        for (int i = 0; i < 100; ++i) {
+            double t = static_cast<double>(i) * 0.01;
+            sink1->pushSample(t, std::sin(2.0f * 3.14159f * static_cast<float>(t)));
+            sink2->pushSample(t, std::sin(5.0f * 3.14159f * static_cast<float>(t)));
+        }
+
+        expect(eq(sink1->size(), 100UZ));
+        expect(eq(sink2->size(), 100UZ));
+    };
+
+    "YYChart mixin methods"_test = [] {
+        auto yyChart = makeYYChart("YYMixinTest");
+
+        expect(eq(yyChart->chartTypeName(), std::string_view("YYChart")));
+
+        auto sink = makeTestStreamingSink("yy_mixin_sink");
+        yyChart->addSignalSink(sink);
+        expect(eq(yyChart->signalSinkCount(), 1UZ));
+    };
+
+    "getSinkNames and syncSinksFromNames roundtrip"_test = [] {
+        auto chart = makeXYChart();
+        auto sink1 = makeTestStreamingSink("roundtrip_sink1");
+        auto sink2 = makeTestStreamingSink("roundtrip_sink2");
+
+        SinkRegistry::instance().registerSink(sink1);
+        SinkRegistry::instance().registerSink(sink2);
+
+        chart->addSignalSink(sink1);
+        chart->addSignalSink(sink2);
+
+        auto names = chart->getSinkNames();
+        expect(eq(names.size(), 2UZ));
+
+        chart->clearSignalSinks();
+        expect(eq(chart->signalSinkCount(), 0UZ));
+
+        chart->syncSinksFromNames(names);
+        expect(eq(chart->signalSinkCount(), 2UZ));
+
+        SinkRegistry::instance().unregisterSink(sink1->uniqueName());
+        SinkRegistry::instance().unregisterSink(sink2->uniqueName());
+    };
+
+    // --- Axis-grouping edge-case tests ---
+
+    "findOrCreateCategory with 3 different groups"_test = [] {
+        std::array<std::optional<AxisCategory>, 3> categories{};
+
+        auto idx0 = axis::findOrCreateCategory(categories, "voltage", "V", 0xFF0000);
+        auto idx1 = axis::findOrCreateCategory(categories, "current", "A", 0x00FF00);
+        auto idx2 = axis::findOrCreateCategory(categories, "power", "W", 0x0000FF);
+
+        expect(idx0.has_value());
+        expect(idx1.has_value());
+        expect(idx2.has_value());
+        expect(eq(*idx0, 0UZ));
+        expect(eq(*idx1, 1UZ));
+        expect(eq(*idx2, 2UZ));
+    };
+
+    "findOrCreateCategory overflow returns nullopt"_test = [] {
+        std::array<std::optional<AxisCategory>, 3> categories{};
+
+        axis::findOrCreateCategory(categories, "voltage", "V", 0xFF0000);
+        axis::findOrCreateCategory(categories, "current", "A", 0x00FF00);
+        axis::findOrCreateCategory(categories, "power", "W", 0x0000FF);
+        auto overflow = axis::findOrCreateCategory(categories, "temperature", "K", 0xFFFF00);
+
+        expect(!overflow.has_value());
+    };
+
+    "findOrCreateCategory merges matching quantity and unit"_test = [] {
+        std::array<std::optional<AxisCategory>, 3> categories{};
+
+        auto idx0   = axis::findOrCreateCategory(categories, "voltage", "V", 0xFF0000);
+        auto idx1   = axis::findOrCreateCategory(categories, "current", "A", 0x00FF00);
+        auto idxDup = axis::findOrCreateCategory(categories, "voltage", "V", 0x00FFFF);
+
+        expect(idx0.has_value());
+        expect(idx1.has_value());
+        expect(idxDup.has_value());
+        expect(eq(*idx0, *idxDup)) << "same quantity+unit should return same index";
+        expect(eq(*idx1, 1UZ));
+    };
+
+    "YYChart buildMultiYCategories groups sinks correctly"_test = [] {
+        auto chart = makeYYChart("GroupTest");
+
+        // sink[0] = X-axis source
+        auto sinkX = makeTestStreamingSink("x_signal");
+        sinkX->setSignalQuantity("time");
+        sinkX->setSignalUnit("s");
+
+        // sink[1] and sink[2] share quantity+unit -> same Y-axis group
+        auto sinkY1 = makeTestStreamingSink("y_voltage1");
+        sinkY1->setSignalQuantity("voltage");
+        sinkY1->setSignalUnit("V");
+
+        auto sinkY2 = makeTestStreamingSink("y_voltage2");
+        sinkY2->setSignalQuantity("voltage");
+        sinkY2->setSignalUnit("V");
+
+        // sink[3] has a different quantity -> separate Y-axis group
+        auto sinkY3 = makeTestStreamingSink("y_current");
+        sinkY3->setSignalQuantity("current");
+        sinkY3->setSignalUnit("A");
+
+        chart->addSignalSink(sinkX);
+        chart->addSignalSink(sinkY1);
+        chart->addSignalSink(sinkY2);
+        chart->addSignalSink(sinkY3);
+
+        // Push one sample each so sinks have data
+        for (auto& s : chart->signalSinks()) {
+            auto* ts = dynamic_cast<TestStreamingSink*>(s.get());
+            if (ts) {
+                ts->pushSample(0.0, 1.0f);
+            }
+        }
+
+        // buildMultiYCategories is private, but we can test axis::findOrCreateCategory logic
+        // which is the same underlying mechanism
+        std::array<std::optional<AxisCategory>, 3> yCategories{};
+        std::array<std::vector<std::string>, 3>    yAxisGroups{};
+        std::vector<std::size_t>                   overflowSinkIndices;
+
+        for (std::size_t i = 1; i < chart->signalSinks().size(); ++i) {
+            const auto& sink = chart->signalSinks()[i];
+            auto        idx  = axis::findOrCreateCategory(yCategories, sink->signalQuantity(), sink->signalUnit(), sink->color());
+            if (idx.has_value()) {
+                yAxisGroups[*idx].push_back(std::string(sink->uniqueName()));
+            } else {
+                overflowSinkIndices.push_back(i);
+            }
+        }
+
+        expect(eq(axis::activeAxisCount(yCategories), 2UZ)) << "should have 2 Y-axis categories";
+        expect(eq(yAxisGroups[0].size(), 2UZ)) << "voltage group should have 2 sinks";
+        expect(eq(yAxisGroups[1].size(), 1UZ)) << "current group should have 1 sink";
+        expect(overflowSinkIndices.empty()) << "no overflow with 2 distinct groups";
+    };
+
+    "YYChart buildMultiYCategories overflow"_test = [] {
+        auto chart = makeYYChart("OverflowTest");
+
+        auto sinkX = makeTestStreamingSink("x_sig");
+        chart->addSignalSink(sinkX);
+
+        // 4 Y sinks with 4 distinct quantity+unit pairs -> 4th overflows (max 3 axes)
+        std::vector<std::pair<std::string, std::string>> units = {{"voltage", "V"}, {"current", "A"}, {"power", "W"}, {"temperature", "K"}};
+        for (std::size_t i = 0; i < units.size(); ++i) {
+            auto sink = makeTestStreamingSink("y_" + std::to_string(i));
+            sink->setSignalQuantity(units[i].first);
+            sink->setSignalUnit(units[i].second);
+            chart->addSignalSink(sink);
+        }
+
+        std::array<std::optional<AxisCategory>, 3> yCategories{};
+        std::vector<std::size_t>                   overflowSinkIndices;
+
+        for (std::size_t i = 1; i < chart->signalSinks().size(); ++i) {
+            const auto& sink = chart->signalSinks()[i];
+            auto        idx  = axis::findOrCreateCategory(yCategories, sink->signalQuantity(), sink->signalUnit(), sink->color());
+            if (!idx.has_value()) {
+                overflowSinkIndices.push_back(i);
+            }
+        }
+
+        expect(eq(axis::activeAxisCount(yCategories), 3UZ)) << "should fill all 3 Y-axis slots";
+        expect(eq(overflowSinkIndices.size(), 1UZ)) << "4th distinct group should overflow";
+    };
+
+    "getXRange boundaries"_test = [] {
+        auto sink = makeTestStreamingSink("range_test", 1000);
+
+        // empty sink
+        auto [emptyStart, emptyCount] = sink->getXRange(0.0, 1.0);
+        expect(eq(emptyStart, 0UZ));
+        expect(eq(emptyCount, 0UZ));
+
+        // push sorted samples
+        for (int i = 0; i < 10; ++i) {
+            sink->pushSample(static_cast<double>(i), static_cast<float>(i));
+        }
+
+        // tMin > tMax returns {0, 0}
+        auto [invStart, invCount] = sink->getXRange(5.0, 2.0);
+        expect(eq(invStart, 0UZ));
+        expect(eq(invCount, 0UZ));
+
+        // exact boundary match
+        auto [start, count] = sink->getXRange(3.0, 7.0);
+        expect(eq(start, 3UZ));
+        expect(eq(count, 5UZ)) << "should include values [3.0, 4.0, 5.0, 6.0, 7.0]";
+    };
+
+    "capacity request expiry reduces capacity"_test = [] {
+        auto sink = makeTestStreamingSink("expiry_test", 1000);
+
+        sink->requestCapacity("chart1", 3000);
+        sink->requestCapacity("chart2", 5000, std::chrono::seconds{0});
+        expect(eq(sink->bufferCapacity(), 5000UZ));
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        sink->expireCapacityRequests();
+        expect(eq(sink->bufferCapacity(), 3000UZ)) << "after expiry, should fall back to chart1's request";
+    };
+
+    return 0;
+}

--- a/src/ui/test/qa_SignalSink.cpp
+++ b/src/ui/test/qa_SignalSink.cpp
@@ -1,0 +1,215 @@
+#include "TestSinks.hpp"
+
+#include <boost/ut.hpp>
+
+#include <chrono>
+#include <cmath>
+#include <numbers>
+#include <thread>
+
+int main() {
+    using namespace boost::ut;
+    using namespace opendigitizer::charts;
+    using namespace opendigitizer::test;
+
+    "TestStreamingSink basic usage"_test = [] {
+        auto sink = std::make_shared<TestStreamingSink>("test_sink", 100);
+
+        expect(eq(sink->uniqueName(), std::string_view("test_sink")));
+        expect(eq(sink->signalName(), std::string_view("test_sink")));
+        expect(eq(sink->bufferCapacity(), 100UZ));
+        expect(eq(sink->size(), 0UZ));
+        expect(!sink->hasDataSets());
+    };
+
+    "TestStreamingSink push and retrieve data"_test = [] {
+        auto sink = std::make_shared<TestStreamingSink>("test_sink", 100);
+
+        for (std::size_t i = 0; i < 50; ++i) {
+            double x = static_cast<double>(i) * 0.01;
+            float  y = std::sin(static_cast<float>(i) * 0.1f);
+            sink->pushSample(x, y);
+        }
+
+        expect(eq(sink->size(), 50UZ));
+
+        expect(std::abs(sink->xAt(0) - 0.0) < 1e-9);
+        expect(std::abs(sink->xAt(49) - 0.49) < 1e-9);
+
+        auto pd = sink->plotData();
+        expect(!pd.empty());
+        expect(eq(pd.count, 50));
+        expect(pd.getter != nullptr);
+
+        auto point = pd.getter(0, pd.user_data);
+        expect(std::abs(point.x - 0.0) < 1e-9);
+    };
+
+    "TestStreamingSink circular buffer behavior"_test = [] {
+        auto sink = std::make_shared<TestStreamingSink>("test_sink", 50);
+
+        for (std::size_t i = 0; i < 100; ++i) {
+            double x = static_cast<double>(i);
+            float  y = static_cast<float>(i);
+            sink->pushSample(x, y);
+        }
+
+        expect(eq(sink->size(), 50UZ));
+
+        expect(std::abs(sink->xAt(0) - 50.0) < 1e-9);
+        expect(std::abs(sink->xAt(49) - 99.0) < 1e-9);
+    };
+
+    "TestStreamingSink metadata"_test = [] {
+        auto sink = std::make_shared<TestStreamingSink>("test_sink", 100);
+
+        sink->setSignalName("Voltage");
+        sink->setSampleRate(1000.0f);
+        sink->setColor(0xFF0000);
+
+        expect(eq(sink->signalName(), std::string_view("Voltage")));
+        expect(eq(sink->sampleRate(), 1000.0f));
+        expect(eq(sink->color(), 0xFF0000U));
+    };
+
+    "TestStreamingSink capacity requests"_test = [] {
+        auto sink = std::make_shared<TestStreamingSink>("test_sink", 1000);
+
+        sink->requestCapacity("chart1", 3000);
+        expect(eq(sink->bufferCapacity(), 3000UZ));
+
+        sink->requestCapacity("chart2", 5000);
+        expect(eq(sink->bufferCapacity(), 5000UZ));
+
+        sink->requestCapacity("chart3", 7000, std::chrono::seconds{0});
+        expect(eq(sink->bufferCapacity(), 7000UZ));
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        sink->expireCapacityRequests();
+        expect(eq(sink->bufferCapacity(), 5000UZ));
+    };
+
+    "TestDataSetSink basic usage"_test = [] {
+        auto sink = std::make_shared<TestDataSetSink>("dataset_sink", 5);
+
+        expect(eq(sink->uniqueName(), std::string_view("dataset_sink")));
+        expect(eq(sink->size(), 0UZ));
+        expect(!sink->hasDataSets());
+    };
+
+    "TestDataSetSink push and retrieve DataSets"_test = [] {
+        auto sink = std::make_shared<TestDataSetSink>("dataset_sink", 5);
+
+        gr::DataSet<float> ds;
+        ds.timestamp         = 1000000000; // 1 second in ns
+        ds.signal_names      = {"sig1"};
+        ds.signal_quantities = {"voltage"};
+        ds.signal_units      = {"V"};
+        ds.axis_names        = {"time"};
+        ds.axis_units        = {"s"};
+        ds.axis_values       = {{0.0f, 0.1f, 0.2f, 0.3f, 0.4f}};
+        ds.extents           = {5};
+        ds.signal_values     = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+
+        sink->pushDataSet(ds);
+
+        expect(sink->hasDataSets());
+        expect(eq(sink->dataSetCount(), 1UZ));
+        expect(eq(sink->size(), 5UZ));
+
+        expect(std::abs(sink->xAt(0) - 0.0f) < 1e-6);
+        expect(std::abs(sink->yAt(0) - 1.0f) < 1e-6);
+
+        auto pd = sink->plotData();
+        expect(!pd.empty());
+        expect(eq(pd.count, 5));
+    };
+
+    "TestDataSetSink max capacity"_test = [] {
+        auto sink = std::make_shared<TestDataSetSink>("dataset_sink", 3);
+
+        for (int i = 0; i < 5; ++i) {
+            gr::DataSet<float> ds;
+            ds.timestamp     = static_cast<int64_t>(i) * 1000000000;
+            ds.signal_names  = {"sig" + std::to_string(i)};
+            ds.signal_values = {static_cast<float>(i)};
+            sink->pushDataSet(ds);
+        }
+
+        expect(eq(sink->dataSetCount(), 3UZ));
+
+        const auto& raw = sink->rawDataSets();
+        expect(eq(raw.front().signal_names[0], std::string("sig2")));
+    };
+
+    "SinkRegistry registration"_test = [] {
+        auto& registry = SinkRegistry::instance();
+
+        auto sink1 = std::make_shared<TestStreamingSink>("registry_sink1", 100);
+        auto sink2 = std::make_shared<TestStreamingSink>("registry_sink2", 100);
+
+        std::size_t initialCount = registry.sinkCount();
+
+        registry.registerSink(sink1);
+        registry.registerSink(sink2);
+
+        expect(eq(registry.sinkCount(), initialCount + 2));
+
+        auto found = registry.getSink("registry_sink1");
+        expect(found != nullptr);
+        expect(eq(found->uniqueName(), std::string_view("registry_sink1")));
+
+        registry.unregisterSink("registry_sink1");
+        registry.unregisterSink("registry_sink2");
+
+        expect(eq(registry.sinkCount(), initialCount));
+    };
+
+    "SinkRegistry listener"_test = [] {
+        auto& registry = SinkRegistry::instance();
+
+        bool addedCalled   = false;
+        bool removedCalled = false;
+
+        void* owner = reinterpret_cast<void*>(456);
+        registry.addListener(owner, [&](SignalSink& /*sink*/, bool isAdded) {
+            if (isAdded) {
+                addedCalled = true;
+            } else {
+                removedCalled = true;
+            }
+        });
+
+        auto sink = std::make_shared<TestStreamingSink>("registry_listener_test", 100);
+        registry.registerSink(sink);
+        expect(addedCalled);
+
+        registry.unregisterSink("registry_listener_test");
+        expect(removedCalled);
+
+        registry.removeListener(owner);
+    };
+
+    "PlotData compatibility with ImPlot"_test = [] {
+        auto sink = std::make_shared<TestStreamingSink>("test_sink", 100);
+
+        for (int i = 0; i < 10; ++i) {
+            sink->pushSample(static_cast<double>(i), static_cast<float>(i * 2));
+        }
+
+        auto pd = sink->plotData();
+
+        expect(eq(pd.count, 10));
+        expect(pd.getter != nullptr);
+
+        auto p0 = pd.getter(0, pd.user_data);
+        expect(std::abs(p0.x - 0.0) < 1e-9);
+        expect(std::abs(p0.y - 0.0) < 1e-9);
+
+        auto p5 = pd.getter(5, pd.user_data);
+        expect(std::abs(p5.x - 5.0) < 1e-9);
+        expect(std::abs(p5.y - 10.0) < 1e-9);
+    };
+
+    return 0;
+}

--- a/src/ui/test/qa_layout.cpp
+++ b/src/ui/test/qa_layout.cpp
@@ -53,7 +53,7 @@ struct TestApp : public DigitizerUi::test::ImGuiTestApp {
                 page.setDashboard(*g_state->dashboard);
                 page.setLayoutType(vars.layoutType);
                 page.draw();
-                ut::expect(!g_state->dashboard->plots().empty()) << ut::fatal;
+                ut::expect(!g_state->dashboard->uiWindows.empty()) << ut::fatal;
             }
         };
 
@@ -103,9 +103,7 @@ int main(int argc, char* argv[]) {
     auto dashBoardDescription = DigitizerUi::DashboardDescription::createEmpty("empty");
     g_state->dashboard        = DigitizerUi::Dashboard::create(restClient, dashBoardDescription);
     g_state->dashboard->loadAndThen(std::string(grcFile.begin(), grcFile.end()), [&](gr::Graph&& graph) { //
-        using TScheduler = gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::multiThreaded>;
-        g_state->dashboard->emplaceScheduler<TScheduler>();
-        g_state->dashboard->scheduler()->setGraph(std::move(graph));
+        g_state->dashboard->emplaceGraph(std::move(graph));
     });
 
     auto result = app.runTests();

--- a/src/utils/include/settings.hpp
+++ b/src/utils/include/settings.hpp
@@ -166,7 +166,7 @@ public:
         std::string fallback;
         for (std::string_view bindAddress : bindAddresses) {
             if (bindAddress.starts_with("https://")) {
-                const auto bindUri = opencmw::URI<>(std::string(std::string(bindAddress)));
+                const auto bindUri = opencmw::URI<>(std::string(bindAddress));
                 // we need to set the full authority here, if we only set the port, the constructed url will have the authority of bindUrl and the port will be ignored
                 return opencmw::URI<>::UriFactory(bindUri).authority(std::format("{}:{}", hostname, bindUri.port().value_or(443)));
             }
@@ -185,7 +185,7 @@ public:
         using std::operator""s;
         for (std::string_view bindAddress : bindAddresses) {
             if (bindAddress.starts_with("http://")) {
-                const auto bindUri = opencmw::URI<>(std::string(std::string(bindAddress)));
+                const auto bindUri = opencmw::URI<>(std::string(bindAddress));
                 return opencmw::URI<>::UriFactory(bindUri).authority(std::format("{}:{}", hostname, bindUri.port().value_or(80)));
             }
         }


### PR DESCRIPTION
Refactors the OpenDigitizer chart/plotting system so that **charts are self-contained GR4 blocks** that own their rendering, signal management, drag-and-drop, and context menus. Closes #250, aligned with GR4 PR [#697](https://github.com/fair-acc/gnuradio4/pull/697).

**Before:** `DashboardPage` contained ~850 lines of rendering code, axis management, and signal routing. Adding a chart type required editing Dashboard, DashboardPage, and several helper functions.

**After:** `DashboardPage::drawPlots()` is a loop over `uiGraph.blocks()` calling `block->draw(config)`. New chart types need only inherit `gr::Block<T, Drawable<ChartPane>>` + `Chart` mixin (optional helper).

## Architecture

```text
┌─ Dashboard ──────────────────────────────────────┐
│  _uiGraph (gr::Graph)                            │
│  ├── XYChart       ─┐                            │
│  ├── YYChart        ├─ UICategory::ChartPane     │
│  └── GlobalSignal  ─── UICategory::Toolbar       │
│       Legend                                      │
│                                                   │
│  _uiWindows[] ── layout position/size per block   │
└──────────────────────────────────────────────────┘

DashboardPage::draw()
├── drawPlots()        → block->draw(config) for ChartPane
└── drawGlobalLegend() → block->draw(config) for Toolbar
```
*N.B. the `YYChart` implements a correlation-type plot to test/demonstrate the composability of different UI elements using GR4 blocks.*

<img width="1278" height="741" alt="image" src="https://github.com/user-attachments/assets/9452fad1-edef-4fbf-bf6b-f07c72c42f84" />



## Key types

### `SignalSink` — thread-safe data access interface
```cpp
struct SignalSink {
    virtual DataGuard dataGuard() const = 0;  // RAII lock
    virtual PlotData  plotData() const = 0;   // ImPlot-compatible getter
    virtual void      pruneTags(double minX) = 0;
    // + name, color, sampleRate, lineStyle, lineWidth, range queries
};

SinkAdapter<T> — bridges gr::BlockLike sinks to SignalSink

template<gr::BlockLike T>
struct SinkAdapter : SignalSink { std::shared_ptr<T> _block; ... };

Chart — CRTP mixin with C++23 deducing this

struct Chart {
    template<typename Self>
    void addSignalSink(this Self& self, std::shared_ptr<SignalSink> sink);
    // D&D helpers, context menu, history depth widget, sink sync
};

struct XYChart : gr::Block<XYChart, BlockingIO<false>,
                           Drawable<ChartPane, "ImGui">>, Chart {
    A<std::vector<std::string>, "data sinks"> data_sinks;
    gr::work::Status draw(const gr::property_map& config = {});
};

SinkRegistry — global thread-safe sink lookup

SinkRegistry::instance().add("name", sink);
auto sink = SinkRegistry::instance().find("name");
```

## What changed

```text
┌────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────┐
│        Area        │                                             Change                                              │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Chart blocks       │ New XYChart, YYChart as gr::Block + Chart mixin with draw(), context menus, D&D, axis config    │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
│ SignalSink         │ New abstract interface with DataGuard RAII locking, PlotData getter, range queries, tag pruning │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
│ SinkRegistry       │ New global registry with listener support                                                       │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ImPlotSink         │ Refactored: processBulk + std::mutex replaces processOne + atomic_flag; removed BlockingIO      │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
│ GlobalSignalLegend │ New Drawable<Toolbar> block in _uiGraph (replaces standalone component)                         │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Dashboard          │ Layout-only: emplaceChartBlock(), UIWindow, transmuteUIWindow(), copyChart(), deleteChart()     │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
│ DashboardPage      │ Reduced from ~850 to ~250 lines; renders by iterating _uiGraph blocks                           │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
│ D&D                │ Simplified: DndState struct replaces callback, source chart self-cleans                         │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Context menu       │ 7-item menu with Font Awesome icons, axis spinners, history depth widget                        │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Chart registration │ Via gr::registerBlock<T>(globalBlockRegistry()) — no factory functions                          │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
│ GLSL shader        │ Custom vertex shader pipeline for prototype-mode rendering (see below)                          │
├────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Naming             │ m_ → _lowerCamelCase in Dashboard/DashboardPage per CLAUDE.md §1.3                              │
└────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────┘
```

### GLSL vertex shader pipeline

Added a custom vertex shader into the ImGui/ImPlot rendering pipeline via ImDrawList callbacks. 
 - Desktop: GL 3.3+ with #version 330 core
 - WebGL: GLES 3.0 with #version 300 es
 - Gated behind LookAndFeel::prototypeMode toggle
 
## CLAUDE.md style guide and slash commands

Added `CLAUDE.md` — a self-contained code and work-in-progress documentation style guide for GNU Radio 4.0 and downstream projects, covering naming conventions, struct layout, documentation policy, complexity reduction, C++23 expectations, GR4-specific patterns, testing conventions, and AI anti-patterns.

Think of these commands as a design and code review assistant — the same way a spell-checker catches typos you'd otherwise miss on the fifth read-through, the `const` linter flags, or duplicate/dead/overly-complex code you forgot at 2 o'clock. They don't replace your judgement; they free you up to focus on the actual problem domain instead of mentally tracking whether every field follows `snake_case` or checking if you accidentally left Doxygen boilerplate in a new block. To note: any AI-agent-driven design/implementation requires strong constraints, domain-knowledge, a good pre-design phase, strong unit-tests, and -- this is my recommendation -- a WIP/ToDo list so that the AI doesn't go haywire or start hallucinating.

The review commands give you a second pair of eyes before you ping a colleague. The fix commands handle the mechanical cleanup so you can spend your time on architecture decisions, not reformatting.
**All findings still must go through human review** — these tools just raise the baseline.

Please try them out and feel free to provide some feedback on the matrix.io channel.

### Review commands (read-only analysis):

```text
┌─────────────────────┬─────────────────────────────────────────────────────┐
│       Command       │                        Focus                        │
├─────────────────────┼─────────────────────────────────────────────────────┤
│ /review-correctness │ Logic bugs, UB, off-by-one, race conditions         │
├─────────────────────┼─────────────────────────────────────────────────────┤
│ /review-perf        │ Hot-path allocations, SIMD, cache patterns          │
├─────────────────────┼─────────────────────────────────────────────────────┤
│ /review-api         │ CRTP, concepts, type safety, GR4 idiom consistency  │
├─────────────────────┼─────────────────────────────────────────────────────┤
│ /review-simplify    │ Terseness, STL algorithms, dead abstraction removal │
├─────────────────────┼─────────────────────────────────────────────────────┤
│ /review-safety      │ Memory safety, thread safety, real-time constraints │
├─────────────────────┼─────────────────────────────────────────────────────┤
│ /review-tests       │ Missing qa_ files, untested paths, edge case gaps   │
├─────────────────────┼─────────────────────────────────────────────────────┤
│ /review-pr          │ Aggregated summary across all review perspectives   │
└─────────────────────┴─────────────────────────────────────────────────────┘
```

### Fix commands (edit files directly):
```text
┌────────────┬────────────────────────────────────────────────────────────────────┐
│  Command   │                               Scope                                │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ /fix-style │ Naming, documentation cleanup, wrong abstraction flags             │
├────────────┼────────────────────────────────────────────────────────────────────┤
│ /refactor  │ Member reordering, simplification (ranges, early returns, lambdas) │
└────────────┴────────────────────────────────────────────────────────────────────┘
```
All commands default to uncommitted changes and accept an optional git range argument (e.g., `/review-pr main..HEAD`).

### Backward compatibility

- `.grc format`: sources: key auto-migrated to data_sinks property (transition code in grc_compat namespace, removable later)
- `IOCategory::ChartPane` kept until GR4 renames this to `Content`

Test plan

- qa_SignalSink — DataGuard locking, history expiration, range queries (11 tests, 46 asserts)
- qa_ChartAbstraction — chart creation via registry, sink management, D&D state, transmutation (20 tests, 74 asserts)
- Manual: drag signals between charts, context menu axis limits, chart type transmutation
- Manual: load existing .grc dashboards (backward compat)
- WASM build: verify WebGL2 shader path