### PR TITLE
add spectrum visualisation suite: SpectrumPlot, SpectrumDensity, Wate…

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -34,7 +34,7 @@ if(EMSCRIPTEN)
     -pthread)
   add_link_options(
     "SHELL:-s WASM=1"
-    "SHELL:-sFULL_ES2=1"
+    "SHELL:-sFULL_ES3=1"
     "SHELL:-sMAX_WEBGL_VERSION=2"
     "SHELL:-sMIN_WEBGL_VERSION=2"
     "SHELL:-s ALLOW_MEMORY_GROWTH=1"
@@ -197,6 +197,9 @@ else()
 endif()
 target_compile_options(${target_name}lib PUBLIC "-Wfatal-errors")
 target_compile_definitions(${target_name}lib PUBLIC IMGUI_DEFINE_MATH_OPERATORS)
+if(NOT EMSCRIPTEN)
+  target_compile_definitions(${target_name}lib PUBLIC GL_GLEXT_PROTOTYPES)
+endif()
 target_link_libraries(${target_name} PRIVATE ${target_name}lib)
 
 if(OPENDIGITIZER_ENABLE_TESTING)

--- a/src/ui/assets/sampleDashboards/DemoDashboard.grc
+++ b/src/ui/assets/sampleDashboards/DemoDashboard.grc
@@ -189,6 +189,33 @@ blocks:
       signal_name: sine 5Hz
       signal_quantity: voltage
       signal_unit: V
+  - id: gr::basic::ClockSource
+    parameters:
+      name: SpectrumClock
+      sample_rate: 25
+      chunk_size: 1
+      n_samples_max: 0
+  - id: opendigitizer::TestSpectrumGenerator<float32>
+    parameters:
+      name: SpectrumGenerator
+      spectrum_size: 4096
+      center_freq: 100e6
+      signal_bandwidth: 1e6
+      clock_rate: 25
+      seed: 42
+      show_schottky: true
+      show_interference_lines: true
+      show_sweep_line: true
+      log_interval: 0
+  - id: opendigitizer::ImPlotSink<gr::DataSet<float32>>
+    parameters:
+      name: spectrumSink
+      dataset_index: 0
+      signal_name: spectrum
+      abscissa_quantity: frequency
+      abscissa_unit: Hz
+      signal_quantity: magnitude
+      signal_unit: dB
 connections:
   - [sine source 1, 0, sum sigs, 0]
   - [sine source 3, 0, sum sigs, 1]
@@ -201,6 +228,8 @@ connections:
   - [DipoleCurrentGenerator, 0, DipoleCurrentSink, 0]
   - [ClockSource, 0, IntensityGenerator, 0]
   - [IntensityGenerator, 0, IntensitySink, 0]
+  - [SpectrumClock, 0, SpectrumGenerator, 0]
+  - [SpectrumGenerator, 0, spectrumSink, 0]
 dashboard:
   layout: Free
   sources:
@@ -218,6 +247,8 @@ dashboard:
       block: sineSink1
     - name: sineSink3
       block: sineSink3
+    - name: spectrumSink
+      block: spectrumSink
   plots:
     - name: Raw Signal
       parameters:
@@ -279,4 +310,28 @@ dashboard:
       sources:
         - IntensitySink
         - DipoleCurrentSink
-      rect: [ 0, 1, 3, 1 ] # x, y, width, height - spans all 3 columns
+      rect: [ 0, 1, 3, 1 ] # x, y, width, height - spans 3 columns
+    - name: Spectrum View
+      type: opendigitizer::charts::SpectrumView
+      parameters:
+        show_max_hold: true
+        show_min_hold: true
+        show_average: true
+        decay_tau_frames: 120
+        n_history: 256
+        colormap: ImPlotColormap_Viridis
+        top_pane_ratio: 0.4
+      axes:
+        - axis: X
+          min: NaN
+          max: NaN
+          format: MetricInline
+        - axis: Y
+          min: NaN
+          max: NaN
+        - axis: Z
+          min: -85
+          max: -55
+      sources:
+        - spectrumSink
+      rect: [ 3, 0, 2, 2 ] # 2 columns wide, spans 2 rows

--- a/src/ui/blocks/TestSpectrumGenerator.hpp
+++ b/src/ui/blocks/TestSpectrumGenerator.hpp
@@ -1,0 +1,266 @@
+#ifndef OPENDIGITIZER_TESTSPECTRUMGENERATOR_HPP
+#define OPENDIGITIZER_TESTSPECTRUMGENERATOR_HPP
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/DataSet.hpp>
+
+#include "../../utils/include/Xoshiro256pp.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <numbers>
+#include <print>
+#include <string>
+#include <vector>
+
+namespace opendigitizer {
+
+GR_REGISTER_BLOCK("opendigitizer::TestSpectrumGenerator", opendigitizer::TestSpectrumGenerator, [ float, double ]);
+
+template<typename T>
+requires std::floating_point<T>
+struct TestSpectrumGenerator : gr::Block<TestSpectrumGenerator<T>, gr::Resampling<1LU, 1LU>> {
+    using Description = gr::Doc<"Procedural beam-spectrum generator for UI testing. Driven by an upstream ClockSource.">;
+
+    gr::PortIn<std::uint8_t>    in;
+    gr::PortOut<gr::DataSet<T>> out;
+
+    // spectrum configuration
+    gr::Annotated<gr::Size_t, "spectrum size", gr::Doc<"number of frequency bins">, gr::Visible>                 spectrum_size    = 4096U;
+    gr::Annotated<T, "center frequency", gr::Unit<"Hz">>                                                         center_freq      = T(100e6);
+    gr::Annotated<T, "signal bandwidth", gr::Unit<"Hz">, gr::Doc<"total bandwidth of the generated spectrum">>   signal_bandwidth = T(1e6);
+    gr::Annotated<T, "clock rate", gr::Unit<"Hz">, gr::Doc<"rate of incoming clock ticks for time computation">> clock_rate       = T(25);
+    gr::Annotated<std::uint64_t, "seed", gr::Doc<"RNG seed for reproducibility">>                                seed             = 42ULL;
+
+    // cycle timing
+    gr::Annotated<T, "active duration", gr::Unit<"s">, gr::Doc<"active phase duration">>    active_duration = T(10);
+    gr::Annotated<T, "pause duration", gr::Unit<"s">, gr::Doc<"noise-only pause duration">> pause_duration  = T(1);
+
+    // noise floor
+    gr::Annotated<T, "noise floor", gr::Unit<"dB">, gr::Doc<"mean noise floor level">>         noise_floor_db  = T(-80);
+    gr::Annotated<T, "noise spread", gr::Unit<"dB">, gr::Doc<"Gaussian sigma of noise floor">> noise_spread_db = T(0.2);
+
+    // Schottky peak
+    gr::Annotated<bool, "show Schottky peak", gr::Visible>                                                   show_schottky       = true;
+    gr::Annotated<T, "initial peak above floor", gr::Unit<"dB">>                                             initial_peak_db     = T(6);
+    gr::Annotated<T, "initial sigma", gr::Doc<"initial peak width as fraction of spectrum">>                 initial_sigma       = T(0.1);
+    gr::Annotated<T, "width ratio", gr::Doc<"ratio of initial to final peak width (narrowing factor)">>      width_ratio         = T(10);
+    gr::Annotated<T, "freq shift fraction", gr::Doc<"upward frequency shift as fraction of spectrum width">> freq_shift_fraction = T(0.05);
+    gr::Annotated<T, "freq shift tau", gr::Unit<"s">, gr::Doc<"exponential approach time constant">>         freq_shift_tau      = T(0.33);
+
+    // sweep line
+    gr::Annotated<bool, "show sweep line", gr::Visible>                                                show_sweep_line = true;
+    gr::Annotated<T, "sweep start", gr::Doc<"sweep start position as fraction of spectrum [0,1]">>     sweep_start     = T(0.05);
+    gr::Annotated<T, "sweep stop", gr::Doc<"sweep stop position as fraction of spectrum [0,1]">>       sweep_stop      = T(0.3);
+    gr::Annotated<T, "sweep period", gr::Unit<"s">, gr::Doc<"time for one full back-and-forth cycle">> sweep_period    = T(4.0);
+
+    // interference lines
+    gr::Annotated<bool, "show interference lines", gr::Visible>                                                                                 show_interference_lines = true;
+    gr::Annotated<T, "line amplitude above floor", gr::Unit<"dB">>                                                                              line_amplitude_db       = T(12);
+    gr::Annotated<T, "line sigma", gr::Doc<"interference line width as fraction of spectrum">>                                                  line_sigma              = T(0.005);
+    gr::Annotated<std::string, "morse pattern", gr::Visible, gr::Doc<"dots/dashes/spaces for third line keying (e.g. '.... . .-.. .-.. ---')">> morse_pattern           = ".... . .-.. .-.. --- ..-. .- .. .-. -.-.--";
+    gr::Annotated<T, "morse unit duration", gr::Unit<"s">, gr::Doc<"time unit for morse keying on third line">>                                 morse_unit_duration     = T(0.2);
+
+    // debug
+    gr::Annotated<gr::Size_t, "log interval", gr::Doc<"print debug info every N clock ticks (0 = off)">> log_interval = 0U;
+
+    GR_MAKE_REFLECTABLE(TestSpectrumGenerator, in, out, spectrum_size, center_freq, signal_bandwidth, clock_rate, seed, active_duration, pause_duration, noise_floor_db, noise_spread_db, show_schottky, initial_peak_db, initial_sigma, width_ratio, freq_shift_fraction, freq_shift_tau, show_sweep_line, sweep_start, sweep_stop, sweep_period, show_interference_lines, line_amplitude_db, line_sigma, morse_pattern, morse_unit_duration, log_interval);
+
+    Xoshiro256pp              _rng{seed};
+    std::size_t               _sampleCount = 0;
+    std::vector<std::uint8_t> _morseKey;
+
+    static constexpr double                kDbPerNeper    = 10.0 / std::numbers::ln10; // ~4.343
+    static constexpr std::array<double, 3> kLinePositions = {0.12, 0.25, 0.85};
+
+    void start() {
+        _rng         = Xoshiro256pp(seed);
+        _sampleCount = 0;
+        rebuildMorseKey();
+    }
+
+    void reset() {
+        _rng         = Xoshiro256pp(seed);
+        _sampleCount = 0;
+        rebuildMorseKey();
+    }
+
+    void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) {
+        if (newSettings.contains("seed")) {
+            _rng = Xoshiro256pp(seed);
+        }
+        if (newSettings.contains("morse_pattern")) {
+            rebuildMorseKey();
+        }
+    }
+
+    [[nodiscard]] gr::work::Status processBulk(std::span<const std::uint8_t> input, std::span<gr::DataSet<T>> output) {
+        for (std::size_t i = 0; i < input.size(); ++i) {
+            output[i] = createSpectrum(static_cast<std::size_t>(spectrum_size));
+            ++_sampleCount;
+
+            if (log_interval > 0U && _sampleCount % static_cast<std::size_t>(log_interval) == 0) {
+                const double elapsed  = static_cast<double>(_sampleCount) / static_cast<double>(clock_rate);
+                const double cycleDur = static_cast<double>(active_duration) + static_cast<double>(pause_duration);
+                const double cycTime  = std::fmod(elapsed, cycleDur);
+                std::println(stderr, "[TestSpectrumGenerator] input={} sample={} elapsed={:.2f}s cycleTime={:.2f}s active={} batchSize={}", input.size(), _sampleCount, elapsed, cycTime, cycTime < static_cast<double>(active_duration), output.size());
+            }
+        }
+        return gr::work::Status::OK;
+    }
+
+    [[nodiscard]] gr::DataSet<T> createSpectrum(std::size_t N) {
+        gr::DataSet<T> ds{};
+        ds.timestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+
+        const auto   fMin = static_cast<double>(center_freq) - static_cast<double>(signal_bandwidth) * 0.5;
+        const auto   fMax = static_cast<double>(center_freq) + static_cast<double>(signal_bandwidth) * 0.5;
+        const double df   = (fMax - fMin) / static_cast<double>(N);
+
+        ds.axis_names = {"Frequency"};
+        ds.axis_units = {"Hz"};
+        ds.axis_values.resize(1);
+        ds.axis_values[0].resize(N);
+        for (std::size_t i = 0; i < N; ++i) {
+            ds.axis_values[0][i] = static_cast<T>(fMin + static_cast<double>(i) * df);
+        }
+
+        ds.extents = {static_cast<std::int32_t>(N)};
+        ds.layout  = gr::LayoutRight{};
+
+        constexpr std::size_t nSignals = 1;
+        ds.signal_names                = {"Magnitude"};
+        ds.signal_quantities           = {"magnitude"};
+        ds.signal_units                = {"dB"};
+        ds.signal_values.resize(nSignals * N);
+        ds.signal_ranges.resize(nSignals);
+
+        auto magnitudes = ds.signalValues(0);
+        generateSpectrum(magnitudes, N);
+
+        const auto [minIt, maxIt] = std::minmax_element(magnitudes.begin(), magnitudes.end());
+        ds.signal_ranges[0]       = {*minIt, *maxIt};
+
+        ds.meta_information.resize(nSignals);
+        ds.meta_information[0] = {
+            {"sample_rate", static_cast<float>(signal_bandwidth)},
+            {"center_frequency", static_cast<float>(center_freq)},
+            {"output_in_db", true},
+            {"clock_rate", static_cast<float>(clock_rate)},
+        };
+        ds.timing_events.resize(nSignals);
+        return ds;
+    }
+
+    void generateSpectrum(std::span<T> bins, std::size_t N) {
+        const double cycleDur  = static_cast<double>(active_duration) + static_cast<double>(pause_duration);
+        const double elapsed   = static_cast<double>(_sampleCount) / static_cast<double>(clock_rate);
+        const double cycleTime = std::fmod(elapsed, cycleDur);
+        const bool   active    = cycleTime < static_cast<double>(active_duration);
+
+        const auto noiseFloor  = static_cast<double>(noise_floor_db);
+        const auto noiseSpread = static_cast<double>(noise_spread_db);
+
+        for (std::size_t i = 0; i < N; ++i) {
+            bins[i] = static_cast<T>(noiseFloor + _rng.triangularM11() * noiseSpread);
+        }
+
+        if (active && show_schottky) {
+            addSchottkyPeak(bins, N, cycleTime);
+        }
+
+        if (show_interference_lines) {
+            const double lineAmp = noiseFloor + static_cast<double>(line_amplitude_db);
+            for (std::size_t j = 0; j < kLinePositions.size(); ++j) {
+                if (j == 2 && !isMorseKeyOn(elapsed)) {
+                    continue; // third line: morse-code keyed
+                }
+                addNarrowLine(bins, N, kLinePositions[j], lineAmp);
+            }
+        }
+
+        if (show_sweep_line && active) {
+            const double period   = std::max(static_cast<double>(sweep_period), 0.01);
+            const double phase    = std::fmod(cycleTime / period, 1.0);
+            const double triangle = 1.0 - std::abs(2.0 * phase - 1.0); // 0→1→0 back-and-forth
+            const auto   lo       = static_cast<double>(sweep_start);
+            const auto   hi       = static_cast<double>(sweep_stop);
+            const double sweepPos = lo + triangle * (hi - lo);
+            addNarrowLine(bins, N, sweepPos, noiseFloor + static_cast<double>(line_amplitude_db) + 3.0);
+        }
+    }
+
+    void addSchottkyPeak(std::span<T> bins, std::size_t N, double t) {
+        const double sigmaRel      = static_cast<double>(initial_sigma) * std::pow(static_cast<double>(width_ratio), -t / static_cast<double>(active_duration));
+        const double sigma         = sigmaRel * static_cast<double>(N);
+        const double invTwoSigmaSq = 1.0 / (2.0 * sigma * sigma);
+
+        const double peakDb = static_cast<double>(noise_floor_db) + static_cast<double>(initial_peak_db) + t;
+
+        const double shift     = static_cast<double>(freq_shift_fraction) * (1.0 - std::exp(-t / static_cast<double>(freq_shift_tau)));
+        const double centerBin = (0.5 + shift) * static_cast<double>(N);
+
+        for (std::size_t i = 0; i < N; ++i) {
+            const double dist     = static_cast<double>(i) - centerBin;
+            const double signalDb = peakDb - dist * dist * invTwoSigmaSq * kDbPerNeper;
+            bins[i]               = static_cast<T>(std::max(static_cast<double>(bins[i]), signalDb));
+        }
+    }
+
+    // convert morse notation string to binary time-unit array
+    // '.' = 1 ON + 1 OFF, '-' = 3 ON + 1 OFF, ' ' = 2 extra OFF (total 3), end = 6 extra OFF (word gap)
+    void rebuildMorseKey() {
+        _morseKey.clear();
+        const auto& pat = morse_pattern.value;
+        for (std::size_t i = 0; i < pat.size(); ++i) {
+            const char c = pat[i];
+            if (c == '.') {
+                _morseKey.push_back(1);
+                _morseKey.push_back(0);
+            } else if (c == '-') {
+                _morseKey.insert(_morseKey.end(), 3, 1);
+                _morseKey.push_back(0);
+            } else if (c == ' ') {
+                _morseKey.insert(_morseKey.end(), 2, 0); // 1 already from previous element + 2 = 3 total
+            }
+        }
+        if (_morseKey.empty()) {
+            _morseKey.push_back(1); // fallback: always on
+        } else {
+            // word gap at end before repeat (7 units total, 1 already from last element)
+            _morseKey.insert(_morseKey.end(), 6, 0);
+        }
+    }
+
+    [[nodiscard]] bool isMorseKeyOn(double elapsedSeconds) const {
+        if (_morseKey.empty()) {
+            return true;
+        }
+        const double unitDur    = std::max(static_cast<double>(morse_unit_duration), 0.01);
+        const double patternDur = static_cast<double>(_morseKey.size()) * unitDur;
+        const double t          = std::fmod(elapsedSeconds, patternDur);
+        const auto   idx        = static_cast<std::size_t>(t / unitDur) % _morseKey.size();
+        return _morseKey[idx] != 0;
+    }
+
+    void addNarrowLine(std::span<T> bins, std::size_t N, double position, double amplitudeDb) {
+        const double sigma         = static_cast<double>(line_sigma) * static_cast<double>(N);
+        const double centerBin     = position * static_cast<double>(N);
+        const double invTwoSigmaSq = 1.0 / (2.0 * sigma * sigma);
+        const auto   iMin          = static_cast<std::size_t>(std::max(0.0, centerBin - 5.0 * sigma));
+        const auto   iMax          = std::min(N, static_cast<std::size_t>(centerBin + 5.0 * sigma + 1.0));
+
+        for (std::size_t i = iMin; i < iMax; ++i) {
+            const double dist     = static_cast<double>(i) - centerBin;
+            const double signalDb = amplitudeDb - dist * dist * invTwoSigmaSq * kDbPerNeper;
+            bins[i]               = static_cast<T>(std::max(static_cast<double>(bins[i]), signalDb));
+        }
+    }
+};
+
+} // namespace opendigitizer
+
+inline auto registerTestSpectrumGenerator = gr::registerBlock<opendigitizer::TestSpectrumGenerator, float, double>(gr::globalBlockRegistry());
+
+#endif // OPENDIGITIZER_TESTSPECTRUMGENERATOR_HPP

