### PR TITLE
Fix CI: remove stale Picoscope APT repo before apt-get update

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -59,8 +59,9 @@ jobs:
     - name: Install image comparing tools
       shell: bash
       run: |
-        sudo apt update
-        sudo apt-get -y install imagemagick || true # needed because of packaging errors in the picoscope dpkgs
+        sudo rm -f /etc/apt/sources.list.d/picoscope* || true
+        sudo apt-get update
+        sudo apt-get -y install imagemagick || true
 
     - name: Configure CMake
       shell: bash
@@ -80,7 +81,7 @@ jobs:
         cmake --build ../build
 
     - name: Install Xvfb
-      run: ( sudo apt-get update && sudo apt-get install -y xvfb || true )
+      run: sudo apt-get install -y xvfb || true
 
     - name: execute tests
       if: matrix.configurations.compiler != 'gcc-14' || matrix.cmake-build-type != 'Debug'


### PR DESCRIPTION
The build container's Picoscope RC repo was re-signed with an unpublished key, causing `apt update` to fail with exit code 100. Since the picoscope libraries are already installed in the container image, remove the broken repo source before updating package lists.

See also: https://github.com/fair-acc/gr-digitizers/pull/195