--- a/src/ui/charts/Charts.hpp
+++ b/src/ui/charts/Charts.hpp
@@ -5,6 +5,10 @@
 
 #include "Chart.hpp"
 #include "SignalSink.hpp"
+#include "SpectrumDensity.hpp"
+#include "SpectrumPlot.hpp"
+#include "SpectrumView.hpp"
+#include "WaterfallPlot.hpp"
 #include "XYChart.hpp"
 #include "YYChart.hpp"
 

--- a/src/ui/charts/SignalSink.hpp
+++ b/src/ui/charts/SignalSink.hpp
@@ -162,9 +162,10 @@ struct SignalSink {
     };
 
     struct YRangeResult {
-        std::span<const float> data;         // Y values in the requested range
-        double                 actual_t_min; // actual start time of returned data
-        double                 actual_t_max; // actual end time of returned data
+        std::span<const float>                    data;         // Y values in the requested range
+        double                                    actual_t_min; // actual start time of returned data
+        double                                    actual_t_max; // actual end time of returned data
+        std::shared_ptr<const std::vector<float>> _storage;     // keeps converted data alive when T != float
 
         [[nodiscard]] bool empty() const noexcept { return data.empty(); }
     };

--- a/src/ui/charts/SpectrumDensity.hpp
+++ b/src/ui/charts/SpectrumDensity.hpp
@@ -1,0 +1,224 @@
+#ifndef OPENDIGITIZER_CHARTS_SPECTRUMDENSITY_HPP
+#define OPENDIGITIZER_CHARTS_SPECTRUMDENSITY_HPP
+
+#include "Chart.hpp"
+#include "SignalSink.hpp"
+#include "SpectrumHelper.hpp"
+
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
+
+#include "../common/LookAndFeel.hpp"
+#include "../common/TouchHandler.hpp"
+#include <imgui.h>
+#include <implot.h>
+
+namespace opendigitizer::charts {
+
+struct SpectrumDensity : gr::Block<SpectrumDensity, gr::BlockingIO<false>, gr::Drawable<gr::UICategory::ChartPane, "ImGui">>, Chart {
+    using Description = gr::Doc<"2D persistence display showing spectrum amplitude density over time.">;
+
+    template<typename T, gr::meta::fixed_string description = "", typename... Arguments>
+    using A = gr::Annotated<T, description, Arguments...>;
+
+    // identity
+    A<std::string, "chart name", gr::Visible>              chart_name;
+    A<std::string, "chart title">                          chart_title;
+    A<std::vector<std::string>, "data sinks", gr::Visible> data_sinks  = {};
+    A<bool, "show legend", gr::Visible>                    show_legend = false;
+    A<bool, "show grid", gr::Visible>                      show_grid   = true;
+
+    // density histogram
+    A<gr::Size_t, "amplitude bins", gr::Visible, gr::Limits<4U, 1024U>>                       amplitude_bins             = 256U;
+    A<ImPlotColormap_, "colormap", gr::Visible>                                               colormap                   = ImPlotColormap_Viridis;
+    A<gr::Size_t, "histogram decay tau", gr::Doc<"histogram decay in frames (0 = infinite)">> histogram_decay_tau_frames = 100U;
+
+    // trace overlays
+    A<bool, "show current overlay", gr::Visible>                                                     show_current_overlay   = true;
+    A<bool, "show max hold", gr::Visible>                                                            show_max_hold          = false;
+    A<bool, "show min hold", gr::Visible>                                                            show_min_hold          = false;
+    A<bool, "show average", gr::Visible>                                                             show_average           = false;
+    A<std::uint32_t, "trace color", gr::Visible, gr::Doc<"RGB colour for overlay lines (0xRRGGBB)">> trace_color            = 0xFF8C00U;
+    A<gr::Size_t, "trace decay tau", gr::Doc<"trace decay in frames (0 = infinite hold)">>           trace_decay_tau_frames = 25U;
+
+    A<bool, "GPU acceleration", gr::Doc<"use GPU shaders for histogram (falls back to CPU if unavailable)">> gpu_acceleration = true;
+    A<bool, "adaptive Y range", gr::Visible, gr::Doc<"rebin histogram to visible Y-axis range on zoom">>     adaptive_y_range = true;
+
+    // axis limits
+    A<bool, "X auto-scale"> x_auto_scale = true;
+    A<bool, "Y auto-scale"> y_auto_scale = false;
+    A<double, "X-axis min"> x_min        = std::numeric_limits<double>::lowest();
+    A<double, "X-axis max"> x_max        = std::numeric_limits<double>::max();
+    A<double, "Y-axis min"> y_min        = -120.0;
+    A<double, "Y-axis max"> y_max        = 0.0;
+
+    GR_MAKE_REFLECTABLE(SpectrumDensity, chart_name, chart_title, data_sinks, show_legend, show_grid, amplitude_bins, colormap, histogram_decay_tau_frames, gpu_acceleration, adaptive_y_range, show_current_overlay, show_max_hold, show_min_hold, show_average, trace_color, trace_decay_tau_frames, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max);
+
+    DensityHistogram _density;
+    TraceAccumulator _traces;
+    double           _lastSetYMin         = std::numeric_limits<double>::quiet_NaN();
+    double           _lastSetYMax         = std::numeric_limits<double>::quiet_NaN();
+    bool             _yLimitsForceApplied = false;
+
+    static constexpr std::string_view kChartTypeName = "SpectrumDensity";
+
+    [[nodiscard]] static constexpr std::string_view chartTypeName() noexcept { return kChartTypeName; }
+    [[nodiscard]] std::string_view                  uniqueId() const noexcept { return this->unique_name; }
+
+    void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) { handleSettingsChanged(newSettings); }
+
+    gr::work::Status draw(const gr::property_map& config = {}) {
+        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, layoutMode, showGrid] = prepareDrawPrologue(config);
+
+        if (_signalSinks.empty()) {
+            drawEmptyPlot("No signals", plotFlags, plotSize);
+            return gr::work::Status::OK;
+        }
+
+        ImPlot::PushStyleColor(ImPlotCol_AxisGrid, contrastingGridColor(colormap.value));
+
+        if (!DigitizerUi::TouchHandler<>::BeginZoomablePlot(chart_name.value, plotSize, plotFlags)) {
+            ImPlot::PopStyleColor();
+            return gr::work::Status::OK;
+        }
+
+        setupAxes(showGrid);
+        ImPlot::SetupFinish();
+
+        // detect user zoom on Y-axis: if auto-fit is active and the actual plot limits
+        // differ from what we programmatically set, the user zoomed → disable auto-fit
+        if (y_auto_scale.value && !_yLimitsForceApplied) {
+            auto         plotLimits = ImPlot::GetPlotLimits();
+            const double range      = std::abs(_lastSetYMax - _lastSetYMin);
+            const double tol        = std::max(range * 1e-3, 1e-10);
+            if (std::abs(plotLimits.Y.Min - _lastSetYMin) > tol || std::abs(plotLimits.Y.Max - _lastSetYMax) > tol) {
+                y_auto_scale = false;
+                y_min        = plotLimits.Y.Min;
+                y_max        = plotLimits.Y.Max;
+                _lastSetYMin = plotLimits.Y.Min;
+                _lastSetYMax = plotLimits.Y.Max;
+            }
+        }
+
+        // register legend entries for each sink (enables legend display and D&D)
+        for (const auto& sink : _signalSinks) {
+            ImVec4 color = sinkColor(sink->color());
+            ImPlot::SetNextLineStyle(color);
+            ImPlot::PlotDummy(std::string(sink->signalName()).c_str());
+        }
+
+        drawDensitySignals();
+        tooltip::showPlotMouseTooltip();
+        handleCommonInteractions();
+        DigitizerUi::TouchHandler<>::EndZoomablePlot();
+        ImPlot::PopStyleColor();
+
+        return gr::work::Status::OK;
+    }
+
+    void reset() {
+        _density.reset();
+        _traces.reset();
+    }
+
+    // effective Y-range considering dashboard config override (always finite, needed for histogram binning)
+    [[nodiscard]] std::pair<double, double> effectiveYRange() const {
+        double yMin = y_min.value;
+        double yMax = y_max.value;
+        if (auto dashCfg = parseAxisConfig(this->ui_constraints.value, false)) {
+            if (std::isfinite(dashCfg->min)) {
+                yMin = static_cast<double>(dashCfg->min);
+            }
+            if (std::isfinite(dashCfg->max)) {
+                yMax = static_cast<double>(dashCfg->max);
+            }
+        }
+        return {yMin, yMax};
+    }
+
+    void setupAxes(bool showGrid) {
+        // x-axis: frequency
+        {
+            const auto      dashCfg = parseAxisConfig(this->ui_constraints.value, true);
+            const AxisScale scale   = dashCfg ? dashCfg->scale.value_or(AxisScale::Linear) : AxisScale::Linear;
+            const auto      format  = dashCfg ? dashCfg->format : LabelFormat::MetricInline;
+
+            double minLimit = x_auto_scale.value ? std::numeric_limits<double>::quiet_NaN() : x_min.value;
+            double maxLimit = x_auto_scale.value ? std::numeric_limits<double>::quiet_NaN() : x_max.value;
+            if (dashCfg) {
+                if (std::isfinite(dashCfg->min)) {
+                    minLimit = static_cast<double>(dashCfg->min);
+                }
+                if (std::isfinite(dashCfg->max)) {
+                    maxLimit = static_cast<double>(dashCfg->max);
+                }
+            }
+
+            auto [xQuantity, xUnit] = sinkAxisInfo(true);
+            AxisCategory               xCat{.quantity = xQuantity, .unit = xUnit};
+            std::array<std::string, 6> unitStore{};
+            axis::setupAxis(ImAxis_X1, xCat, format, 100.f, minLimit, maxLimit, 1, scale, unitStore, showGrid, /*foreground=*/true);
+        }
+
+        // y-axis: amplitude — always use finite limits because the heatmap provides no
+        // plottable data for ImPlot's AutoFit. Force-apply only when the desired range
+        // changes; otherwise use ImPlotCond_Once so user zoom/pan is preserved.
+        {
+            const auto      dashCfg = parseAxisConfig(this->ui_constraints.value, false);
+            const AxisScale scale   = dashCfg ? dashCfg->scale.value_or(AxisScale::Linear) : AxisScale::Linear;
+            const auto      format  = dashCfg ? dashCfg->format : LabelFormat::Auto;
+
+            auto [yMin, yMax]       = effectiveYRange();
+            auto [yQuantity, yUnit] = sinkAxisInfo(false);
+
+            double minLimit = y_auto_scale.value ? yMin : y_min.value;
+            double maxLimit = y_auto_scale.value ? yMax : y_max.value;
+
+            bool limitsChanged   = (minLimit != _lastSetYMin || maxLimit != _lastSetYMax);
+            auto limitCond       = limitsChanged ? ImPlotCond_Always : ImPlotCond_Once;
+            _lastSetYMin         = minLimit;
+            _lastSetYMax         = maxLimit;
+            _yLimitsForceApplied = limitsChanged;
+
+            AxisCategory               yCat{.quantity = yQuantity, .unit = yUnit};
+            std::array<std::string, 6> unitStore{};
+            axis::setupAxis(ImAxis_Y1, yCat, format, 100.f, minLimit, maxLimit, 1, scale, unitStore, showGrid, /*foreground=*/true, limitCond);
+        }
+    }
+
+    void drawDensitySignals() {
+        forEachValidSpectrum(_signalSinks, [&](const auto& /*sink*/, const SpectrumFrame& f) {
+            const auto ampBins      = static_cast<std::size_t>(amplitude_bins);
+            auto [effYMin, effYMax] = effectiveYRange();
+
+            if (adaptive_y_range.value) {
+                auto limits = ImPlot::GetPlotLimits();
+                effYMin     = std::max(limits.Y.Min, effYMin);
+                effYMax     = std::min(limits.Y.Max, effYMax);
+            }
+
+            _density.update(f.yValues, f.nBins, ampBins, static_cast<double>(histogram_decay_tau_frames), effYMin, effYMax, colormap.value, gpu_acceleration);
+            _density.plot(f.xValues, effYMin, effYMax);
+
+            ImVec4 traceBase = sinkColor(trace_color);
+            drawTraceOverlays(_traces, f.xValues, f.yValues, f.nBins, static_cast<double>(trace_decay_tau_frames), traceBase, show_max_hold, show_min_hold, show_average);
+
+            if (show_current_overlay.value) {
+                plotTrace("##current", f.xValues, f.yValues, f.nBins, ImVec4(traceBase.x, traceBase.y, traceBase.z, 1.0f));
+            }
+
+            return false; // density display uses first valid sink only
+        });
+    }
+};
+
+} // namespace opendigitizer::charts
+
+GR_REGISTER_BLOCK("opendigitizer::charts::SpectrumDensity", opendigitizer::charts::SpectrumDensity)
+inline auto registerSpectrumDensity = gr::registerBlock<opendigitizer::charts::SpectrumDensity>(gr::globalBlockRegistry());
+
+#endif // OPENDIGITIZER_CHARTS_SPECTRUMDENSITY_HPP

--- a/src/ui/charts/SpectrumHelper.hpp
+++ b/src/ui/charts/SpectrumHelper.hpp
@@ -1,0 +1,1044 @@
+#ifndef OPENDIGITIZER_CHARTS_SPECTRUMHELPER_HPP
+#define OPENDIGITIZER_CHARTS_SPECTRUMHELPER_HPP
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <ranges>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "../utils/ShaderHelper.hpp"
+#include <implot.h>
+
+namespace opendigitizer::charts {
+
+static constexpr std::size_t kColormapSize = 256;
+
+inline std::array<uint32_t, kColormapSize> buildColormapLut(ImPlotColormap cmap) {
+    std::array<uint32_t, kColormapSize> lut{};
+    for (std::size_t i = 0; i < kColormapSize; ++i) {
+        const float t = static_cast<float>(i) / static_cast<float>(kColormapSize - 1);
+        ImVec4      c = ImPlot::SampleColormap(t, cmap);
+        lut[i]        = uint32_t(c.x * 255.f) | (uint32_t(c.y * 255.f) << 8) | (uint32_t(c.z * 255.f) << 16) | (uint32_t(c.w * 255.f) << 24);
+    }
+    return lut;
+}
+
+inline ImVec4 contrastingGridColor(ImPlotColormap cmap, float alpha = 0.3f) {
+    float         luminance = 0.f;
+    constexpr int kSamples  = 16;
+    for (int i = 0; i < kSamples; ++i) {
+        ImVec4 c = ImPlot::SampleColormap(static_cast<float>(i) / static_cast<float>(kSamples - 1), cmap);
+        luminance += 0.299f * c.x + 0.587f * c.y + 0.114f * c.z; // ITU-R BT.601
+    }
+    luminance /= static_cast<float>(kSamples);
+    float grid = (luminance > 0.5f) ? 0.f : 1.f;
+    return ImVec4(grid, grid, grid, alpha);
+}
+
+inline uint32_t colormapLookup(double value, double scaleMin, double scaleMax, std::span<const uint32_t, kColormapSize> lut) {
+    if (scaleMax <= scaleMin) {
+        return lut[0];
+    }
+    double norm = (value - scaleMin) / (scaleMax - scaleMin);
+    auto   idx  = static_cast<std::size_t>(std::clamp(norm, 0.0, 1.0) * static_cast<double>(kColormapSize - 1));
+    return lut[idx];
+}
+
+struct SpectrumFrame {
+    std::span<const float> xValues;
+    std::span<const float> yValues;
+    std::size_t            nBins;
+    int64_t                timestamp;
+};
+
+template<typename Sinks, typename Fn>
+void forEachValidSpectrum(const Sinks& sinks, Fn&& fn) {
+    for (const auto& sink : sinks) {
+        if (!sink->drawEnabled()) {
+            continue;
+        }
+        auto dataLock = sink->dataGuard();
+        if (!sink->hasDataSets()) {
+            continue;
+        }
+        auto allDataSets = sink->dataSets();
+        if (allDataSets.empty()) {
+            continue;
+        }
+        const auto& ds = allDataSets.back();
+        if (ds.axis_values.empty() || ds.axis_values[0].empty()) {
+            continue;
+        }
+        auto xV = ds.axisValues(0);
+        auto yV = ds.signalValues(0);
+        auto n  = std::min(xV.size(), yV.size());
+        if (n == 0) {
+            continue;
+        }
+        if (!fn(*sink, SpectrumFrame{xV, yV, n, ds.timestamp})) {
+            return;
+        }
+    }
+}
+
+[[nodiscard]] inline double timestampFromNanos(int64_t ns) {
+    double sec = static_cast<double>(ns) * 1e-9;
+    if (sec <= 0.0) {
+        sec = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count()) * 1e-9;
+    }
+    return sec;
+}
+
+/**
+ * @brief Accumulates max-hold, min-hold, and exponential-average traces over successive spectrum frames.
+ *
+ * Max/min-hold tracks the per-bin extremes with optional exponential decay
+ * controlled by a time constant in frames (tau = 0 means infinite hold).
+ */
+struct TraceAccumulator {
+    std::vector<float> _maxHold;
+    std::vector<float> _minHold;
+    std::vector<float> _average;
+    std::size_t        _frameCount = 0;
+
+    void update(std::span<const float> current, std::size_t nBins, double tau, bool enabled) {
+        if (!enabled) {
+            return;
+        }
+
+        if (_maxHold.size() != nBins) {
+            _maxHold.assign(nBins, -std::numeric_limits<float>::infinity());
+            _minHold.assign(nBins, std::numeric_limits<float>::infinity());
+            _average.assign(nBins, 0.0f);
+            _frameCount = 0;
+        }
+
+        const bool   decay = tau > 0.0;
+        const double alpha = decay ? 1.0 / tau : 0.0; // IIR coefficient
+
+        for (std::size_t i = 0; i < nBins; ++i) {
+            const auto val = static_cast<double>(current[i]);
+
+            if (val > static_cast<double>(_maxHold[i])) {
+                _maxHold[i] = current[i];
+            } else if (decay) {
+                _maxHold[i] = static_cast<float>(static_cast<double>(_maxHold[i]) + (val - static_cast<double>(_maxHold[i])) * alpha);
+            }
+
+            if (val < static_cast<double>(_minHold[i])) {
+                _minHold[i] = current[i];
+            } else if (decay) {
+                _minHold[i] = static_cast<float>(static_cast<double>(_minHold[i]) + (val - static_cast<double>(_minHold[i])) * alpha);
+            }
+
+            if (_frameCount == 0) {
+                _average[i] = current[i];
+            } else {
+                const double effectiveAlpha = decay ? alpha : (1.0 / static_cast<double>(_frameCount + 1));
+                _average[i]                 = static_cast<float>(static_cast<double>(_average[i]) + (val - static_cast<double>(_average[i])) * effectiveAlpha);
+            }
+        }
+
+        ++_frameCount;
+    }
+
+    void reset() {
+        _maxHold.clear();
+        _minHold.clear();
+        _average.clear();
+        _frameCount = 0;
+    }
+
+    [[nodiscard]] std::span<const float> maxHold() const noexcept { return _maxHold; }
+    [[nodiscard]] std::span<const float> minHold() const noexcept { return _minHold; }
+    [[nodiscard]] std::span<const float> average() const noexcept { return _average; }
+    [[nodiscard]] bool                   empty() const noexcept { return _maxHold.empty(); }
+};
+
+struct TracePlotContext {
+    std::span<const float> xValues;
+    std::span<const float> yValues;
+};
+
+inline void plotTrace(const char* label, std::span<const float> xValues, std::span<const float> yValues, std::size_t count, const ImVec4& color) {
+    TracePlotContext ctx{xValues, yValues};
+    ImPlot::SetNextLineStyle(color);
+    ImPlot::PlotLineG(
+        label,
+        [](int idx, void* userData) -> ImPlotPoint {
+            auto* c = static_cast<TracePlotContext*>(userData);
+            return ImPlotPoint(static_cast<double>(c->xValues[static_cast<std::size_t>(idx)]), static_cast<double>(c->yValues[static_cast<std::size_t>(idx)]));
+        },
+        &ctx, static_cast<int>(count));
+}
+
+inline void drawTraceOverlays(TraceAccumulator& traces, std::span<const float> xValues, std::span<const float> yValues, std::size_t nBins, double decayTau, const ImVec4& baseColor, bool showMaxHold, bool showMinHold, bool showAverage) {
+    const bool anyEnabled = showMaxHold || showMinHold || showAverage;
+    traces.update(yValues, nBins, decayTau, anyEnabled);
+
+    if (traces.empty()) {
+        return;
+    }
+
+    if (showMaxHold) {
+        plotTrace("##maxHold", xValues, traces.maxHold(), nBins, ImVec4(baseColor.x, baseColor.y, baseColor.z, 0.9f));
+    }
+    if (showMinHold) {
+        plotTrace("##minHold", xValues, traces.minHold(), nBins, ImVec4(baseColor.x, baseColor.y, baseColor.z, 0.5f));
+    }
+    if (showAverage) {
+        plotTrace("##average", xValues, traces.average(), nBins, ImVec4(baseColor.x, baseColor.y, baseColor.z, 0.7f));
+    }
+}
+
+namespace gl = opendigitizer::shader;
+
+/**
+ * @brief GPU-accelerated 2D density histogram with automatic CPU fallback.
+ *
+ * Accumulates incoming 1D spectrum lines into a 2D frequency-vs-amplitude
+ * histogram with exponential decay, then colormaps the result into an RGBA8
+ * texture for display via ImPlot::PlotImage.
+ *
+ * The GPU path uses a two-pass fullscreen-triangle pipeline (GLES3 / WebGL2):
+ *   pass 1 — decay previous histogram + accumulate new spectrum (ping-pong R32F FBOs)
+ *   pass 2 — normalise by peak density and sample a 256-entry colormap LUT → RGBA8
+ *
+ * If the driver lacks EXT_color_buffer_float or shader compilation fails,
+ * the implementation transparently falls back to an equivalent CPU path.
+ */
+struct DensityHistogram {
+    std::size_t _specBins      = 0;
+    std::size_t _ampBins       = 0;
+    double      _binningYMin   = 0.0;
+    double      _binningYMax   = 0.0;
+    bool        _preferGpu     = true;
+    bool        _initAttempted = false;
+    bool        _gpuAvailable  = false;
+
+    // GPU path — ping-pong R32F histogram + RGBA8 output
+    std::array<GLuint, 2> _histogramTextures{};
+    std::array<GLuint, 2> _histogramFBOs{};
+    int                   _pingPongIndex      = 0;
+    GLuint                _colormapTexture    = 0;
+    GLuint                _colormapFBO        = 0;
+    GLuint                _spectrumTexture    = 0;
+    GLuint                _colormapLutTexture = 0;
+    ImPlotColormap        _activeColormap     = -1;
+    GLuint                _emptyVAO           = 0;
+    GLuint                _accumulateProgram  = 0;
+    GLuint                _colormapProgram    = 0;
+    GLint                 _locAccPrevHist     = -1;
+    GLint                 _locAccSpecLine     = -1;
+    GLint                 _locAccDecay        = -1;
+    GLint                 _locAccAmpBins      = -1;
+    GLint                 _locCmHist          = -1;
+    GLint                 _locCmLut           = -1;
+    GLint                 _locCmMaxDensity    = -1;
+    float                 _peakDensity        = 0.f;
+
+    // reusable scratch buffers (avoid per-frame heap allocations)
+    std::vector<float> _scratchBuffer;
+
+    // CPU fallback — full histogram in system memory, RGBA8 texture upload per frame
+    std::vector<float>                  _cpuHistogram;
+    std::vector<uint32_t>               _cpuPixels;
+    GLuint                              _cpuTexture        = 0;
+    ImPlotColormap                      _cpuActiveColormap = -1;
+    std::array<uint32_t, kColormapSize> _cpuColormapLut{};
+
+    DensityHistogram() = default;
+
+    ~DensityHistogram() { destroyAllResources(); }
+
+    DensityHistogram(DensityHistogram&& o) noexcept { swap(o); }
+
+    DensityHistogram& operator=(DensityHistogram&& o) noexcept {
+        if (this != &o) {
+            destroyAllResources();
+            swap(o);
+        }
+        return *this;
+    }
+
+    void swap(DensityHistogram& o) noexcept {
+        using std::swap;
+        swap(_specBins, o._specBins);
+        swap(_ampBins, o._ampBins);
+        swap(_binningYMin, o._binningYMin);
+        swap(_binningYMax, o._binningYMax);
+        swap(_preferGpu, o._preferGpu);
+        swap(_initAttempted, o._initAttempted);
+        swap(_gpuAvailable, o._gpuAvailable);
+        swap(_histogramTextures, o._histogramTextures);
+        swap(_histogramFBOs, o._histogramFBOs);
+        swap(_pingPongIndex, o._pingPongIndex);
+        swap(_colormapTexture, o._colormapTexture);
+        swap(_colormapFBO, o._colormapFBO);
+        swap(_spectrumTexture, o._spectrumTexture);
+        swap(_colormapLutTexture, o._colormapLutTexture);
+        swap(_activeColormap, o._activeColormap);
+        swap(_emptyVAO, o._emptyVAO);
+        swap(_accumulateProgram, o._accumulateProgram);
+        swap(_colormapProgram, o._colormapProgram);
+        swap(_locAccPrevHist, o._locAccPrevHist);
+        swap(_locAccSpecLine, o._locAccSpecLine);
+        swap(_locAccDecay, o._locAccDecay);
+        swap(_locAccAmpBins, o._locAccAmpBins);
+        swap(_locCmHist, o._locCmHist);
+        swap(_locCmLut, o._locCmLut);
+        swap(_locCmMaxDensity, o._locCmMaxDensity);
+        swap(_peakDensity, o._peakDensity);
+        swap(_scratchBuffer, o._scratchBuffer);
+        swap(_cpuHistogram, o._cpuHistogram);
+        swap(_cpuPixels, o._cpuPixels);
+        swap(_cpuTexture, o._cpuTexture);
+        swap(_cpuActiveColormap, o._cpuActiveColormap);
+        swap(_cpuColormapLut, o._cpuColormapLut);
+    }
+
+    DensityHistogram(const DensityHistogram&)            = delete;
+    DensityHistogram& operator=(const DensityHistogram&) = delete;
+
+    void init() {
+        if (_initAttempted) {
+            return;
+        }
+        _initAttempted = true;
+        _gpuAvailable  = _preferGpu && tryInitGpu();
+    }
+
+    [[nodiscard]] bool tryInitGpu() {
+        using namespace opendigitizer::shader;
+
+        // fullscreen triangle from gl_VertexID — no VBO needed, just an empty VAO + glDrawArrays(GL_TRIANGLES, 0, 3)
+        // vertices: (-1,-1), (3,-1), (-1,3) — the GPU clips the oversized triangle to the viewport
+        static constexpr auto* kVertBody = R"glsl(
+out vec2 v_uv;
+void main() {
+    float x = -1.0 + float((gl_VertexID & 1) << 2);
+    float y = -1.0 + float((gl_VertexID & 2) << 1);
+    v_uv = vec2(x, y) * 0.5 + 0.5;
+    gl_Position = vec4(x, y, 0.0, 1.0);
+}
+)glsl";
+
+        // decay + accumulate: reads the previous R32F histogram (ping-pong) and the new 1D spectrum line (R32F, specBins×1)
+        // spectrum values are pre-normalised to [0,1] on CPU; (1-specVal) maps high amplitudes to the top of the texture
+        // each fragment checks whether its amplitude bin matches the new spectrum value (±0.5 bin tolerance)
+        static constexpr auto* kAccumulateFragBody = R"glsl(
+in vec2 v_uv;
+out float fragDensity;
+
+uniform sampler2D u_prevHistogram;  // ping-pong R32F, specBins × ampBins
+uniform sampler2D u_spectrumLine;   // R32F, specBins × 1, values in [0,1]
+uniform float     u_decayFactor;    // (1 - 1/tau), applied to previous density
+uniform float     u_ampBins;        // number of amplitude bins (float for GPU arithmetic)
+
+void main() {
+    float prev    = texture(u_prevHistogram, v_uv).r * u_decayFactor;
+    float specVal = texture(u_spectrumLine, vec2(v_uv.x, 0.5)).r;
+    float thisBin = v_uv.y * u_ampBins;
+    float hitBin  = (1.0 - specVal) * u_ampBins;
+    float hit     = step(abs(thisBin - hitBin), 0.5) * step(0.0, specVal);
+    fragDensity   = prev + hit;
+}
+)glsl";
+
+        // colormap: normalises accumulated density by peak and samples a 256×1 RGBA8 LUT texture
+        static constexpr auto* kColormapFragBody = R"glsl(
+in vec2 v_uv;
+out vec4 fragColor;
+
+uniform sampler2D u_histogram;    // accumulated R32F density from the accumulate pass
+uniform sampler2D u_colormapLut;  // RGBA8, 256×1, built from ImPlot colormap on CPU
+uniform float     u_maxDensity;   // CPU-tracked peak density (converges to tau)
+
+void main() {
+    float density = texture(u_histogram, v_uv).r;
+    float norm    = clamp(density / max(u_maxDensity, 1.0), 0.0, 1.0);
+    fragColor     = texture(u_colormapLut, vec2(norm, 0.5));
+}
+)glsl";
+
+        GLuint vs  = compileShader(GL_VERTEX_SHADER, kGlslPrefix, kVertBody);
+        GLuint fsA = compileShader(GL_FRAGMENT_SHADER, kGlslPrefix, kAccumulateFragBody);
+        GLuint fsC = compileShader(GL_FRAGMENT_SHADER, kGlslPrefix, kColormapFragBody);
+
+        _accumulateProgram = linkProgram(vs, fsA);
+        _colormapProgram   = linkProgram(vs, fsC);
+
+        glDeleteShader(vs);
+        glDeleteShader(fsA);
+        glDeleteShader(fsC);
+
+        if (!_accumulateProgram || !_colormapProgram) {
+            destroyGpuResources();
+            return false;
+        }
+
+        _locAccPrevHist = glGetUniformLocation(_accumulateProgram, "u_prevHistogram");
+        _locAccSpecLine = glGetUniformLocation(_accumulateProgram, "u_spectrumLine");
+        _locAccDecay    = glGetUniformLocation(_accumulateProgram, "u_decayFactor");
+        _locAccAmpBins  = glGetUniformLocation(_accumulateProgram, "u_ampBins");
+
+        _locCmHist       = glGetUniformLocation(_colormapProgram, "u_histogram");
+        _locCmLut        = glGetUniformLocation(_colormapProgram, "u_colormapLut");
+        _locCmMaxDensity = glGetUniformLocation(_colormapProgram, "u_maxDensity");
+
+        glGenVertexArrays(1, &_emptyVAO);
+
+        if (!supportsR32FFBO()) {
+            destroyGpuResources();
+            return false;
+        }
+
+        return true;
+    }
+
+    void destroyGpuTextures() {
+        glDeleteTextures(static_cast<GLsizei>(_histogramTextures.size()), _histogramTextures.data());
+        glDeleteFramebuffers(static_cast<GLsizei>(_histogramFBOs.size()), _histogramFBOs.data());
+        _histogramTextures = {};
+        _histogramFBOs     = {};
+
+        if (_colormapTexture) {
+            glDeleteTextures(1, &_colormapTexture);
+            _colormapTexture = 0;
+        }
+        if (_colormapFBO) {
+            glDeleteFramebuffers(1, &_colormapFBO);
+            _colormapFBO = 0;
+        }
+        if (_spectrumTexture) {
+            glDeleteTextures(1, &_spectrumTexture);
+            _spectrumTexture = 0;
+        }
+        if (_colormapLutTexture) {
+            glDeleteTextures(1, &_colormapLutTexture);
+            _colormapLutTexture = 0;
+        }
+        _activeColormap = -1;
+    }
+
+    void destroyGpuResources() {
+        destroyGpuTextures();
+        if (_accumulateProgram) {
+            glDeleteProgram(_accumulateProgram);
+            _accumulateProgram = 0;
+        }
+        if (_colormapProgram) {
+            glDeleteProgram(_colormapProgram);
+            _colormapProgram = 0;
+        }
+        if (_emptyVAO) {
+            glDeleteVertexArrays(1, &_emptyVAO);
+            _emptyVAO = 0;
+        }
+    }
+
+    void destroyCpuResources() {
+        _cpuHistogram.clear();
+        _cpuPixels.clear();
+        _cpuActiveColormap = -1;
+        if (_cpuTexture) {
+            glDeleteTextures(1, &_cpuTexture);
+            _cpuTexture = 0;
+        }
+    }
+
+    void destroyAllResources() {
+        destroyGpuResources();
+        destroyCpuResources();
+        _initAttempted = false;
+        _gpuAvailable  = false;
+    }
+
+    void gpuResize(std::size_t specBins, std::size_t ampBins) {
+        destroyGpuTextures();
+        _specBins      = specBins;
+        _ampBins       = ampBins;
+        _pingPongIndex = 0;
+        _peakDensity   = 0.f;
+
+        const auto w = static_cast<GLsizei>(_specBins);
+        const auto h = static_cast<GLsizei>(_ampBins);
+
+        for (int i = 0; i < 2; ++i) {
+            gl::createR32FTexture(_histogramTextures[static_cast<std::size_t>(i)], w, h);
+            _histogramFBOs[static_cast<std::size_t>(i)] = gl::attachFBO(_histogramTextures[static_cast<std::size_t>(i)]);
+        }
+
+        gl::createRGBA8Texture(_colormapTexture, w, h);
+        _colormapFBO = gl::attachFBO(_colormapTexture);
+
+        gl::createR32FTexture(_spectrumTexture, w, 1);
+
+        const auto nTexels = static_cast<std::size_t>(w) * static_cast<std::size_t>(h);
+        _scratchBuffer.resize(nTexels);
+        std::ranges::fill(_scratchBuffer, 0.f);
+        for (auto tex : _histogramTextures) {
+            glBindTexture(GL_TEXTURE_2D, tex);
+            glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h, GL_RED, GL_FLOAT, _scratchBuffer.data());
+        }
+    }
+
+    void gpuReset() {
+        if (_specBins == 0 || _ampBins == 0) {
+            return;
+        }
+        const auto w       = static_cast<GLsizei>(_specBins);
+        const auto h       = static_cast<GLsizei>(_ampBins);
+        const auto nTexels = static_cast<std::size_t>(w) * static_cast<std::size_t>(h);
+        _scratchBuffer.resize(nTexels);
+        std::ranges::fill(_scratchBuffer, 0.f);
+        for (auto tex : _histogramTextures) {
+            glBindTexture(GL_TEXTURE_2D, tex);
+            glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h, GL_RED, GL_FLOAT, _scratchBuffer.data());
+        }
+        _peakDensity   = 0.f;
+        _pingPongIndex = 0;
+    }
+
+    void gpuUpdateColormapLut(ImPlotColormap colormap) {
+        if (_activeColormap == colormap && _colormapLutTexture != 0) {
+            return;
+        }
+        _activeColormap = colormap;
+        auto lut        = buildColormapLut(colormap);
+
+        if (!_colormapLutTexture) {
+            gl::createRGBA8Texture(_colormapLutTexture, static_cast<GLsizei>(kColormapSize), 1);
+        }
+        glBindTexture(GL_TEXTURE_2D, _colormapLutTexture);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, static_cast<GLsizei>(kColormapSize), 1, GL_RGBA, GL_UNSIGNED_BYTE, lut.data());
+    }
+
+    void gpuUpdate(std::span<const float> yValues, std::size_t nBins, std::size_t ampBins, double decayTau, double yMin, double yMax, ImPlotColormap colormap) {
+        // save GL state before any GL calls (resize/reset/upload all modify bindings)
+        GLint                prevFBO = 0, prevProgram = 0, prevActiveTexture = 0, prevVAO = 0;
+        GLint                prevTexture0 = 0, prevTexture1 = 0;
+        std::array<GLint, 4> prevViewport{};
+        glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFBO);
+        glGetIntegerv(GL_CURRENT_PROGRAM, &prevProgram);
+        glGetIntegerv(GL_VIEWPORT, prevViewport.data());
+        glGetIntegerv(GL_ACTIVE_TEXTURE, &prevActiveTexture);
+        glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &prevVAO);
+        glActiveTexture(GL_TEXTURE0);
+        glGetIntegerv(GL_TEXTURE_BINDING_2D, &prevTexture0);
+        glActiveTexture(GL_TEXTURE1);
+        glGetIntegerv(GL_TEXTURE_BINDING_2D, &prevTexture1);
+
+        if (_specBins != nBins || _ampBins != ampBins) {
+            gpuResize(nBins, ampBins);
+            _binningYMin = yMin;
+            _binningYMax = yMax;
+        }
+
+        if (_binningYMin != yMin || _binningYMax != yMax) {
+            gpuReset();
+            _binningYMin = yMin;
+            _binningYMax = yMax;
+        }
+
+        gpuUpdateColormapLut(colormap);
+
+        // normalise spectrum to [0,1] range for the shader (reuses _scratchBuffer)
+        _scratchBuffer.resize(nBins);
+        const double ampRange = yMax - yMin;
+        if (ampRange > 0.0) {
+            const double invRange = 1.0 / ampRange;
+            for (std::size_t i = 0; i < nBins; ++i) {
+                _scratchBuffer[i] = static_cast<float>(std::clamp((static_cast<double>(yValues[i]) - yMin) * invRange, 0.0, 1.0));
+            }
+        } else {
+            std::ranges::fill(_scratchBuffer, 0.f);
+        }
+
+        glBindTexture(GL_TEXTURE_2D, _spectrumTexture);
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, static_cast<GLsizei>(nBins), 1, GL_RED, GL_FLOAT, _scratchBuffer.data());
+
+        const auto w = static_cast<GLsizei>(_specBins);
+        const auto h = static_cast<GLsizei>(_ampBins);
+
+        glBindVertexArray(_emptyVAO);
+
+        // pass 1: accumulate — read from ping, write to pong
+        const auto src = static_cast<std::size_t>(_pingPongIndex);
+        const auto dst = static_cast<std::size_t>(1 - _pingPongIndex);
+
+        glBindFramebuffer(GL_FRAMEBUFFER, _histogramFBOs[dst]);
+        glViewport(0, 0, w, h);
+        glUseProgram(_accumulateProgram);
+
+        const float decayFactor = (decayTau > 0.0) ? static_cast<float>(1.0 - 1.0 / decayTau) : 1.f;
+
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, _histogramTextures[src]);
+        glUniform1i(_locAccPrevHist, 0);
+
+        glActiveTexture(GL_TEXTURE1);
+        glBindTexture(GL_TEXTURE_2D, _spectrumTexture);
+        glUniform1i(_locAccSpecLine, 1);
+
+        glUniform1f(_locAccDecay, decayFactor);
+        glUniform1f(_locAccAmpBins, static_cast<float>(_ampBins));
+
+        glDrawArrays(GL_TRIANGLES, 0, 3);
+
+        _pingPongIndex = 1 - _pingPongIndex;
+
+        // track peak density on CPU
+        _peakDensity = _peakDensity * decayFactor + 1.f;
+
+        // pass 2: colormap — read histogram, write RGBA8
+        glBindFramebuffer(GL_FRAMEBUFFER, _colormapFBO);
+        glViewport(0, 0, w, h);
+        glUseProgram(_colormapProgram);
+
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, _histogramTextures[static_cast<std::size_t>(_pingPongIndex)]);
+        glUniform1i(_locCmHist, 0);
+
+        glActiveTexture(GL_TEXTURE1);
+        glBindTexture(GL_TEXTURE_2D, _colormapLutTexture);
+        glUniform1i(_locCmLut, 1);
+
+        glUniform1f(_locCmMaxDensity, std::max(_peakDensity, 1.f));
+
+        glDrawArrays(GL_TRIANGLES, 0, 3);
+
+        // restore GL state
+        glActiveTexture(GL_TEXTURE1);
+        glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(prevTexture1));
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(prevTexture0));
+        glBindVertexArray(static_cast<GLuint>(prevVAO));
+        glActiveTexture(static_cast<GLenum>(prevActiveTexture));
+        glUseProgram(static_cast<GLuint>(prevProgram));
+        glBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(prevFBO));
+        glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
+    }
+
+    void cpuResize(std::size_t specBins, std::size_t ampBins) {
+        _specBins         = specBins;
+        _ampBins          = ampBins;
+        const auto nCells = _ampBins * _specBins;
+        _cpuHistogram.assign(nCells, 0.f);
+        _cpuPixels.assign(nCells, 0U);
+
+        if (_cpuTexture) {
+            glDeleteTextures(1, &_cpuTexture);
+        }
+        glGenTextures(1, &_cpuTexture);
+        glBindTexture(GL_TEXTURE_2D, _cpuTexture);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, static_cast<GLsizei>(_specBins), static_cast<GLsizei>(_ampBins), 0, GL_RGBA, GL_UNSIGNED_BYTE, _cpuPixels.data());
+    }
+
+    void cpuReset() {
+        std::ranges::fill(_cpuHistogram, 0.f);
+        std::ranges::fill(_cpuPixels, uint32_t(0));
+        if (_cpuTexture && _specBins > 0 && _ampBins > 0) {
+            glBindTexture(GL_TEXTURE_2D, _cpuTexture);
+            glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, static_cast<GLsizei>(_specBins), static_cast<GLsizei>(_ampBins), GL_RGBA, GL_UNSIGNED_BYTE, _cpuPixels.data());
+        }
+    }
+
+    void cpuUpdate(std::span<const float> yValues, std::size_t nBins, std::size_t ampBins, double decayTau, double yMin, double yMax, ImPlotColormap colormap) {
+        if (_specBins != nBins || _ampBins != ampBins) {
+            cpuResize(nBins, ampBins);
+            _binningYMin = yMin;
+            _binningYMax = yMax;
+        }
+
+        if (_binningYMin != yMin || _binningYMax != yMax) {
+            cpuReset();
+            _binningYMin = yMin;
+            _binningYMax = yMax;
+        }
+
+        const double decayFactor = (decayTau > 0.0) ? (1.0 - 1.0 / decayTau) : 1.0;
+        for (auto& cell : _cpuHistogram) {
+            cell *= static_cast<float>(decayFactor);
+        }
+
+        const double ampRange = yMax - yMin;
+        if (ampRange > 0.0) {
+            const double invRange = static_cast<double>(_ampBins) / ampRange;
+            for (std::size_t i = 0; i < nBins; ++i) {
+                const auto val = static_cast<double>(yValues[i]);
+                const auto bin = static_cast<std::size_t>(std::clamp((yMax - val) * invRange, 0.0, static_cast<double>(_ampBins - 1)));
+                _cpuHistogram[bin * _specBins + i] += 1.f;
+            }
+        }
+
+        if (_cpuActiveColormap != colormap) {
+            _cpuActiveColormap = colormap;
+            _cpuColormapLut    = buildColormapLut(colormap);
+        }
+
+        const float maxDensity = std::max(*std::ranges::max_element(_cpuHistogram), 1.f);
+        std::ranges::transform(_cpuHistogram, _cpuPixels.begin(), [&](float density) { return colormapLookup(static_cast<double>(density), 0.0, static_cast<double>(maxDensity), _cpuColormapLut); });
+
+        glBindTexture(GL_TEXTURE_2D, _cpuTexture);
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, static_cast<GLsizei>(_specBins), static_cast<GLsizei>(_ampBins), GL_RGBA, GL_UNSIGNED_BYTE, _cpuPixels.data());
+    }
+
+    void resize(std::size_t specBins, std::size_t ampBins) {
+        if (_gpuAvailable) {
+            gpuResize(specBins, ampBins);
+        } else {
+            cpuResize(specBins, ampBins);
+        }
+    }
+
+    void reset() {
+        if (_gpuAvailable) {
+            gpuReset();
+        } else {
+            cpuReset();
+        }
+    }
+
+    void update(std::span<const float> yValues, std::size_t nBins, std::size_t ampBins, double decayTau, double yMin, double yMax, ImPlotColormap colormap, bool preferGpu = true) {
+        if (_preferGpu != preferGpu) {
+            destroyAllResources();
+            _specBins  = 0;
+            _ampBins   = 0;
+            _preferGpu = preferGpu;
+        }
+        init();
+        if (_gpuAvailable) {
+            gpuUpdate(yValues, nBins, ampBins, decayTau, yMin, yMax, colormap);
+        } else {
+            cpuUpdate(yValues, nBins, ampBins, decayTau, yMin, yMax, colormap);
+        }
+    }
+
+    void plot(std::span<const float> xValues, double yMin, double yMax) {
+        GLuint tex = _gpuAvailable ? _colormapTexture : _cpuTexture;
+        if (!tex) {
+            return;
+        }
+        const double freqMin     = static_cast<double>(xValues.front());
+        const double freqMax     = static_cast<double>(xValues.back());
+        auto         toTextureId = []<typename TexId = ImTextureID>(GLuint id) -> TexId {
+            if constexpr (std::is_pointer_v<TexId>) {
+                return reinterpret_cast<TexId>(static_cast<std::uintptr_t>(id));
+            } else {
+                return static_cast<TexId>(id);
+            }
+        };
+        ImPlot::PlotImage("##density", toTextureId(tex), ImPlotPoint(freqMin, yMin), ImPlotPoint(freqMax, yMax));
+    }
+};
+
+/**
+ * @brief GPU ring-buffer texture for scrolling spectrogram (waterfall) display.
+ *
+ * Manages an RGBA8 texture with GL_REPEAT wrapping on the T-axis so that
+ * advancing the write row and adjusting UV coordinates produces a scrolling
+ * effect without any data movement. Each new spectrum row is colour-mapped
+ * on the CPU and uploaded via a single-row glTexSubImage2D call.
+ */
+struct WaterfallBuffer {
+    std::size_t _width      = 0;
+    std::size_t _height     = 0;
+    std::size_t _writeRow   = 0;
+    std::size_t _filledRows = 0;
+
+    std::vector<uint32_t> _pixels;
+    std::vector<double>   _timestamps; // UTC seconds per row (parallel ring buffer)
+    GLuint                _texture = 0;
+
+    ImPlotColormap                      _activeColormap = -1;
+    std::array<uint32_t, kColormapSize> _colormapLut{};
+
+    double _scaleMin = 0.0;
+    double _scaleMax = 0.0;
+
+    bool                       _preferGpu = true;
+    std::vector<float>         _rawMagnitudes; // CPU path: raw magnitude ring buffer
+    mutable std::vector<float> _linearized;    // CPU path: scratch for rendering
+    double                     _effectiveScaleMin = 0.0;
+    double                     _effectiveScaleMax = 0.0;
+
+    WaterfallBuffer() = default;
+
+    ~WaterfallBuffer() { destroy(); }
+
+    WaterfallBuffer(WaterfallBuffer&& o) noexcept { swap(o); }
+
+    WaterfallBuffer& operator=(WaterfallBuffer&& o) noexcept {
+        if (this != &o) {
+            destroy();
+            swap(o);
+        }
+        return *this;
+    }
+
+    void swap(WaterfallBuffer& o) noexcept {
+        using std::swap;
+        swap(_width, o._width);
+        swap(_height, o._height);
+        swap(_writeRow, o._writeRow);
+        swap(_filledRows, o._filledRows);
+        swap(_pixels, o._pixels);
+        swap(_timestamps, o._timestamps);
+        swap(_texture, o._texture);
+        swap(_activeColormap, o._activeColormap);
+        swap(_colormapLut, o._colormapLut);
+        swap(_scaleMin, o._scaleMin);
+        swap(_scaleMax, o._scaleMax);
+        swap(_preferGpu, o._preferGpu);
+        swap(_rawMagnitudes, o._rawMagnitudes);
+        swap(_linearized, o._linearized);
+        swap(_effectiveScaleMin, o._effectiveScaleMin);
+        swap(_effectiveScaleMax, o._effectiveScaleMax);
+    }
+
+    WaterfallBuffer(const WaterfallBuffer&)            = delete;
+    WaterfallBuffer& operator=(const WaterfallBuffer&) = delete;
+
+    void init(std::size_t width, std::size_t height, bool preferGpu = true) {
+        destroy();
+        _width      = width;
+        _height     = height;
+        _writeRow   = 0;
+        _filledRows = 0;
+        _scaleMin   = 0.0;
+        _scaleMax   = 0.0;
+        _preferGpu  = preferGpu;
+
+        _timestamps.assign(_height, 0.0);
+
+        if (_preferGpu) {
+            _pixels.assign(_width * _height, 0U);
+            glGenTextures(1, &_texture);
+            glBindTexture(GL_TEXTURE_2D, _texture);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, static_cast<GLsizei>(_width), static_cast<GLsizei>(_height), 0, GL_RGBA, GL_UNSIGNED_BYTE, _pixels.data());
+        } else {
+            _rawMagnitudes.assign(_width * _height, 0.0f);
+        }
+    }
+
+    void setPreferGpu(bool preferGpu) {
+        if (_preferGpu == preferGpu) {
+            return;
+        }
+        auto w = _width;
+        auto h = _height;
+        init(w, h, preferGpu);
+    }
+
+    void pushRow(std::span<const float> magnitudes, std::size_t count, double scaleMin, double scaleMax, double timestampSec, ImPlotColormap colormap) {
+        if (_width == 0 || _height == 0) {
+            return;
+        }
+
+        _effectiveScaleMin = scaleMin;
+        _effectiveScaleMax = scaleMax;
+
+        auto n = std::min(count, _width);
+
+        if (_preferGpu && _texture) {
+            if (_activeColormap != colormap || (_colormapLut[0] == 0 && _colormapLut[1] == 0)) {
+                _colormapLut = buildColormapLut(colormap);
+            }
+
+            uint32_t* row = _pixels.data() + _writeRow * _width;
+            for (std::size_t i = 0; i < n; ++i) {
+                row[i] = colormapLookup(static_cast<double>(magnitudes[i]), scaleMin, scaleMax, _colormapLut);
+            }
+            std::fill_n(row + n, _width - n, uint32_t(0));
+
+            GLint prevTexture = 0;
+            glGetIntegerv(GL_TEXTURE_BINDING_2D, &prevTexture);
+            glBindTexture(GL_TEXTURE_2D, _texture);
+            glTexSubImage2D(GL_TEXTURE_2D, 0, 0, static_cast<GLint>(_writeRow), static_cast<GLsizei>(_width), 1, GL_RGBA, GL_UNSIGNED_BYTE, row);
+            glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(prevTexture));
+        } else {
+            float* row = _rawMagnitudes.data() + _writeRow * _width;
+            for (std::size_t i = 0; i < n; ++i) {
+                row[i] = magnitudes[i];
+            }
+            std::fill_n(row + n, _width - n, 0.0f);
+        }
+
+        _activeColormap        = colormap;
+        _timestamps[_writeRow] = timestampSec;
+        _writeRow              = (_writeRow + 1) % _height;
+        if (_filledRows < _height) {
+            ++_filledRows;
+        }
+    }
+
+    void render(double freqMin, double freqMax, double yMin, double yMax, bool newestAtTop = true) const {
+        if (_filledRows == 0) {
+            return;
+        }
+
+        if (_texture) {
+            // center-of-texel UVs avoid GL_NEAREST boundary ambiguity at the write-head seam
+            const auto fHeight = static_cast<float>(_height);
+            float      vNewest = (static_cast<float>(_writeRow) - 0.5f) / fHeight;
+            float      vOldest = (static_cast<float>(_writeRow) - static_cast<float>(_filledRows) + 0.5f) / fHeight;
+
+            // uv0 maps to (bmin.x, bmax.y) = screen top-left = plot yMax
+            // uv1 maps to (bmax.x, bmin.y) = screen bottom-right = plot yMin
+            float vTop        = newestAtTop ? vNewest : vOldest;
+            float vBottom     = newestAtTop ? vOldest : vNewest;
+            auto  toTextureId = []<typename TexId = ImTextureID>(GLuint id) -> TexId {
+                if constexpr (std::is_pointer_v<TexId>) {
+                    return reinterpret_cast<TexId>(static_cast<std::uintptr_t>(id));
+                } else {
+                    return static_cast<TexId>(id);
+                }
+            };
+            ImPlot::PlotImage("##waterfall", toTextureId(_texture), ImPlotPoint(freqMin, yMin), ImPlotPoint(freqMax, yMax), ImVec2(0.0f, vTop), ImVec2(1.0f, vBottom));
+        } else {
+            renderCpu(freqMin, freqMax, yMin, yMax, newestAtTop);
+        }
+    }
+
+    void renderCpu(double freqMin, double freqMax, double yMin, double yMax, bool newestAtTop) const {
+        _linearized.resize(_filledRows * _width);
+        for (std::size_t i = 0; i < _filledRows; ++i) {
+            // PlotHeatmap maps row 0 to the top of the bounding box
+            std::size_t srcRow = newestAtTop ? (_writeRow + _height - 1 - i) % _height : (_writeRow + _height - _filledRows + i) % _height;
+            std::copy_n(_rawMagnitudes.data() + srcRow * _width, _width, _linearized.data() + i * _width);
+        }
+
+        ImPlot::PushColormap(_activeColormap);
+        ImPlot::PlotHeatmap("##waterfall", _linearized.data(), static_cast<int>(_filledRows), static_cast<int>(_width), _effectiveScaleMin, _effectiveScaleMax, nullptr, ImPlotPoint(freqMin, yMin), ImPlotPoint(freqMax, yMax));
+        ImPlot::PopColormap();
+    }
+
+    void resizeHistory(std::size_t newHeight) {
+        if (newHeight == _height || _width == 0) {
+            return;
+        }
+
+        std::vector<double> newTimestamps(newHeight, 0.0);
+        std::size_t         rowsToCopy = std::min(_filledRows, newHeight);
+
+        if (_preferGpu) {
+            std::vector<uint32_t> newPixels(_width * newHeight, 0U);
+            for (std::size_t i = 0; i < rowsToCopy; ++i) {
+                std::size_t srcRow = (_writeRow + _height - rowsToCopy + i) % _height;
+                std::size_t dstRow = (newHeight - rowsToCopy + i) % newHeight;
+                std::copy_n(_pixels.data() + srcRow * _width, _width, newPixels.data() + dstRow * _width);
+                newTimestamps[dstRow] = _timestamps[srcRow];
+            }
+            _pixels = std::move(newPixels);
+
+            GLint prevTexture = 0;
+            glGetIntegerv(GL_TEXTURE_BINDING_2D, &prevTexture);
+            glBindTexture(GL_TEXTURE_2D, _texture);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, static_cast<GLsizei>(_width), static_cast<GLsizei>(newHeight), 0, GL_RGBA, GL_UNSIGNED_BYTE, _pixels.data());
+            glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(prevTexture));
+        } else {
+            std::vector<float> newMagnitudes(_width * newHeight, 0.0f);
+            for (std::size_t i = 0; i < rowsToCopy; ++i) {
+                std::size_t srcRow = (_writeRow + _height - rowsToCopy + i) % _height;
+                std::size_t dstRow = (newHeight - rowsToCopy + i) % newHeight;
+                std::copy_n(_rawMagnitudes.data() + srcRow * _width, _width, newMagnitudes.data() + dstRow * _width);
+                newTimestamps[dstRow] = _timestamps[srcRow];
+            }
+            _rawMagnitudes = std::move(newMagnitudes);
+        }
+
+        _timestamps = std::move(newTimestamps);
+        _height     = newHeight;
+        _filledRows = rowsToCopy;
+        _writeRow   = 0;
+    }
+
+    void clear() {
+        if (_preferGpu) {
+            std::ranges::fill(_pixels, uint32_t(0));
+        } else {
+            std::ranges::fill(_rawMagnitudes, 0.0f);
+        }
+        std::ranges::fill(_timestamps, 0.0);
+        _writeRow   = 0;
+        _filledRows = 0;
+        _scaleMin   = 0.0;
+        _scaleMax   = 0.0;
+
+        if (_texture && _width > 0 && _height > 0) {
+            GLint prevTexture = 0;
+            glGetIntegerv(GL_TEXTURE_BINDING_2D, &prevTexture);
+            glBindTexture(GL_TEXTURE_2D, _texture);
+            glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, static_cast<GLsizei>(_width), static_cast<GLsizei>(_height), GL_RGBA, GL_UNSIGNED_BYTE, _pixels.data());
+            glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(prevTexture));
+        }
+    }
+
+    [[nodiscard]] std::pair<double, double> rawTimeBounds() const {
+        if (_filledRows == 0) {
+            return {0.0, 0.0};
+        }
+        double tOldest = _timestamps[(_writeRow + _height - _filledRows) % _height];
+        double tNewest = _timestamps[(_writeRow + _height - 1) % _height];
+        if (tNewest <= tOldest) {
+            tNewest = tOldest + static_cast<double>(_filledRows);
+        }
+        return {tOldest, tNewest};
+    }
+
+    void updateAutoScale(std::span<const float> yValues, std::size_t nBins) {
+        auto [minIt, maxIt] = std::ranges::minmax_element(yValues | std::views::take(static_cast<std::ptrdiff_t>(nBins)));
+        double fMin         = static_cast<double>(*minIt);
+        double fMax         = static_cast<double>(*maxIt);
+        if (_filledRows == 0) {
+            _scaleMin = fMin;
+            _scaleMax = fMax;
+        } else {
+            constexpr double kAlpha = 0.05;
+            _scaleMin += (fMin - _scaleMin) * kAlpha;
+            _scaleMax += (fMax - _scaleMax) * kAlpha;
+        }
+    }
+
+    void destroy() {
+        if (_texture) {
+            glDeleteTextures(1, &_texture);
+            _texture = 0;
+        }
+        _pixels.clear();
+        _rawMagnitudes.clear();
+        _linearized.clear();
+        _timestamps.clear();
+        _width      = 0;
+        _height     = 0;
+        _writeRow   = 0;
+        _filledRows = 0;
+    }
+
+    [[nodiscard]] std::size_t width() const noexcept { return _width; }
+    [[nodiscard]] std::size_t filledRows() const noexcept { return _filledRows; }
+    [[nodiscard]] double      scaleMin() const noexcept { return _scaleMin; }
+    [[nodiscard]] double      scaleMax() const noexcept { return _scaleMax; }
+};
+
+} // namespace opendigitizer::charts
+
+#endif // OPENDIGITIZER_CHARTS_SPECTRUMHELPER_HPP

--- a/src/ui/charts/SpectrumPlot.hpp
+++ b/src/ui/charts/SpectrumPlot.hpp
@@ -1,0 +1,142 @@
+#ifndef OPENDIGITIZER_CHARTS_SPECTRUMPLOT_HPP
+#define OPENDIGITIZER_CHARTS_SPECTRUMPLOT_HPP
+
+#include "Chart.hpp"
+#include "SignalSink.hpp"
+#include "SpectrumHelper.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
+
+#include "../common/LookAndFeel.hpp"
+#include "../common/TouchHandler.hpp"
+#include <imgui.h>
+#include <implot.h>
+
+namespace opendigitizer::charts {
+
+struct SpectrumPlot : gr::Block<SpectrumPlot, gr::BlockingIO<false>, gr::Drawable<gr::UICategory::ChartPane, "ImGui">>, Chart {
+    using Description = gr::Doc<"Spectrum magnitude plot with optional max-hold, min-hold, and average traces.">;
+
+    template<typename T, gr::meta::fixed_string description = "", typename... Arguments>
+    using A = gr::Annotated<T, description, Arguments...>;
+
+    A<std::string, "chart name", gr::Visible>              chart_name;
+    A<std::string, "chart title">                          chart_title;
+    A<std::vector<std::string>, "data sinks", gr::Visible> data_sinks  = {};
+    A<bool, "show legend", gr::Visible>                    show_legend = false;
+    A<bool, "show grid", gr::Visible>                      show_grid   = true;
+
+    // trace toggles and accumulation
+    A<bool, "show max hold", gr::Visible>                                                                       show_max_hold    = true;
+    A<bool, "show min hold", gr::Visible>                                                                       show_min_hold    = true;
+    A<bool, "show average", gr::Visible>                                                                        show_average     = false;
+    A<std::uint32_t, "trace color", gr::Visible, gr::Doc<"RGB colour for accumulated traces (0xRRGGBB)">>       trace_color      = 0x8855BBU;
+    A<gr::Size_t, "decay tau frames", gr::Doc<"exponential decay time constant in frames (0 = infinite hold)">> decay_tau_frames = 100U;
+
+    // axis limits
+    A<bool, "X auto-scale"> x_auto_scale = true;
+    A<bool, "Y auto-scale"> y_auto_scale = true;
+    A<double, "X-axis min"> x_min        = std::numeric_limits<double>::lowest();
+    A<double, "X-axis max"> x_max        = std::numeric_limits<double>::max();
+    A<double, "Y-axis min"> y_min        = -120.0;
+    A<double, "Y-axis max"> y_max        = 0.0;
+
+    GR_MAKE_REFLECTABLE(SpectrumPlot, chart_name, chart_title, data_sinks, show_legend, show_grid, show_max_hold, show_min_hold, show_average, trace_color, decay_tau_frames, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max);
+
+    std::unordered_map<std::string, TraceAccumulator> _tracesPerSink;
+
+    static constexpr std::string_view kChartTypeName = "SpectrumPlot";
+
+    [[nodiscard]] static constexpr std::string_view chartTypeName() noexcept { return kChartTypeName; }
+    [[nodiscard]] std::string_view                  uniqueId() const noexcept { return this->unique_name; }
+
+    void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) { handleSettingsChanged(newSettings); }
+
+    gr::work::Status draw(const gr::property_map& config = {}) {
+        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, layoutMode, showGrid] = prepareDrawPrologue(config);
+
+        if (_signalSinks.empty()) {
+            drawEmptyPlot("No signals", plotFlags, plotSize);
+            return gr::work::Status::OK;
+        }
+
+        if (!DigitizerUi::TouchHandler<>::BeginZoomablePlot(chart_name.value, plotSize, plotFlags)) {
+            return gr::work::Status::OK;
+        }
+
+        setupAxes(showGrid);
+        ImPlot::SetupFinish();
+        drawSpectrumSignals();
+        tooltip::showPlotMouseTooltip();
+        handleCommonInteractions();
+        DigitizerUi::TouchHandler<>::EndZoomablePlot();
+
+        return gr::work::Status::OK;
+    }
+
+    void reset() { _tracesPerSink.clear(); }
+
+    void setupAxes(bool showGrid) {
+        // x-axis: frequency
+        {
+            const auto      dashCfg = parseAxisConfig(this->ui_constraints.value, true);
+            const AxisScale scale   = dashCfg ? dashCfg->scale.value_or(AxisScale::Linear) : AxisScale::Linear;
+            const auto      format  = dashCfg ? dashCfg->format : LabelFormat::MetricInline;
+
+            double minLimit = x_auto_scale.value ? std::numeric_limits<double>::quiet_NaN() : x_min.value;
+            double maxLimit = x_auto_scale.value ? std::numeric_limits<double>::quiet_NaN() : x_max.value;
+            if (dashCfg && x_auto_scale.value) {
+                minLimit = std::isfinite(dashCfg->min) ? static_cast<double>(dashCfg->min) : minLimit;
+                maxLimit = std::isfinite(dashCfg->max) ? static_cast<double>(dashCfg->max) : maxLimit;
+            }
+
+            auto [xQuantity, xUnit] = sinkAxisInfo(true);
+            AxisCategory               xCat{.quantity = xQuantity, .unit = xUnit};
+            std::array<std::string, 6> unitStore{};
+            axis::setupAxis(ImAxis_X1, xCat, format, 100.f, minLimit, maxLimit, 1, scale, unitStore, showGrid);
+        }
+
+        // y-axis: magnitude
+        {
+            const auto      dashCfg = parseAxisConfig(this->ui_constraints.value, false);
+            const AxisScale scale   = dashCfg ? dashCfg->scale.value_or(AxisScale::Linear) : AxisScale::Linear;
+            const auto      format  = dashCfg ? dashCfg->format : LabelFormat::Auto;
+
+            double minLimit = y_auto_scale.value ? std::numeric_limits<double>::quiet_NaN() : y_min.value;
+            double maxLimit = y_auto_scale.value ? std::numeric_limits<double>::quiet_NaN() : y_max.value;
+            if (dashCfg && y_auto_scale.value) {
+                minLimit = std::isfinite(dashCfg->min) ? static_cast<double>(dashCfg->min) : minLimit;
+                maxLimit = std::isfinite(dashCfg->max) ? static_cast<double>(dashCfg->max) : maxLimit;
+            }
+
+            auto [yQuantity, yUnit] = sinkAxisInfo(false);
+            AxisCategory               yCat{.quantity = yQuantity, .unit = yUnit};
+            std::array<std::string, 6> unitStore{};
+            axis::setupAxis(ImAxis_Y1, yCat, format, 100.f, minLimit, maxLimit, 1, scale, unitStore, showGrid);
+        }
+    }
+
+    void drawSpectrumSignals() {
+        forEachValidSpectrum(_signalSinks, [&](const auto& sink, const SpectrumFrame& f) {
+            plotTrace(std::string(sink.signalName()).c_str(), f.xValues, f.yValues, f.nBins, sinkColor(sink.color()));
+            auto& traces = _tracesPerSink[std::string(sink.signalName())];
+            drawTraceOverlays(traces, f.xValues, f.yValues, f.nBins, static_cast<double>(decay_tau_frames), sinkColor(trace_color), show_max_hold, show_min_hold, show_average);
+            return true;
+        });
+    }
+};
+
+} // namespace opendigitizer::charts
+
+GR_REGISTER_BLOCK("opendigitizer::charts::SpectrumPlot", opendigitizer::charts::SpectrumPlot)
+inline auto registerSpectrumPlot = gr::registerBlock<opendigitizer::charts::SpectrumPlot>(gr::globalBlockRegistry());
+
+#endif // OPENDIGITIZER_CHARTS_SPECTRUMPLOT_HPP

--- a/src/ui/charts/SpectrumView.hpp
+++ b/src/ui/charts/SpectrumView.hpp
@@ -1,0 +1,307 @@
+#ifndef OPENDIGITIZER_CHARTS_SPECTRUMVIEW_HPP
+#define OPENDIGITIZER_CHARTS_SPECTRUMVIEW_HPP
+
+#include "Chart.hpp"
+#include "SignalSink.hpp"
+#include "SpectrumHelper.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
+
+#include "../common/LookAndFeel.hpp"
+#include <imgui.h>
+#include <implot.h>
+
+namespace opendigitizer::charts {
+
+enum class TopPaneMode : int {
+    Spectrum = 0, // magnitude line traces (max/min hold, average)
+    Density  = 1  // 2-D histogram heatmap
+};
+
+struct SpectrumView : gr::Block<SpectrumView, gr::BlockingIO<false>, gr::Drawable<gr::UICategory::ChartPane, "ImGui">>, Chart {
+    using Description = gr::Doc<"Composite spectrum display: magnitude plot or density (top) + waterfall (bottom) with synchronised X-axis.">;
+
+    template<typename T, gr::meta::fixed_string description = "", typename... Arguments>
+    using A = gr::Annotated<T, description, Arguments...>;
+
+    // identity
+    A<std::string, "chart name", gr::Visible>              chart_name;
+    A<std::vector<std::string>, "data sinks", gr::Visible> data_sinks  = {};
+    A<bool, "show legend", gr::Visible>                    show_legend = false;
+    A<bool, "show grid", gr::Visible>                      show_grid   = true;
+
+    A<TopPaneMode, "top pane mode", gr::Visible> top_pane_mode = TopPaneMode::Spectrum;
+
+    // spectrum trace settings (top pane mode 0)
+    A<bool, "show max hold", gr::Visible>                                                                       show_max_hold    = true;
+    A<bool, "show min hold", gr::Visible>                                                                       show_min_hold    = true;
+    A<bool, "show average", gr::Visible>                                                                        show_average     = false;
+    A<std::uint32_t, "trace color", gr::Visible, gr::Doc<"RGB colour for accumulated traces (0xRRGGBB)">>       trace_color      = 0x8855BBU;
+    A<gr::Size_t, "decay tau frames", gr::Doc<"exponential decay time constant in frames (0 = infinite hold)">> decay_tau_frames = 100U;
+
+    // density settings (top pane mode 1)
+    A<gr::Size_t, "amplitude bins", gr::Visible, gr::Limits<4U, 1024U>>                       amplitude_bins             = 256U;
+    A<gr::Size_t, "histogram decay tau", gr::Doc<"histogram decay in frames (0 = infinite)">> histogram_decay_tau_frames = 100U;
+    A<bool, "show current overlay", gr::Visible>                                              show_current_overlay       = true;
+
+    // waterfall settings (bottom pane)
+    A<gr::Size_t, "history depth", gr::Visible, gr::Limits<16U, 4096U>>                                      n_history        = 256U;
+    A<ImPlotColormap_, "colormap", gr::Visible>                                                              colormap         = ImPlotColormap_Viridis;
+    A<bool, "GPU acceleration", gr::Doc<"use GPU texture for rendering (falls back to CPU if unavailable)">> gpu_acceleration = true;
+
+    // pane layout
+    A<float, "top pane ratio", gr::Limits<0.2f, 0.8f>, gr::Doc<"fraction of height for top pane">> top_pane_ratio = 0.4f;
+
+    // axis limits
+    A<bool, "X auto-scale"> x_auto_scale = true;
+    A<bool, "Y auto-scale"> y_auto_scale = true;
+    A<double, "X-axis min"> x_min        = std::numeric_limits<double>::lowest();
+    A<double, "X-axis max"> x_max        = std::numeric_limits<double>::max();
+    A<double, "Y-axis min"> y_min        = -120.0;
+    A<double, "Y-axis max"> y_max        = 0.0;
+
+    GR_MAKE_REFLECTABLE(SpectrumView, chart_name, data_sinks, show_legend, show_grid, top_pane_mode, show_max_hold, show_min_hold, show_average, trace_color, decay_tau_frames, amplitude_bins, histogram_decay_tau_frames, show_current_overlay, n_history, colormap, gpu_acceleration, top_pane_ratio, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max);
+
+    std::unordered_map<std::string, TraceAccumulator> _tracesPerSink;
+    DensityHistogram                                  _density;
+    WaterfallBuffer                                   _waterfall;
+    std::size_t                                       _lastSpectrumSize    = 0;
+    int64_t                                           _lastPushedTimestamp = 0;
+    std::array<float, 2>                              _rowRatios           = {0.4f, 0.6f};
+    std::array<std::string, 6>                        _unitStore{};
+
+    struct RenderInfo {
+        double freqMin;
+        double freqMax;
+    };
+    std::optional<RenderInfo> _lastRenderInfo;
+
+    static constexpr std::string_view kChartTypeName = "SpectrumView";
+
+    [[nodiscard]] static constexpr std::string_view chartTypeName() noexcept { return kChartTypeName; }
+    [[nodiscard]] std::string_view                  uniqueId() const noexcept { return this->unique_name; }
+
+    void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) { handleSettingsChanged(newSettings); }
+
+    void reset() {
+        _tracesPerSink.clear();
+        _density.reset();
+        _waterfall.clear();
+    }
+
+    gr::work::Status draw(const gr::property_map& config = {}) {
+        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, layoutMode, showGrid] = prepareDrawPrologue(config);
+
+        _waterfall.setPreferGpu(gpu_acceleration);
+        if (_pendingResizeTime == 0.0 && _waterfall.width() > 0) {
+            _waterfall.resizeHistory(static_cast<std::size_t>(n_history));
+        }
+
+        if (_signalSinks.empty()) {
+            drawEmptyPlot("No signals", plotFlags, plotSize);
+            return gr::work::Status::OK;
+        }
+
+        _rowRatios[0] = top_pane_ratio;
+        _rowRatios[1] = 1.0f - top_pane_ratio;
+
+        ImPlotSubplotFlags subplotFlags = ImPlotSubplotFlags_LinkCols | ImPlotSubplotFlags_LinkAllX;
+        auto               subplotId    = std::format("##combined_{}", chart_name.value);
+        if (!ImPlot::BeginSubplots(subplotId.c_str(), 2, 1, plotSize, subplotFlags, _rowRatios.data())) {
+            return gr::work::Status::OK;
+        }
+
+        drawTopPane(plotFlags, showGrid);
+        drawBottomPane(plotFlags, showGrid);
+
+        ImPlot::EndSubplots();
+        return gr::work::Status::OK;
+    }
+
+    void setupFrequencyAxis(bool showGrid) {
+        const auto      dashCfg = parseAxisConfig(this->ui_constraints.value, true);
+        const AxisScale scale   = dashCfg ? dashCfg->scale.value_or(AxisScale::Linear) : AxisScale::Linear;
+        const auto      format  = dashCfg ? dashCfg->format : LabelFormat::MetricInline;
+
+        double minLimit = x_auto_scale.value ? std::numeric_limits<double>::quiet_NaN() : x_min.value;
+        double maxLimit = x_auto_scale.value ? std::numeric_limits<double>::quiet_NaN() : x_max.value;
+        if (dashCfg && x_auto_scale.value) {
+            minLimit = std::isfinite(dashCfg->min) ? static_cast<double>(dashCfg->min) : minLimit;
+            maxLimit = std::isfinite(dashCfg->max) ? static_cast<double>(dashCfg->max) : maxLimit;
+        }
+
+        auto [xQuantity, xUnit] = sinkAxisInfo(true);
+        AxisCategory               xCat{.quantity = xQuantity, .unit = xUnit};
+        std::array<std::string, 6> unitStore{};
+        axis::setupAxis(ImAxis_X1, xCat, format, 100.f, minLimit, maxLimit, 1, scale, unitStore, showGrid, /*foreground=*/true);
+    }
+
+    void drawTopPane(ImPlotFlags plotFlags, bool showGrid) {
+        const bool isDensity = (top_pane_mode.value == TopPaneMode::Density);
+
+        ImGui::PushID("top");
+        if (isDensity) {
+            ImPlot::PushStyleColor(ImPlotCol_AxisGrid, contrastingGridColor(colormap.value));
+        }
+
+        ImPlot::PushStyleVar(ImPlotStyleVar_FitPadding, ImVec2{0.0f, 0.05f});
+        if (ImPlot::BeginPlot("##spectrum", ImVec2(0, 0), plotFlags)) {
+            setupFrequencyAxis(showGrid);
+            setupMagnitudeAxis(showGrid);
+            ImPlot::SetupFinish();
+
+            if (isDensity) {
+                drawDensitySignals();
+            } else {
+                drawSpectrumSignals();
+            }
+
+            tooltip::showPlotMouseTooltip();
+            handleCommonInteractions();
+            ImPlot::EndPlot();
+        }
+        ImPlot::PopStyleVar();
+
+        if (isDensity) {
+            ImPlot::PopStyleColor();
+        }
+        ImGui::PopID();
+    }
+
+    void setupMagnitudeAxis(bool showGrid) {
+        const auto      dashCfg = parseAxisConfig(this->ui_constraints.value, false);
+        const AxisScale scale   = dashCfg ? dashCfg->scale.value_or(AxisScale::Linear) : AxisScale::Linear;
+        const auto      format  = dashCfg ? dashCfg->format : LabelFormat::Auto;
+
+        double minLimit = y_auto_scale.value ? std::numeric_limits<double>::quiet_NaN() : y_min.value;
+        double maxLimit = y_auto_scale.value ? std::numeric_limits<double>::quiet_NaN() : y_max.value;
+        if (dashCfg && y_auto_scale.value) {
+            minLimit = std::isfinite(dashCfg->min) ? static_cast<double>(dashCfg->min) : minLimit;
+            maxLimit = std::isfinite(dashCfg->max) ? static_cast<double>(dashCfg->max) : maxLimit;
+        }
+
+        auto [yQuantity, yUnit] = sinkAxisInfo(false);
+        AxisCategory               yCat{.quantity = yQuantity, .unit = yUnit};
+        std::array<std::string, 6> unitStore{};
+        axis::setupAxis(ImAxis_Y1, yCat, format, 100.f, minLimit, maxLimit, 1, scale, unitStore, showGrid);
+    }
+
+    void drawSpectrumSignals() {
+        forEachValidSpectrum(_signalSinks, [&](const auto& sink, const SpectrumFrame& f) {
+            plotTrace(std::string(sink.signalName()).c_str(), f.xValues, f.yValues, f.nBins, sinkColor(sink.color()));
+            auto& traces = _tracesPerSink[std::string(sink.signalName())];
+            drawTraceOverlays(traces, f.xValues, f.yValues, f.nBins, static_cast<double>(decay_tau_frames), sinkColor(trace_color), show_max_hold, show_min_hold, show_average);
+            return true;
+        });
+    }
+
+    void drawDensitySignals() {
+        forEachValidSpectrum(_signalSinks, [&](const auto& sink, const SpectrumFrame& f) {
+            const auto ampBins = static_cast<std::size_t>(amplitude_bins);
+            double     effYMin = y_min.value;
+            double     effYMax = y_max.value;
+
+            _density.update(f.yValues, f.nBins, ampBins, static_cast<double>(histogram_decay_tau_frames), effYMin, effYMax, colormap.value, gpu_acceleration);
+            _density.plot(f.xValues, effYMin, effYMax);
+
+            ImVec4 traceBase = sinkColor(trace_color);
+            auto&  traces    = _tracesPerSink[std::string(sink.signalName())];
+            drawTraceOverlays(traces, f.xValues, f.yValues, f.nBins, static_cast<double>(decay_tau_frames), traceBase, show_max_hold, show_min_hold, show_average);
+
+            if (show_current_overlay.value) {
+                plotTrace("##current", f.xValues, f.yValues, f.nBins, ImVec4(traceBase.x, traceBase.y, traceBase.z, 1.0f));
+            }
+
+            return false; // density display uses first valid sink only
+        });
+    }
+
+    void drawBottomPane(ImPlotFlags plotFlags, bool showGrid) {
+        ImGui::PushID("bottom");
+        ImPlot::PushStyleColor(ImPlotCol_AxisGrid, contrastingGridColor(colormap.value));
+        ImPlot::PushStyleVar(ImPlotStyleVar_FitPadding, ImVec2{0.0f, 0.05f});
+
+        if (ImPlot::BeginPlot("##waterfall", ImVec2(0, 0), plotFlags | ImPlotFlags_NoLegend)) {
+            setupFrequencyAxis(showGrid);
+            setupWaterfallYAxis(showGrid);
+
+            auto renderInfo = fetchAndPushData();
+
+            auto [tOldest, tNewest] = _waterfall.rawTimeBounds();
+            auto [yLo, yHi]         = transformedYBounds(tOldest, tNewest);
+
+            if (_waterfall.filledRows() > 0 && yHi > yLo) {
+                ImPlot::SetupAxisLimits(ImAxis_Y1, yLo, yHi, ImPlotCond_Always);
+            }
+
+            ImPlot::SetupFinish();
+
+            constexpr bool newestAtTop = true;
+            if (renderInfo) {
+                _waterfall.render(renderInfo->freqMin, renderInfo->freqMax, yLo, yHi, newestAtTop);
+            } else if (_waterfall.filledRows() > 0 && _lastRenderInfo) {
+                _waterfall.render(_lastRenderInfo->freqMin, _lastRenderInfo->freqMax, yLo, yHi, newestAtTop);
+            }
+
+            tooltip::showPlotMouseTooltip();
+            handlePlotDropTarget();
+            ImPlot::EndPlot();
+        }
+
+        ImPlot::PopStyleVar();
+        ImPlot::PopStyleColor();
+        ImGui::PopID();
+    }
+
+    void setupWaterfallYAxis(bool showGrid) {
+        ImPlotAxisFlags yFlags = (showGrid ? ImPlotAxisFlags_None : ImPlotAxisFlags_NoGridLines) | ImPlotAxisFlags_Foreground;
+        ImPlot::SetupAxis(ImAxis_Y1, "", yFlags);
+        _unitStore[ImAxis_Y1] = "s";
+        ImPlot::SetupAxisFormat(ImAxis_Y1, axis::formatMetric, const_cast<void*>(static_cast<const void*>(_unitStore[ImAxis_Y1].c_str())));
+        ImPlot::SetupAxisScale(ImAxis_Y1, ImPlotScale_Linear);
+    }
+
+    [[nodiscard]] static std::pair<double, double> transformedYBounds(double tOldest, double tNewest) {
+        double duration = tNewest - tOldest;
+        return {-duration, 0.0}; // newest at top (LinearReverse equivalent)
+    }
+
+    [[nodiscard]] std::optional<RenderInfo> fetchAndPushData() {
+        std::optional<RenderInfo> result;
+        forEachValidSpectrum(_signalSinks, [&](const auto& /*sink*/, const SpectrumFrame& f) -> bool {
+            if (f.timestamp == _lastPushedTimestamp && _lastPushedTimestamp != 0) {
+                return false;
+            }
+            _lastPushedTimestamp = f.timestamp;
+
+            if (_lastSpectrumSize != f.nBins) {
+                _waterfall.init(f.nBins, static_cast<std::size_t>(n_history), gpu_acceleration);
+                _lastSpectrumSize = f.nBins;
+            }
+
+            _waterfall.updateAutoScale(f.yValues, f.nBins);
+            auto [cMin, cMax] = effectiveColourRange(this->ui_constraints.value, _waterfall.scaleMin(), _waterfall.scaleMax());
+            _waterfall.pushRow(f.yValues, f.nBins, cMin, cMax, timestampFromNanos(f.timestamp), colormap.value);
+
+            _lastRenderInfo = RenderInfo{.freqMin = static_cast<double>(f.xValues.front()), .freqMax = static_cast<double>(f.xValues.back())};
+            result          = _lastRenderInfo;
+            return false;
+        });
+        return result;
+    }
+};
+
+} // namespace opendigitizer::charts
+
+GR_REGISTER_BLOCK("opendigitizer::charts::SpectrumView", opendigitizer::charts::SpectrumView)
+inline auto registerSpectrumView = gr::registerBlock<opendigitizer::charts::SpectrumView>(gr::globalBlockRegistry());
+
+#endif // OPENDIGITIZER_CHARTS_SPECTRUMVIEW_HPP

--- a/src/ui/charts/WaterfallPlot.hpp
+++ b/src/ui/charts/WaterfallPlot.hpp
@@ -1,0 +1,237 @@
+#ifndef OPENDIGITIZER_CHARTS_WATERFALLPLOT_HPP
+#define OPENDIGITIZER_CHARTS_WATERFALLPLOT_HPP
+
+#include "Chart.hpp"
+#include "SignalSink.hpp"
+#include "SpectrumHelper.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
+
+#include "../common/LookAndFeel.hpp"
+#include "../common/TouchHandler.hpp"
+#include <imgui.h>
+#include <implot.h>
+
+namespace opendigitizer::charts {
+
+struct WaterfallPlot : gr::Block<WaterfallPlot, gr::BlockingIO<false>, gr::Drawable<gr::UICategory::ChartPane, "ImGui">>, Chart {
+    using Description = gr::Doc<"Scrolling spectrogram using a GPU ring-buffer texture with single-row updates.">;
+
+    template<typename T, gr::meta::fixed_string description = "", typename... Arguments>
+    using A = gr::Annotated<T, description, Arguments...>;
+
+    // identity
+    A<std::string, "chart name", gr::Visible>              chart_name;
+    A<std::string, "chart title">                          chart_title;
+    A<std::vector<std::string>, "data sinks", gr::Visible> data_sinks  = {};
+    A<bool, "show legend", gr::Visible>                    show_legend = false;
+    A<bool, "show grid", gr::Visible>                      show_grid   = true;
+
+    // waterfall
+    A<gr::Size_t, "history depth", gr::Visible, gr::Limits<16U, 4096U>>                                      n_history        = 256U;
+    A<ImPlotColormap_, "colormap", gr::Visible>                                                              colormap         = ImPlotColormap_Viridis;
+    A<bool, "GPU acceleration", gr::Doc<"use GPU texture for rendering (falls back to CPU if unavailable)">> gpu_acceleration = true;
+    // axis limits (Z = colour scale: NaN min/max → auto-scale from data)
+    A<bool, "X auto-scale"> x_auto_scale = true;
+    A<bool, "Y auto-scale"> y_auto_scale = true;
+    A<double, "X-axis min"> x_min        = std::numeric_limits<double>::lowest();
+    A<double, "X-axis max"> x_max        = std::numeric_limits<double>::max();
+    A<double, "Y-axis min"> y_min        = std::numeric_limits<double>::lowest();
+    A<double, "Y-axis max"> y_max        = std::numeric_limits<double>::max();
+
+    GR_MAKE_REFLECTABLE(WaterfallPlot, chart_name, chart_title, data_sinks, show_legend, show_grid, n_history, colormap, gpu_acceleration, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max);
+
+    struct RenderInfo {
+        double freqMin;
+        double freqMax;
+    };
+
+    WaterfallBuffer            _waterfall;
+    std::size_t                _lastSpectrumSize = 0;
+    std::array<std::string, 6> _unitStore{};
+    int64_t                    _lastPushedTimestamp = 0;
+    std::optional<RenderInfo>  _lastRenderInfo;
+
+    static constexpr std::string_view kChartTypeName = "WaterfallPlot";
+
+    [[nodiscard]] static constexpr std::string_view chartTypeName() noexcept { return kChartTypeName; }
+    [[nodiscard]] std::string_view                  uniqueId() const noexcept { return this->unique_name; }
+
+    [[nodiscard]] std::optional<AxisScale> getAxisScale(AxisKind axis) const noexcept {
+        if (auto cfg = parseAxisConfig(this->ui_constraints.value, axis)) {
+            if (cfg->scale) {
+                return cfg->scale;
+            }
+        }
+        return (axis == AxisKind::Y) ? AxisScale::LinearReverse : AxisScale::Linear;
+    }
+
+    void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) { handleSettingsChanged(newSettings); }
+
+    gr::work::Status draw(const gr::property_map& config = {}) {
+        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, layoutMode, showGrid] = prepareDrawPrologue(config);
+
+        // sync GPU preference with setting
+        _waterfall.setPreferGpu(gpu_acceleration);
+
+        // sync waterfall depth with n_history after debounced UI changes
+        // (UI modifies n_history directly, bypassing settingsChanged)
+        if (_pendingResizeTime == 0.0 && _waterfall.width() > 0) {
+            _waterfall.resizeHistory(static_cast<std::size_t>(n_history));
+        }
+
+        if (_signalSinks.empty()) {
+            drawEmptyPlot("No signals", plotFlags, plotSize);
+            return gr::work::Status::OK;
+        }
+
+        ImPlot::PushStyleColor(ImPlotCol_AxisGrid, contrastingGridColor(colormap.value));
+
+        if (!DigitizerUi::TouchHandler<>::BeginZoomablePlot(chart_name.value, plotSize, plotFlags)) {
+            ImPlot::PopStyleColor();
+            return gr::work::Status::OK;
+        }
+
+        // phase 1: set up axes (X fully, Y skeleton without limits)
+        setupAxes(showGrid);
+
+        // phase 2: fetch new data and push into waterfall (skips duplicate frames)
+        auto renderInfo = fetchAndPushData();
+
+        // phase 3: compute Y-axis bounds in the coordinate system determined by the scale
+        const AxisScale yScale  = getAxisScale(AxisKind::Y).value_or(AxisScale::LinearReverse);
+        auto [tOldest, tNewest] = _waterfall.rawTimeBounds();
+        auto [yLo, yHi]         = transformedYBounds(tOldest, tNewest, yScale);
+
+        if (_waterfall.filledRows() > 0 && yHi > yLo) {
+            ImPlot::SetupAxisLimits(ImAxis_Y1, yLo, yHi, ImPlotCond_Always);
+        }
+
+        ImPlot::SetupFinish();
+
+        // register legend entries for each sink (enables legend display and D&D)
+        for (const auto& sink : _signalSinks) {
+            ImVec4 color = sinkColor(sink->color());
+            ImPlot::SetNextLineStyle(color);
+            ImPlot::PlotDummy(std::string(sink->signalName()).c_str());
+        }
+
+        // phase 4: render waterfall image (always, even when no new data this frame)
+        const bool newestAtTop = (yScale == AxisScale::LinearReverse);
+        if (renderInfo) {
+            _waterfall.render(renderInfo->freqMin, renderInfo->freqMax, yLo, yHi, newestAtTop);
+        } else if (_waterfall.filledRows() > 0 && _lastRenderInfo) {
+            _waterfall.render(_lastRenderInfo->freqMin, _lastRenderInfo->freqMax, yLo, yHi, newestAtTop);
+        }
+
+        tooltip::showPlotMouseTooltip();
+        handleCommonInteractions();
+        DigitizerUi::TouchHandler<>::EndZoomablePlot();
+        ImPlot::PopStyleColor();
+
+        return gr::work::Status::OK;
+    }
+
+    void reset() { _waterfall.clear(); }
+
+    [[nodiscard]] static std::pair<double, double> transformedYBounds(double tOldest, double tNewest, AxisScale scale) {
+        double duration = tNewest - tOldest;
+        if (scale == AxisScale::Time) {
+            return {tOldest, tNewest};
+        }
+        if (scale == AxisScale::LinearReverse) {
+            return {-duration, 0.0};
+        }
+        return {0.0, duration}; // Linear, Log10, SymLog — positive offsets
+    }
+
+    static int formatTimeAxis(double value, char* buff, int size, void* /*userData*/) {
+        using Clock    = std::chrono::system_clock;
+        auto timePoint = Clock::time_point(std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(value)));
+        auto secs      = std::chrono::time_point_cast<std::chrono::seconds>(timePoint);
+        auto ms        = std::chrono::duration_cast<std::chrono::milliseconds>(timePoint - secs).count();
+        auto result    = std::format_to_n(buff, static_cast<std::ptrdiff_t>(size) - 1, "{:%H:%M:%S}.{:02}", secs, ms / 10);
+        *result.out    = '\0';
+        return static_cast<int>(result.out - buff);
+    }
+
+    void setupAxes(bool showGrid) {
+        // x-axis: frequency
+        {
+            const auto      dashCfg = parseAxisConfig(this->ui_constraints.value, true);
+            const AxisScale scale   = dashCfg ? dashCfg->scale.value_or(AxisScale::Linear) : AxisScale::Linear;
+            const auto      format  = dashCfg ? dashCfg->format : LabelFormat::MetricInline;
+
+            double minLimit = x_auto_scale.value ? std::numeric_limits<double>::quiet_NaN() : x_min.value;
+            double maxLimit = x_auto_scale.value ? std::numeric_limits<double>::quiet_NaN() : x_max.value;
+            if (dashCfg && x_auto_scale.value) {
+                minLimit = std::isfinite(dashCfg->min) ? static_cast<double>(dashCfg->min) : minLimit;
+                maxLimit = std::isfinite(dashCfg->max) ? static_cast<double>(dashCfg->max) : maxLimit;
+            }
+
+            auto [xQuantity, xUnit] = sinkAxisInfo(true);
+            AxisCategory xCat{.quantity = xQuantity, .unit = xUnit};
+            axis::setupAxis(ImAxis_X1, xCat, format, 100.f, minLimit, maxLimit, 1, scale, _unitStore, showGrid, /*foreground=*/true);
+        }
+
+        // y-axis: time — limits are set in draw() after data push so axis and image stay synchronised.
+        // ImPlotScale_Time is X-axis-only; we use Linear + custom formatter.
+        {
+            AxisScale scale = getAxisScale(AxisKind::Y).value_or(AxisScale::LinearReverse);
+
+            ImPlotAxisFlags yFlags = (showGrid ? ImPlotAxisFlags_None : ImPlotAxisFlags_NoGridLines) | ImPlotAxisFlags_Foreground;
+            ImPlot::SetupAxis(ImAxis_Y1, "", yFlags);
+
+            if (scale == AxisScale::Time) {
+                ImPlot::SetupAxisFormat(ImAxis_Y1, formatTimeAxis, nullptr);
+                ImPlot::SetupAxisScale(ImAxis_Y1, ImPlotScale_Linear);
+            } else {
+                _unitStore[ImAxis_Y1] = "s";
+                ImPlot::SetupAxisFormat(ImAxis_Y1, axis::formatMetric, const_cast<void*>(static_cast<const void*>(_unitStore[ImAxis_Y1].c_str())));
+                switch (scale) {
+                case AxisScale::Log10: ImPlot::SetupAxisScale(ImAxis_Y1, ImPlotScale_Log10); break;
+                case AxisScale::SymLog: ImPlot::SetupAxisScale(ImAxis_Y1, ImPlotScale_SymLog); break;
+                default: ImPlot::SetupAxisScale(ImAxis_Y1, ImPlotScale_Linear); break;
+                }
+            }
+        }
+    }
+
+    [[nodiscard]] std::optional<RenderInfo> fetchAndPushData() {
+        std::optional<RenderInfo> result;
+        forEachValidSpectrum(_signalSinks, [&](const auto& /*sink*/, const SpectrumFrame& f) -> bool {
+            if (f.timestamp == _lastPushedTimestamp && _lastPushedTimestamp != 0) {
+                return false;
+            }
+            _lastPushedTimestamp = f.timestamp;
+
+            if (_lastSpectrumSize != f.nBins) {
+                _waterfall.init(f.nBins, static_cast<std::size_t>(n_history), gpu_acceleration);
+                _lastSpectrumSize = f.nBins;
+            }
+
+            _waterfall.updateAutoScale(f.yValues, f.nBins);
+            auto [cMin, cMax] = effectiveColourRange(this->ui_constraints.value, _waterfall.scaleMin(), _waterfall.scaleMax());
+            _waterfall.pushRow(f.yValues, f.nBins, cMin, cMax, timestampFromNanos(f.timestamp), colormap.value);
+
+            _lastRenderInfo = RenderInfo{.freqMin = static_cast<double>(f.xValues.front()), .freqMax = static_cast<double>(f.xValues.back())};
+            result          = _lastRenderInfo;
+            return false;
+        });
+        return result;
+    }
+};
+
+} // namespace opendigitizer::charts
+
+GR_REGISTER_BLOCK("opendigitizer::charts::WaterfallPlot", opendigitizer::charts::WaterfallPlot)
+inline auto registerWaterfallPlot = gr::registerBlock<opendigitizer::charts::WaterfallPlot>(gr::globalBlockRegistry());
+
+#endif // OPENDIGITIZER_CHARTS_WATERFALLPLOT_HPP

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -42,6 +42,7 @@
 #include "blocks/RemoteSource.hpp"
 #include "blocks/SineSource.hpp"
 #include "blocks/TagToSample.hpp"
+#include "blocks/TestSpectrumGenerator.hpp"
 
 #include <version.hpp>
 

--- a/src/ui/test/CMakeLists.txt
+++ b/src/ui/test/CMakeLists.txt
@@ -13,6 +13,12 @@ target_link_libraries(qa_ChartAbstraction PRIVATE ut opendigitizer-uilib)
 target_include_directories(qa_ChartAbstraction PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 add_test(NAME qa_ChartAbstraction COMMAND qa_ChartAbstraction)
 
+add_executable(qa_TestSpectrumGenerator qa_TestSpectrumGenerator.cpp)
+target_link_libraries(qa_TestSpectrumGenerator PRIVATE ut gnuradio-core gnuradio-blocklib-core)
+target_include_directories(qa_TestSpectrumGenerator PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..
+                                                            ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/include)
+add_test(NAME qa_TestSpectrumGenerator COMMAND qa_TestSpectrumGenerator)
+
 add_executable(qa_play_stop_bar qa_play_stop_bar.cpp)
 target_include_directories(qa_play_stop_bar INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                       $<INSTALL_INTERFACE:include/>)

--- a/src/ui/test/qa_SignalSink.cpp
+++ b/src/ui/test/qa_SignalSink.cpp
@@ -117,8 +117,8 @@ int main() {
         expect(eq(sink->dataSetCount(), 1UZ));
         expect(eq(sink->size(), 5UZ));
 
-        expect(std::abs(sink->xAt(0) - 0.0f) < 1e-6);
-        expect(std::abs(sink->yAt(0) - 1.0f) < 1e-6);
+        expect(approx(sink->xAt(0), 0.0, 1e-6));
+        expect(approx(sink->yAt(0), 1.0, 1e-6));
 
         auto pd = sink->plotData();
         expect(!pd.empty());

--- a/src/ui/test/qa_TestSpectrumGenerator.cpp
+++ b/src/ui/test/qa_TestSpectrumGenerator.cpp
@@ -1,0 +1,193 @@
+#include <gnuradio-4.0/BlockRegistry.hpp>
+
+#include "../blocks/TestSpectrumGenerator.hpp"
+
+#include <boost/ut.hpp>
+
+#include <algorithm>
+#include <cmath>
+
+using namespace opendigitizer;
+
+const boost::ut::suite<"TestSpectrumGenerator"> tests = [] {
+    using namespace boost::ut;
+
+    "spectrum has correct size and axis layout"_test = [] {
+        TestSpectrumGenerator<float> gen;
+        gen.spectrum_size    = 512U;
+        gen.center_freq      = 100e6f;
+        gen.signal_bandwidth = 1e6f;
+        gen.clock_rate       = 25.f;
+        gen.seed             = 42ULL;
+        gen.start();
+
+        auto ds = gen.createSpectrum(512);
+        expect(ds.axis_values.size() == 1_u);
+        expect(ds.axis_values[0].size() == 512_u);
+        expect(ds.signal_values.size() == 512_u);
+
+        float fMin = ds.axis_values[0].front();
+        float fMax = ds.axis_values[0].back();
+        expect(fMin > 99.4e6f);
+        expect(fMax < 100.6e6f);
+    };
+
+    "noise floor level is within expected range"_test = [] {
+        TestSpectrumGenerator<float> gen;
+        gen.spectrum_size           = 1024U;
+        gen.center_freq             = 100e6f;
+        gen.signal_bandwidth        = 1e6f;
+        gen.clock_rate              = 25.f;
+        gen.seed                    = 42ULL;
+        gen.noise_floor_db          = -80.f;
+        gen.noise_spread_db         = 0.2f;
+        gen.show_schottky           = false;
+        gen.show_interference_lines = false;
+        gen.show_sweep_line         = false;
+        gen.active_duration         = 10.f;
+        gen.pause_duration          = 0.f;
+        gen.start();
+
+        auto   ds         = gen.createSpectrum(1024);
+        auto   magnitudes = ds.signalValues(0);
+        double sum        = 0.0;
+        for (auto v : magnitudes) {
+            sum += static_cast<double>(v);
+        }
+        double mean = sum / static_cast<double>(magnitudes.size());
+        expect(std::abs(mean - (-80.0)) < 2.0) << "mean=" << mean;
+    };
+
+    "Schottky peak rises above noise floor"_test = [] {
+        TestSpectrumGenerator<float> gen;
+        gen.spectrum_size           = 1024U;
+        gen.center_freq             = 100e6f;
+        gen.signal_bandwidth        = 1e6f;
+        gen.clock_rate              = 25.f;
+        gen.seed                    = 42ULL;
+        gen.noise_floor_db          = -80.f;
+        gen.show_schottky           = true;
+        gen.initial_peak_db         = 20.f;
+        gen.show_interference_lines = false;
+        gen.show_sweep_line         = false;
+        gen.active_duration         = 10.f;
+        gen.pause_duration          = 0.f;
+        gen.start();
+
+        // advance a few samples into the active phase
+        gen._sampleCount = 50;
+        auto  ds         = gen.createSpectrum(1024);
+        auto  magnitudes = ds.signalValues(0);
+        float peakVal    = *std::max_element(magnitudes.begin(), magnitudes.end());
+        expect(peakVal > -70.f) << "peak should be well above noise floor, got " << peakVal;
+    };
+
+    "interference lines appear at expected positions"_test = [] {
+        TestSpectrumGenerator<float> gen;
+        gen.spectrum_size           = 4096U;
+        gen.center_freq             = 100e6f;
+        gen.signal_bandwidth        = 1e6f;
+        gen.clock_rate              = 25.f;
+        gen.seed                    = 42ULL;
+        gen.noise_floor_db          = -80.f;
+        gen.line_amplitude_db       = 20.f;
+        gen.show_schottky           = false;
+        gen.show_interference_lines = true;
+        gen.show_sweep_line         = false;
+        gen.active_duration         = 10.f;
+        gen.pause_duration          = 0.f;
+        gen.start();
+
+        auto ds         = gen.createSpectrum(4096);
+        auto magnitudes = ds.signalValues(0);
+
+        // lines are at positions 0.12, 0.25, 0.85 of spectrum
+        for (double pos : {0.12, 0.25, 0.85}) {
+            auto bin = static_cast<std::size_t>(pos * 4096.0);
+            expect(magnitudes[bin] > -70.f) << "interference line at pos=" << pos << " bin=" << bin;
+        }
+    };
+
+    "morse keying toggles third interference line"_test = [] {
+        TestSpectrumGenerator<float> gen;
+        gen.spectrum_size       = 1024U;
+        gen.center_freq         = 100e6f;
+        gen.signal_bandwidth    = 1e6f;
+        gen.clock_rate          = 1.f;
+        gen.seed                = 42ULL;
+        gen.morse_pattern       = "-";
+        gen.morse_unit_duration = 1.f;
+        gen.start();
+
+        // "dash" = 3 ON units + 1 OFF unit + 6 OFF word gap = 10 units total
+        expect(gen.isMorseKeyOn(0.0) == true);
+        expect(gen.isMorseKeyOn(2.5) == true);  // still in the dash
+        expect(gen.isMorseKeyOn(4.0) == false); // past the dash+gap
+    };
+
+    "reproducibility with same seed"_test = [] {
+        auto makeGen = [] {
+            TestSpectrumGenerator<float> gen;
+            gen.spectrum_size           = 256U;
+            gen.center_freq             = 100e6f;
+            gen.signal_bandwidth        = 1e6f;
+            gen.clock_rate              = 25.f;
+            gen.seed                    = 42ULL;
+            gen.show_schottky           = true;
+            gen.show_interference_lines = true;
+            gen.show_sweep_line         = false;
+            gen.active_duration         = 10.f;
+            gen.pause_duration          = 0.f;
+            gen.start();
+            return gen;
+        };
+
+        auto gen1 = makeGen();
+        auto gen2 = makeGen();
+        auto ds1  = gen1.createSpectrum(256);
+        auto ds2  = gen2.createSpectrum(256);
+        auto m1   = ds1.signalValues(0);
+        auto m2   = ds2.signalValues(0);
+
+        expect(m1.size() == m2.size());
+        for (std::size_t i = 0; i < m1.size(); ++i) {
+            expect(m1[i] == m2[i]) << "mismatch at bin " << i;
+        }
+    };
+
+    "pause phase produces noise-only spectrum"_test = [] {
+        TestSpectrumGenerator<float> gen;
+        gen.spectrum_size           = 512U;
+        gen.center_freq             = 100e6f;
+        gen.signal_bandwidth        = 1e6f;
+        gen.clock_rate              = 1.f;
+        gen.seed                    = 42ULL;
+        gen.noise_floor_db          = -80.f;
+        gen.noise_spread_db         = 0.2f;
+        gen.show_schottky           = true;
+        gen.initial_peak_db         = 30.f;
+        gen.show_interference_lines = false;
+        gen.show_sweep_line         = false;
+        gen.active_duration         = 1.f;
+        gen.pause_duration          = 10.f;
+        gen.start();
+
+        // advance into the pause phase: active=1s, clock_rate=1Hz, so sample 2 is at t=2s (in pause)
+        gen._sampleCount = 2;
+        auto  ds         = gen.createSpectrum(512);
+        auto  magnitudes = ds.signalValues(0);
+        float maxVal     = *std::max_element(magnitudes.begin(), magnitudes.end());
+        expect(maxVal < -75.f) << "pause phase should be noise only, max=" << maxVal;
+    };
+
+    "rebuildMorseKey handles empty pattern"_test = [] {
+        TestSpectrumGenerator<float> gen;
+        gen.morse_pattern = "";
+        gen.start();
+
+        expect(gen.isMorseKeyOn(0.0) == true);
+        expect(gen.isMorseKeyOn(100.0) == true);
+    };
+};
+
+int main() { /* not needed for ut */ }

--- a/src/ui/test/qa_chart.cpp
+++ b/src/ui/test/qa_chart.cpp
@@ -19,6 +19,7 @@
 #include "blocks/Arithmetic.hpp"
 #include "blocks/ImPlotSink.hpp"
 #include "blocks/SineSource.hpp"
+#include "blocks/TestSpectrumGenerator.hpp"
 
 #include <cmrc/cmrc.hpp>
 

--- a/src/ui/test/qa_flowgraph.cpp
+++ b/src/ui/test/qa_flowgraph.cpp
@@ -20,6 +20,7 @@
 #include "blocks/GlobalSignalLegend.hpp"
 #include "blocks/ImPlotSink.hpp"
 #include "blocks/SineSource.hpp"
+#include "blocks/TestSpectrumGenerator.hpp"
 
 #include <cmrc/cmrc.hpp>
 

--- a/src/ui/utils/ShaderHelper.hpp
+++ b/src/ui/utils/ShaderHelper.hpp
@@ -1,0 +1,126 @@
+#ifndef OPENDIGITIZER_UTILS_SHADERHELPER_HPP
+#define OPENDIGITIZER_UTILS_SHADERHELPER_HPP
+
+#include <array>
+#include <optional>
+#include <print>
+
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
+#ifndef GL_GLEXT_PROTOTYPES
+#define GL_GLEXT_PROTOTYPES
+#endif
+#include <SDL3/SDL_opengl.h>
+#endif
+
+namespace opendigitizer::shader {
+
+#ifdef __EMSCRIPTEN__
+static constexpr auto* kGlslPrefix = "#version 300 es\nprecision highp float;\n";
+#else
+static constexpr auto* kGlslPrefix = "#version 330 core\n";
+#endif
+
+inline GLuint compileShader(GLenum type, const char* prefix, const char* body) {
+    GLuint shader = glCreateShader(type);
+    if (!shader) {
+        std::println(stderr, "[ShaderHelper] glCreateShader failed");
+        return 0;
+    }
+    std::array<const char*, 2> sources = {prefix, body};
+    glShaderSource(shader, static_cast<GLsizei>(sources.size()), sources.data(), nullptr);
+    glCompileShader(shader);
+    GLint ok = 0;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+    if (!ok) {
+        std::array<char, 1024> log{};
+        glGetShaderInfoLog(shader, static_cast<GLsizei>(log.size()), nullptr, log.data());
+        std::println(stderr, "[ShaderHelper] {} shader compile error:\n{}", type == GL_VERTEX_SHADER ? "vertex" : "fragment", log.data());
+        glDeleteShader(shader);
+        return 0;
+    }
+    return shader;
+}
+
+inline GLuint linkProgram(GLuint vs, GLuint fs) {
+    if (!vs || !fs) {
+        return 0;
+    }
+    GLuint program = glCreateProgram();
+    if (!program) {
+        std::println(stderr, "[ShaderHelper] glCreateProgram failed");
+        return 0;
+    }
+    glAttachShader(program, vs);
+    glAttachShader(program, fs);
+    glLinkProgram(program);
+    GLint ok = 0;
+    glGetProgramiv(program, GL_LINK_STATUS, &ok);
+    if (!ok) {
+        std::array<char, 1024> log{};
+        glGetProgramInfoLog(program, static_cast<GLsizei>(log.size()), nullptr, log.data());
+        std::println(stderr, "[ShaderHelper] program link error:\n{}", log.data());
+        glDeleteProgram(program);
+        return 0;
+    }
+    return program;
+}
+
+inline void createR32FTexture(GLuint& tex, GLsizei w, GLsizei h) {
+    glGenTextures(1, &tex);
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, w, h, 0, GL_RED, GL_FLOAT, nullptr);
+}
+
+inline void createRGBA8Texture(GLuint& tex, GLsizei w, GLsizei h) {
+    glGenTextures(1, &tex);
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+}
+
+inline GLuint attachFBO(GLuint tex) {
+    GLuint fbo = 0;
+    glGenFramebuffers(1, &fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tex, 0);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        std::println(stderr, "[ShaderHelper] FBO incomplete for texture {}", tex);
+    }
+    return fbo;
+}
+
+// probes whether the driver supports rendering into R32F textures (requires EXT_color_buffer_float on WebGL2)
+// result is cached after the first probe
+[[nodiscard]] inline bool supportsR32FFBO() {
+    static std::optional<bool> cached;
+    if (cached.has_value()) {
+        return *cached;
+    }
+    GLuint tex = 0, fbo = 0;
+    createR32FTexture(tex, 1, 1);
+    glGenFramebuffers(1, &fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tex, 0);
+    bool complete = (glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glDeleteFramebuffers(1, &fbo);
+    glDeleteTextures(1, &tex);
+    if (!complete) {
+        std::println(stderr, "[ShaderHelper] R32F FBO not supported (EXT_color_buffer_float missing?)");
+    }
+    cached = complete;
+    return complete;
+}
+
+} // namespace opendigitizer::shader
+
+#endif // OPENDIGITIZER_UTILS_SHADERHELPER_HPP

--- a/src/utils/include/Xoshiro256pp.hpp
+++ b/src/utils/include/Xoshiro256pp.hpp
@@ -1,0 +1,73 @@
+#ifndef OPENDIGITIZER_XOSHIRO256PP_HPP
+#define OPENDIGITIZER_XOSHIRO256PP_HPP
+
+#include <array>
+#include <concepts>
+#include <cstdint>
+
+namespace opendigitizer {
+
+/**
+ * @brief Fast non-crypto PRNG for DSP/simulation; provides uniform and cheap “semi-uniform” (triangular) noise.
+ *
+ * @details Engine: xoshiro256++ (small state, high throughput); seed via SplitMix64 (avoid zero state).
+ * Triangular noise = (u1 + u2 - 1): Irwin–Hall(n=2), i.e. triangular distribution.
+ * @see D. Blackman, S. Vigna, “Scrambled Linear Pseudorandom Number Generators”, arXiv:1805.01407.
+ * @see xoshiro256++ + SplitMix64 reference code: https://prng.di.unimi.it/
+ * @see Irwin–Hall distribution (n=2): https://en.wikipedia.org/wiki/Irwin%E2%80%93Hall_distribution
+ */
+struct Xoshiro256pp {
+    std::array<std::uint64_t, 4> _s{};
+
+    static constexpr std::uint64_t splitmix64(std::uint64_t& x) {
+        x += 0x9E3779B97F4A7C15ULL;
+        auto z = x;
+        z      = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+        z      = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+        return z ^ (z >> 31);
+    }
+
+    constexpr explicit Xoshiro256pp(std::uint64_t seed = 1) {
+        auto x = seed;
+        for (auto& v : _s) {
+            v = splitmix64(x);
+        }
+    }
+
+    static constexpr std::uint64_t rotl(std::uint64_t x, int k) { return (x << k) | (x >> (64 - k)); }
+
+    constexpr std::uint64_t nextU64() {
+        const auto result = rotl(_s[0] + _s[3], 23) + _s[0];
+        const auto t      = _s[1] << 17;
+        _s[2] ^= _s[0];
+        _s[3] ^= _s[1];
+        _s[1] ^= _s[2];
+        _s[0] ^= _s[3];
+        _s[2] ^= t;
+        _s[3] = rotl(_s[3], 45);
+        return result;
+    }
+
+    template<std::floating_point T = double>
+    constexpr T uniform01() { // [0,1)
+        if constexpr (std::same_as<T, float>) {
+            return static_cast<float>(nextU64() >> 40) * (1.0f / 16777216.0f); // 24-bit
+        } else {
+            return static_cast<double>(nextU64() >> 11) * (1.0 / 9007199254740992.0); // 53-bit
+        }
+    }
+
+    template<std::floating_point T = double>
+    constexpr T uniformM11() {
+        return T(2) * uniform01<T>() - T(1);
+    } // [-1,1)
+
+    template<std::floating_point T = double>
+    constexpr T triangularM11() {
+        return uniform01<T>() + uniform01<T>() - T(1);
+    } // triangular [-1,1)
+};
+
+} // namespace opendigitizer
+
+#endif // OPENDIGITIZER_XOSHIRO256PP_HPP

--- a/src/utils/test/CMakeLists.txt
+++ b/src/utils/test/CMakeLists.txt
@@ -18,3 +18,7 @@ target_include_directories(qa_PeriodicTimer INTERFACE $<BUILD_INTERFACE:${CMAKE_
                                                       $<INSTALL_INTERFACE:include/>)
 add_test(NAME qa_PeriodicTimer COMMAND qa_PeriodicTimer)
 target_link_libraries(qa_PeriodicTimer PRIVATE ut gnuradio-core)
+
+add_executable(qa_Xoshiro256pp qa_Xoshiro256pp.cpp)
+target_link_libraries(qa_Xoshiro256pp PRIVATE ut)
+add_test(NAME qa_Xoshiro256pp COMMAND qa_Xoshiro256pp)

--- a/src/utils/test/qa_Xoshiro256pp.cpp
+++ b/src/utils/test/qa_Xoshiro256pp.cpp
@@ -1,0 +1,124 @@
+#include "../include/Xoshiro256pp.hpp"
+
+#include <boost/ut.hpp>
+
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+using namespace opendigitizer;
+
+const boost::ut::suite<"Xoshiro256pp"> tests = [] {
+    using namespace boost::ut;
+
+    "same seed produces identical sequence"_test = [] {
+        Xoshiro256pp rng1(42);
+        Xoshiro256pp rng2(42);
+        for (int i = 0; i < 1000; ++i) {
+            expect(rng1.nextU64() == rng2.nextU64());
+        }
+    };
+
+    "different seeds produce different sequences"_test = [] {
+        Xoshiro256pp rng1(1);
+        Xoshiro256pp rng2(2);
+        bool         anyDifferent = false;
+        for (int i = 0; i < 10; ++i) {
+            if (rng1.nextU64() != rng2.nextU64()) {
+                anyDifferent = true;
+                break;
+            }
+        }
+        expect(anyDifferent);
+    };
+
+    "uniform01 double is in [0, 1)"_test = [] {
+        Xoshiro256pp rng(123);
+        for (int i = 0; i < 10000; ++i) {
+            double v = rng.uniform01<double>();
+            expect(v >= 0.0_d);
+            expect(v < 1.0_d);
+        }
+    };
+
+    "uniform01 float is in [0, 1)"_test = [] {
+        Xoshiro256pp rng(456);
+        for (int i = 0; i < 10000; ++i) {
+            float v = rng.uniform01<float>();
+            expect(v >= 0.0_f);
+            expect(v < 1.0_f);
+        }
+    };
+
+    "uniformM11 is in [-1, 1)"_test = [] {
+        Xoshiro256pp rng(789);
+        for (int i = 0; i < 10000; ++i) {
+            double v = rng.uniformM11();
+            expect(v >= -1.0_d);
+            expect(v < 1.0_d);
+        }
+    };
+
+    "triangularM11 is in [-1, 1)"_test = [] {
+        Xoshiro256pp rng(101);
+        for (int i = 0; i < 10000; ++i) {
+            double v = rng.triangularM11();
+            expect(v >= -1.0_d);
+            expect(v < 1.0_d);
+        }
+    };
+
+    "uniform01 mean converges to 0.5"_test = [] {
+        Xoshiro256pp  rng(42);
+        constexpr int N   = 100000;
+        double        sum = 0.0;
+        for (int i = 0; i < N; ++i) {
+            sum += rng.uniform01<double>();
+        }
+        double mean = sum / static_cast<double>(N);
+        expect(std::abs(mean - 0.5) < 0.01_d) << "mean=" << mean;
+    };
+
+    "uniformM11 mean converges to 0"_test = [] {
+        Xoshiro256pp  rng(42);
+        constexpr int N   = 100000;
+        double        sum = 0.0;
+        for (int i = 0; i < N; ++i) {
+            sum += rng.uniformM11();
+        }
+        double mean = sum / static_cast<double>(N);
+        expect(std::abs(mean) < 0.01_d) << "mean=" << mean;
+    };
+
+    "triangularM11 mean converges to 0"_test = [] {
+        Xoshiro256pp  rng(42);
+        constexpr int N   = 100000;
+        double        sum = 0.0;
+        for (int i = 0; i < N; ++i) {
+            sum += rng.triangularM11();
+        }
+        double mean = sum / static_cast<double>(N);
+        expect(std::abs(mean) < 0.01_d) << "mean=" << mean;
+    };
+
+    "constexpr evaluation"_test = [] {
+        constexpr auto val = [] {
+            Xoshiro256pp rng(42);
+            return rng.nextU64();
+        }();
+        expect(val != 0_u);
+    };
+
+    "splitmix64 avoids zero state"_test = [] {
+        Xoshiro256pp rng(0); // seed=0 should still produce non-zero state
+        bool         anyNonZero = false;
+        for (auto v : rng._s) {
+            if (v != 0) {
+                anyNonZero = true;
+            }
+        }
+        expect(anyNonZero);
+    };
+};
+
+int main() { /* not needed for ut */ }


### PR DESCRIPTION
Add a complete spectrum visualisation suite for OpenDigitizer: four new chart blocks, a synthetic test source, GPU shader infrastructure, and shared helper extraction to reduce code duplication.

## New chart blocks

**SpectrumPlot** — magnitude line plot with trace accumulation
- Current spectrum trace (always on)
- Max-hold, min-hold, and exponential-average overlay traces (independently toggleable)
- Configurable decay time constant in frames (`decay_tau_frames`, 0 = infinite hold)
- Single `trace_color` setting with opacity-differentiated traces (max α=0.9, avg α=0.7, min α=0.5)
- Frequency axis with SI-prefix auto-formatting (Hz/kHz/MHz)
  <img width="514" height="358" alt="image" src="https://github.com/user-attachments/assets/78045110-b1ca-49da-a010-e0d0f35548d7" />


**SpectrumDensity** — 2D persistence / eye-diagram display
- GPU-accelerated histogram via ping-pong R32F FBOs + colormap shader pass
- Automatic CPU fallback when `EXT_color_buffer_float` is unavailable
- Configurable amplitude bins (4–1024, default 256) and exponential histogram decay
- Adaptive Y-range rebinning on user zoom
- Optional current-spectrum overlay line plus max/min/average traces
- Runtime `gpu_acceleration` toggle
  <img width="514" height="358" alt="image" src="https://github.com/user-attachments/assets/546994cb-d977-4297-bb38-41b627dc868e" />



**WaterfallPlot** — scrolling spectrogram
- GPU ring-buffer texture with `GL_REPEAT` wrapping — single-row `glTexSubImage2D` upload per frame
- CPU fallback via `PlotHeatmap` when GPU texture unavailable
- Configurable history depth (16–4096 rows), runtime-adjustable with data preservation
- Auto-scaling colour range with smooth IIR tracking (α=0.05), or manual Z-axis override via dashboard config
- Configurable Y-axis scale: relative time (default, newest-at-top), absolute UTC, or linear offset
- ImPlot colormap selection (Viridis, Plasma, Hot, etc.)
  <img width="514" height="358" alt="image" src="https://github.com/user-attachments/assets/517fdd23-5450-43d2-85f3-468e8c9846dc" />


**SpectrumView** — composite spectrum + waterfall display
- Vertically stacked subplots: top pane (switchable) + bottom pane (waterfall)
- Top pane mode toggle: Spectrum (line traces) ↔ Density (2D histogram) — instant switching, no data loss
- Synchronised X-axis zoom/pan via `ImPlot::BeginSubplots` with `LinkCols | LinkAllX`
- Configurable pane height ratio (0.2–0.8) with ImPlot's native draggable splitter
- Context menu and legend on top pane only; waterfall pane accepts drag-drop but no duplicate menu
  <img width="250" height="300" alt="image" src="https://github.com/user-attachments/assets/f8659774-5196-46b7-b068-a1567e9a2a42" /><img width="250" height="300" alt="image" src="https://github.com/user-attachments/assets/ec22bac4-a4a3-45d3-8059-122b08c5f835" />


## Test infrastructure

**TestSpectrumGenerator** — synthetic spectrum source block
- GR4 source block (`PortIn<uint8_t>` clock tick → `PortOut<DataSet<T>>` spectrum), template on float/double
- Signal features (independently toggleable): white noise floor, Schottky beam peak (Gaussian with cycling width/centre), 3 interference lines, triangle-wave sweep
- Deterministic seeding for reproducible test output
- Wired into DemoDashboard via `ClockSource` at 25 Hz

## Supporting infrastructure

- `ShaderHelper.hpp` — reusable GLES3/GL3.3 shader utilities (`compileShader`, `linkProgram`, `createR32FTexture`, `attachFBO`, `supportsR32FFBO`) with platform-aware GLSL prefix
- `Xoshiro256pp.hpp` — fast deterministic PRNG for test source
- Emscripten CMake: `-sFULL_ES2=1` → `-sFULL_ES3=1` for R32F FBO support

## Open Items
 * visual chart tests are missing and part of https://github.com/fair-acc/opendigitizer/issues/204
 

## DemoDashboard

![Peek 2026-02-12 17-17](https://github.com/user-attachments/assets/0bde312d-8b83-4309-a1f6-d1e300bc2e05)
