### PR TITLE
Add view-only mode, misc UX improvements

### DIFF
--- a/src/ui/App.hpp
+++ b/src/ui/App.hpp
@@ -12,6 +12,7 @@
 
 #include "components/AppHeader.hpp"
 #include "components/Toolbar.hpp"
+#include "components/YesNoPopup.hpp"
 
 #include "Dashboard.hpp"
 #include "DashboardPage.hpp"
@@ -52,8 +53,8 @@ public:
     OpenDashboardPage openDashboardPage;
 
     std::atomic<bool> isRunning        = true;
-    ViewMode          mainViewMode     = ViewMode::VIEW;
-    ViewMode          previousViewMode = ViewMode::VIEW;
+    ViewMode          mainViewMode     = ViewMode::INTERACTION;
+    ViewMode          previousViewMode = ViewMode::INTERACTION;
 
     std::vector<gr::BlockModel*> toolbarBlocks;
 
@@ -213,9 +214,33 @@ public:
         }
     }
 
+    [[nodiscard]] bool viewModeReturnIsExitRequested() const noexcept {
+        const ImRect buttonArea{{}, ImGui::GetMainViewport()->Size};
+        ImGui::SetNextWindowSize(buttonArea.GetSize());
+        ImGui::SetNextWindowPos(buttonArea.GetTL());
+        IMW::Window window("coveringWindow", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoScrollbar);
+        const auto  unlockPopupID = "Unlock the dashboard?##lockModeDisableInputBlockerPopup";
+        ImGui::BringWindowToDisplayFront(ImGui::GetCurrentWindow());
+        ImGui::SetCursorScreenPos({});
+        if (ImGui::InvisibleButton("inputBlocker", buttonArea.GetSize()) || (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Right))) {
+            ImGui::OpenPopup(unlockPopupID);
+        }
+
+        bool exitRequested = false;
+        using namespace components;
+        if (const auto popup = beginYesNoPopup(unlockPopupID); isPopupOpen(popup)) {
+            ImGui::BringWindowToDisplayFront(ImGui::GetCurrentWindow());
+            if (isPopupConfirmed(popup)) {
+                exitRequested = true;
+            }
+            ImGui::EndPopup();
+        }
+        return exitRequested;
+    }
+
     void processAndRender() {
         {
-            IMW::Window window("Main Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus);
+            IMW::Window window("Main Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoScrollWithMouse);
 
             const char* title = prepareForANewDashboardToLoad ? "Loading..." : dashboard ? dashboard->description->name.data() : "OpenDigitizer";
             header.draw(title, LookAndFeel::instance().fontLarge[LookAndFeel::instance().prototypeMode], LookAndFeel::instance().style);
@@ -248,6 +273,7 @@ public:
                     dashboardPage   = std::make_unique<DashboardPage>();
                     dashboardPage->setDashboard(*dashboard.get());
                     dashboardPage->setLayoutType(loadedDashboard->layout);
+                    dashboardPage->setRequestViewOnlyModeHandler([this] { mainViewMode = ViewMode::VIEW; });
                     flowgraphPage.reset();
                 }
             }
@@ -280,6 +306,10 @@ public:
                 auto msg = std::format("unknown view mode {}", static_cast<int>(mainViewMode));
                 components::Notification::warning(msg);
             }
+        }
+
+        if (mainViewMode == ViewMode::VIEW && this->viewModeReturnIsExitRequested()) {
+            mainViewMode = ViewMode::INTERACTION;
         }
 
         previousViewMode = mainViewMode;

--- a/src/ui/App.hpp
+++ b/src/ui/App.hpp
@@ -145,6 +145,8 @@ public:
         }
         LookAndFeel::mutableInstance().style = style;
 
+        ImGui::GetStyle().Colors[ImGuiCol_WindowBg].w = 1.f;
+
         // with the dark style the plot frame would have the same color as a button. make it have the
         // same color as the window background instead.
         ImPlot::GetStyle().Colors[ImPlotCol_FrameBg] = ImGui::GetStyle().Colors[ImGuiCol_WindowBg];

--- a/src/ui/App.hpp
+++ b/src/ui/App.hpp
@@ -274,6 +274,7 @@ public:
                     dashboardPage->setDashboard(*dashboard.get());
                     dashboardPage->setLayoutType(loadedDashboard->layout);
                     dashboardPage->setRequestViewOnlyModeHandler([this] { mainViewMode = ViewMode::VIEW; });
+                    dashboardPage->setRequestSetLayoutModeHandler([this](bool isLayout) { mainViewMode = isLayout ? ViewMode::LAYOUT : ViewMode::INTERACTION; });
                     flowgraphPage.reset();
                 }
             }

--- a/src/ui/App.hpp
+++ b/src/ui/App.hpp
@@ -69,7 +69,14 @@ public:
     components::AppHeader header;
 
 public:
-    App() : flowgraphPage(restClient), openDashboardPage(restClient) { setStyle(Digitizer::Settings::instance().darkMode ? LookAndFeel::Style::Dark : LookAndFeel::Style::Light); }
+    App() : flowgraphPage(restClient), openDashboardPage(restClient) {
+        setStyle(Digitizer::Settings::instance().darkMode ? LookAndFeel::Style::Dark : LookAndFeel::Style::Light);
+        if (!Digitizer::Settings::instance().editableMode) {
+            // the exit-view-mode button will also check and be disabled in this case so things are fully non-editable
+            mainViewMode     = ViewMode::VIEW;
+            previousViewMode = ViewMode::VIEW;
+        }
+    }
 
     void openNewWindow() {
 #ifdef EMSCRIPTEN
@@ -216,15 +223,14 @@ public:
         }
     }
 
-    [[nodiscard]] bool viewModeReturnIsExitRequested() const noexcept {
-        const ImRect buttonArea{{}, ImGui::GetMainViewport()->Size};
+    [[nodiscard]] bool viewModeReturnIsExitRequested(float startHeight) const noexcept {
+        const ImRect buttonArea{{0, startHeight}, ImGui::GetMainViewport()->Size};
         ImGui::SetNextWindowSize(buttonArea.GetSize());
         ImGui::SetNextWindowPos(buttonArea.GetTL());
         IMW::Window window("coveringWindow", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoScrollbar);
         const auto  unlockPopupID = "Unlock the dashboard?##lockModeDisableInputBlockerPopup";
-        ImGui::BringWindowToDisplayFront(ImGui::GetCurrentWindow());
-        ImGui::SetCursorScreenPos({});
-        if (ImGui::InvisibleButton("inputBlocker", buttonArea.GetSize()) || (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Right))) {
+        ImGui::SetCursorScreenPos(buttonArea.GetTL());
+        if ((ImGui::InvisibleButton("inputBlocker", buttonArea.GetSize()) || (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Right))) && Digitizer::Settings::instance().editableMode) {
             ImGui::OpenPopup(unlockPopupID);
         }
 
@@ -246,6 +252,8 @@ public:
 
             const char* title = prepareForANewDashboardToLoad ? "Loading..." : dashboard ? dashboard->description->name.data() : "OpenDigitizer";
             header.draw(title, LookAndFeel::instance().fontLarge[LookAndFeel::instance().prototypeMode], LookAndFeel::instance().style);
+
+            const float lockedModeBlockerStart = ImGui::GetCursorScreenPos().y;
 
             if (prepareForANewDashboardToLoad) {
                 prepareForANewDashboardToLoad = false;
@@ -309,10 +317,10 @@ public:
                 auto msg = std::format("unknown view mode {}", static_cast<int>(mainViewMode));
                 components::Notification::warning(msg);
             }
-        }
 
-        if (mainViewMode == ViewMode::VIEW && this->viewModeReturnIsExitRequested()) {
-            mainViewMode = ViewMode::INTERACTION;
+            if (mainViewMode == ViewMode::VIEW && this->viewModeReturnIsExitRequested(lockedModeBlockerStart)) {
+                mainViewMode = ViewMode::INTERACTION;
+            }
         }
 
         previousViewMode = mainViewMode;

--- a/src/ui/App.hpp
+++ b/src/ui/App.hpp
@@ -252,9 +252,18 @@ public:
                 }
             }
 
-            if (mainViewMode == ViewMode::VIEW || mainViewMode == ViewMode::LAYOUT) {
+            if (mainViewMode == ViewMode::VIEW || mainViewMode == ViewMode::INTERACTION || mainViewMode == ViewMode::LAYOUT) {
                 if (dashboard != nullptr && dashboard->isInitialised) {
-                    dashboardPage->draw(mainViewMode == ViewMode::VIEW ? DashboardPage::Mode::View : DashboardPage::Mode::Layout);
+                    const auto mode = [&] {
+                        using enum DashboardPage::Mode;
+                        switch (mainViewMode) {
+                        case ViewMode::VIEW: return View;
+                        case ViewMode::INTERACTION: return Interaction;
+                        case ViewMode::LAYOUT: return Layout;
+                        default: assert(false); return View;
+                        }
+                    }();
+                    dashboardPage->draw(mode);
                 }
             } else if (mainViewMode == ViewMode::FLOWGRAPH) {
                 if (dashboard != nullptr && dashboard->isInitialised) {

--- a/src/ui/App.hpp
+++ b/src/ui/App.hpp
@@ -152,7 +152,7 @@ public:
 
     void setStyle(LookAndFeel::Style style) {
         setImGuiStyle(style);
-        flowgraphPage.setStyle(style);
+        flowgraphPage.updateStyle();
     }
 
     void init(int argc, char** argv) {

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -210,6 +210,7 @@ add_library(
   components/Splitter.cpp
   components/Splitter.hpp
   components/Toolbar.hpp
+  components/YesNoPopup.hpp
   utils/stb_impl.cpp # STB is a library with linking issues -- impl instantiated only here
   common/AppDefinitions.hpp
   common/Events.hpp

--- a/src/ui/Dashboard.cpp
+++ b/src/ui/Dashboard.cpp
@@ -604,7 +604,7 @@ void Dashboard::save() {
     }
 }
 
-DigitizerUi::Dashboard::UIWindow& Dashboard::newUIBlock(int x, int y, int w, int h, std::string_view chartType) {
+DigitizerUi::Dashboard::UIWindow& Dashboard::newUIBlock(int x, int y, int w, int h, std::string_view chartType, const gr::property_map& chartInitialParameters) {
     std::string chartTypeName = chartType.empty() ? "XYChart" : std::string(chartType);
 
     // Generate a unique name for the chart
@@ -612,7 +612,7 @@ DigitizerUi::Dashboard::UIWindow& Dashboard::newUIBlock(int x, int y, int w, int
     std::string chartName    = std::format("Chart {}", chartCounter++);
 
     // Create chart block in UI Graph
-    auto* blockPtr = emplaceChartBlock(chartTypeName, chartName);
+    auto* blockPtr = emplaceChartBlock(chartTypeName, chartName, chartInitialParameters);
 
     if (!blockPtr) {
         // Return a reference to an empty UIWindow on failure (shouldn't happen with known types)

--- a/src/ui/Dashboard.hpp
+++ b/src/ui/Dashboard.hpp
@@ -152,7 +152,7 @@ struct Dashboard {
     void save();
     void doLoad(const gr::property_map& dashboard);
 
-    UIWindow& newUIBlock(int x, int y, int w, int h, std::string_view chartType = "XYChart");
+    UIWindow& newUIBlock(int x, int y, int w, int h, std::string_view chartType = "XYChart", const gr::property_map& chartInitialParameters = {});
     void      deleteChart(UIWindow* uiWindow);
     UIWindow* copyChart(std::string_view sourceChartId);
     bool      transmuteUIWindow(UIWindow& uiWindow, std::string_view newChartType);

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -171,12 +171,25 @@ void DashboardPage::draw(Mode mode) noexcept {
         // Legend
         {
             IMW::Group group;
-            // Button strip
-            if (mode == Mode::Layout) {
+
+            if (mode != Mode::View) {
+                namespace dnd = opendigitizer::charts::dnd;
                 if (plotButton("\uF201", "create new chart")) {
                     _showNewPlotModal = true;
+                    _sinkForNewPlot   = {};
                 }
+                const bool dropped = dnd::handleDropTarget(
+                    [this](const dnd::Payload& payload) {
+                        _sinkForNewPlot = payload.sink_name;
+                        return true;
+                    },
+                    dnd::kPayloadType);
+                _showNewPlotModal = _showNewPlotModal || dropped;
                 ImGui::SameLine();
+            }
+
+            // Button strip
+            if (mode == Mode::Layout) {
                 if (plotButton("\uF7A5", "change to the horizontal layout")) {
                     _dockSpace.setLayoutType(DockingLayoutType::Row);
                 }
@@ -330,9 +343,13 @@ void DashboardPage::draw(Mode mode) noexcept {
     drawNewPlotModal();
 }
 
-DigitizerUi::Dashboard::UIWindow* DashboardPage::newUIBlock(std::string_view chartType) {
+DigitizerUi::Dashboard::UIWindow* DashboardPage::newUIBlock(std::string_view chartType, std::string_view initialSignal) {
     if (_dashboard->uiWindows.size() < kMaxPlots) {
-        return std::addressof(_dashboard->newUIBlock(0, 0, 1, 1, chartType));
+        gr::property_map chartInitialParameters;
+        if (!initialSignal.empty()) {
+            chartInitialParameters["data_sinks"] = gr::Tensor<gr::pmt::Value>{initialSignal};
+        }
+        return std::addressof(_dashboard->newUIBlock(0, 0, 1, 1, chartType, chartInitialParameters));
     }
     return nullptr;
 }
@@ -365,7 +382,7 @@ void DashboardPage::drawNewPlotModal() {
         ImGui::Separator();
 
         if (ImGui::Button("Create", ImVec2(120, 0))) {
-            newUIBlock(_selectedChartType);
+            newUIBlock(_selectedChartType, _sinkForNewPlot);
             _showNewPlotModal = false;
             ImGui::CloseCurrentPopup();
         }

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -154,7 +154,7 @@ void DashboardPage::draw(Mode mode) noexcept {
                 // Capture shared_ptr by value to ensure block stays alive during render
                 uiWindow.window->renderFunc = [this, block = blockPtr, mode] {
                     gr::property_map drawConfig;
-                    drawConfig["layoutMode"] = (mode == Mode::Layout);
+                    drawConfig["chartMode"] = magic_enum::enum_name(mode);
                     block->draw(drawConfig);
                 };
 
@@ -223,7 +223,7 @@ void DashboardPage::draw(Mode mode) noexcept {
                                 _editPane.closeTime = std::chrono::system_clock::now() + LookAndFeel::instance().editPaneCloseDelay;
                             }
                         });
-                        legendBlock->setDragDropEnabled(mode != Mode::Layout);
+                        legendBlock->setDragDropEnabled(mode == Mode::Interaction);
                     }
 
                     // Draw the toolbar block
@@ -243,7 +243,7 @@ void DashboardPage::draw(Mode mode) noexcept {
 
             if (_dashboard && _remoteSignalSelector) {
                 // Post button strip
-                if (mode == Mode::View) {
+                if (mode == Mode::Interaction) {
                     ImGui::SameLine();
                     if (plotButton("\uf067", "add signal")) {
                         // 'plus' button in the global legend, adds a new signal

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -188,32 +188,32 @@ void DashboardPage::draw(Mode mode) noexcept {
                 ImGui::SameLine();
             }
 
-            // Button strip
+            // Render Toolbar blocks (legend, layout buttons, etc.) - centre-aligned
+            alignForWidth(std::max(10.f, _legendBox.x), 0.5f);
+            _legendBox.x = 0.f;
             if (mode == Mode::Layout) {
-                if (plotButton("\uF7A5", "change to the horizontal layout")) {
-                    _dockSpace.setLayoutType(DockingLayoutType::Row);
+                {
+                    IMW::Group layout;
+                    if (plotButton("\uF7A5", "change to the horizontal layout")) {
+                        _dockSpace.setLayoutType(DockingLayoutType::Row);
+                    }
+                    ImGui::SameLine();
+                    if (plotButton("\uF7A4", "change to the vertical layout")) {
+                        _dockSpace.setLayoutType(DockingLayoutType::Column);
+                    }
+                    ImGui::SameLine();
+                    if (plotButton("\uF58D", "change to the grid layout")) {
+                        _dockSpace.setLayoutType(DockingLayoutType::Grid);
+                    }
+                    ImGui::SameLine();
+                    if (plotButton("\uF248", "change to the free layout")) {
+                        _dockSpace.setLayoutType(DockingLayoutType::Free);
+                    }
+                    ImGui::SameLine();
                 }
-                ImGui::SameLine();
-                if (plotButton("\uF7A4", "change to the vertical layout")) {
-                    _dockSpace.setLayoutType(DockingLayoutType::Column);
-                }
-                ImGui::SameLine();
-                if (plotButton("\uF58D", "change to the grid layout")) {
-                    _dockSpace.setLayoutType(DockingLayoutType::Grid);
-                }
-                ImGui::SameLine();
-                if (plotButton("\uF248", "change to the free layout")) {
-                    _dockSpace.setLayoutType(DockingLayoutType::Free);
-                }
-                ImGui::SameLine();
-            }
-
-            // Render Toolbar blocks (legend, etc.) - centre-aligned
-            {
+                _legendBox.x = ImGui::GetItemRectSize().x;
+            } else {
                 static constexpr std::string_view kLegendBlockType = "DigitizerUi::GlobalSignalLegend";
-
-                alignForWidth(std::max(10.f, _legendBox.x), 0.5f);
-                _legendBox.x = 0.f;
 
                 ImVec2 totalSize{0.f, 0.f};
                 for (auto& blockPtr : _dashboard->uiGraph.blocks()) {

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -168,6 +168,16 @@ void DashboardPage::draw(Mode mode) noexcept {
         }
         ImGui::SetCursorPos(ImVec2(0, ImGui::GetWindowHeight() - _legendBox.y));
 
+        // quickfix for an imgui bug?: the SetCursorPos above does not seem to
+        // be sufficient for getting our cursor to return there after
+        // SameLine(). The issue is visible iff we do manual cursor
+        // manipulation (as the global signal legend does for the first color
+        // rect). So to make sure the first item draws at the same position as
+        // the succeeding ones after SameLine(), just insert a dummy size and
+        // do SameLine here, so the imgui context is in the same state as later
+        ImGui::ItemSize(ImVec2{}, 0.f);
+        ImGui::SameLine();
+
         // Legend
         {
             IMW::Group group;

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -105,11 +105,15 @@ ImVec2 DashboardPage::drawCharts(Mode mode) noexcept {
     if (mode == Mode::Layout) {
         const uint32_t gridLineColor = LookAndFeel::instance().style == LookAndFeel::Style::Light ? 0x40000000 : 0x40ffffff;
         auto           pos           = ImGui::GetCursorScreenPos();
-        for (float x = pos.x; x < pos.x + paneSize.x; x += w) {
+        float          x             = pos.x;
+        while (x < pos.x + paneSize.x) {
             ImGui::GetWindowDrawList()->AddLine({x, pos.y}, {x, pos.y + paneSize.y}, gridLineColor);
+            x += w;
         }
-        for (float y = pos.y; y < pos.y + paneSize.y; y += h) {
+        float y = pos.y;
+        while (y < pos.y + paneSize.y) {
             ImGui::GetWindowDrawList()->AddLine({pos.x, y}, {pos.x + paneSize.x, y}, gridLineColor);
+            y += w;
         }
     }
 

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -28,11 +28,16 @@ constexpr inline auto kGridWidth  = 16u;
 constexpr inline auto kGridHeight = 16u;
 } // namespace
 
-static bool plotButton(const char* glyph, const char* tooltip, float buttonSize) noexcept {
+static bool plotButton(const char* glyph, const char* tooltip, float buttonSize, bool transparentInactiveBg = false) noexcept {
     const bool ret = [&] {
-        IMW::StyleColor normal(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
-        IMW::StyleColor hovered(ImGuiCol_ButtonHovered, ImVec4(0, 0, 0, 0.1f));
-        IMW::StyleColor active(ImGuiCol_ButtonActive, ImVec4(0, 0, 0, 0.2f));
+        auto bgColor = LookAndFeel::instance().palette().mainWindowButtonBgInactive;
+        if (transparentInactiveBg) {
+            bgColor.w = 0.0f;
+        }
+        IMW::StyleColor buttonStyle(ImGuiCol_Button, bgColor);
+        IMW::StyleColor textStyle(ImGuiCol_Text, LookAndFeel::instance().palette().mainWindowButtonIcon);
+        IMW::StyleColor buttonActiveStyle(ImGuiCol_ButtonActive, LookAndFeel::instance().palette().mainWindowButtonBgActive);
+        IMW::StyleColor buttonHoveredStyle(ImGuiCol_ButtonHovered, LookAndFeel::instance().palette().mainWindowButtonBgHovered);
         IMW::Font       font(LookAndFeel::instance().fontIconsSolidLarge);
         return ImGui::Button(glyph, {buttonSize, buttonSize});
     }();
@@ -103,7 +108,7 @@ ImVec2 DashboardPage::drawCharts(Mode mode) noexcept {
 
     // Draw layout grid in Layout mode
     if (mode == Mode::Layout) {
-        const uint32_t gridLineColor = LookAndFeel::instance().style == LookAndFeel::Style::Light ? 0x40000000 : 0x40ffffff;
+        const uint32_t gridLineColor = ImGui::ColorConvertFloat4ToU32(LookAndFeel::instance().palette().gridLines);
         auto           pos           = ImGui::GetCursorScreenPos();
         float          x             = pos.x;
         while (x < pos.x + paneSize.x) {
@@ -296,7 +301,7 @@ DashboardPage::LegendItemClickResult DashboardPage::drawLegend(Mode mode, ImVec2
 
     if (mode == Mode::Interaction && _dashboard && _remoteSignalSelector) {
         ImGui::SameLine();
-        if (plotButton("\u{F067}", "add signal", plotButtonSize)) {
+        if (plotButton("\u{F067}", "add signal", plotButtonSize, true)) {
             // 'plus' button in the global legend, adds a new signal
             // to the dashboard
             _remoteSignalSelector->open();

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -11,6 +11,7 @@
 #include "common/LookAndFeel.hpp"
 
 #include "components/Splitter.hpp"
+#include "components/YesNoPopup.hpp"
 
 #include "blocks/GlobalSignalLegend.hpp"
 #include "blocks/ImPlotSink.hpp"
@@ -91,6 +92,240 @@ DashboardPage::DashboardPage() {
 
 DashboardPage::~DashboardPage() { opendigitizer::charts::SinkRegistry::instance().removeListener(this); }
 
+ImVec2 DashboardPage::drawCharts(Mode mode) noexcept {
+    IMW::Group group;
+
+    ImVec2 paneSize = ImGui::GetContentRegionAvail();
+    paneSize.y -= _legendBox.y;
+
+    const float w = paneSize.x / float(kGridWidth);
+    const float h = paneSize.y / float(kGridHeight);
+
+    // Draw layout grid in Layout mode
+    if (mode == Mode::Layout) {
+        const uint32_t gridLineColor = LookAndFeel::instance().style == LookAndFeel::Style::Light ? 0x40000000 : 0x40ffffff;
+        auto           pos           = ImGui::GetCursorScreenPos();
+        for (float x = pos.x; x < pos.x + paneSize.x; x += w) {
+            ImGui::GetWindowDrawList()->AddLine({x, pos.y}, {x, pos.y + paneSize.y}, gridLineColor);
+        }
+        for (float y = pos.y; y < pos.y + paneSize.y; y += h) {
+            ImGui::GetWindowDrawList()->AddLine({pos.x, y}, {pos.x + paneSize.x, y}, gridLineColor);
+        }
+    }
+
+    DockSpace::Windows windows;
+
+    // Iterate uiGraph blocks filtered by ChartPane category
+    for (auto& blockPtr : _dashboard->uiGraph.blocks()) {
+        if (blockPtr->uiCategory() != gr::UICategory::Content) {
+            continue;
+        }
+
+        // Get or create UIWindow for this block (lazy creation)
+        auto& uiWindow = _dashboard->getOrCreateUIWindow(blockPtr);
+        if (!uiWindow.window) {
+            continue;
+        }
+
+        windows.push_back(uiWindow.window);
+        // Capture shared_ptr by value to ensure block stays alive during render
+        uiWindow.window->renderFunc = [this, block = blockPtr, mode] {
+            gr::property_map drawConfig;
+            drawConfig["chartMode"] = magic_enum::enum_name(mode);
+            block->draw(drawConfig);
+        };
+
+        uiWindow.window->renderDockingContextMenuFunc = [block = blockPtr] {
+            opendigitizer::charts::drawDuplicateChartMenuItem(block->uniqueName());
+            opendigitizer::charts::drawRemoveChartMenuItem(block->uniqueName());
+        };
+    }
+
+    _dockSpace.render(windows, paneSize, mode == Mode::Layout);
+    return paneSize;
+}
+
+void DashboardPage::drawToolbarLayoutButtons(float plotButtonSize) noexcept {
+    using enum DigitizerUi::DockingLayoutType;
+    IMW::Group layout;
+    if (plotButton("\u{F7A5}", "change to the horizontal layout", plotButtonSize)) {
+        _dockSpace.setLayoutType(Row);
+    }
+    ImGui::SameLine();
+    if (plotButton("\u{F7A4}", "change to the vertical layout", plotButtonSize)) {
+        _dockSpace.setLayoutType(Column);
+    }
+    ImGui::SameLine();
+    if (plotButton("\u{F58D}", "change to the grid layout", plotButtonSize)) {
+        _dockSpace.setLayoutType(Grid);
+    }
+    ImGui::SameLine();
+    if (plotButton("\u{F248}", "change to the free layout", plotButtonSize)) {
+        _dockSpace.setLayoutType(Free);
+    }
+    ImGui::SameLine();
+}
+
+ImVec2 DashboardPage::drawLegendCenter(Mode mode, ImVec2 chartPaneSize) noexcept {
+    static constexpr std::string_view kLegendBlockType = "DigitizerUi::GlobalSignalLegend";
+
+    ImVec2 totalSize{0.f, 0.f};
+    for (auto& blockPtr : _dashboard->uiGraph.blocks()) {
+        if (blockPtr->uiCategory() != gr::UICategory::Toolbar) {
+            continue;
+        }
+
+        // Configure GlobalSignalLegend before drawing
+        const bool isLegendBlock = (blockPtr->typeName() == kLegendBlockType);
+        if (isLegendBlock) {
+            auto* legendBlock = static_cast<GlobalSignalLegend*>(blockPtr->raw());
+            legendBlock->setPaneWidth(chartPaneSize.x);
+            legendBlock->setRightClickCallback([this, mode](std::string_view sinkUniqueName) {
+                if (mode == Mode::Layout) {
+                    return;
+                }
+                auto found = _dashboard->graphModel.recursiveFindBlockByUniqueName(std::string(sinkUniqueName));
+                if (found) {
+                    _editPane.setSelectedBlock(found.block, std::addressof(_dashboard->graphModel));
+                    _editPane.closeTime = std::chrono::system_clock::now() + LookAndFeel::instance().editPaneCloseDelay;
+                }
+            });
+            legendBlock->setDragDropEnabled(mode == Mode::Interaction);
+        }
+
+        // Draw the toolbar block
+        gr::property_map drawConfig;
+        drawConfig["paneWidth"] = chartPaneSize.x;
+        blockPtr->draw(drawConfig);
+
+        // Track legend size
+        if (isLegendBlock) {
+            auto* legendBlock = static_cast<GlobalSignalLegend*>(blockPtr->raw());
+            totalSize         = legendBlock->legendSize();
+        }
+    }
+    return totalSize;
+}
+
+void DashboardPage::addSelectedRemoteSignal(const SignalData& selectedRemoteSignal) noexcept {
+    const auto& uriStr_           = selectedRemoteSignal.uri();
+    _addingRemoteSignals[uriStr_] = selectedRemoteSignal;
+
+    _dashboard->addRemoteSignal(selectedRemoteSignal);
+
+    opendigitizer::RemoteSourceManager::instance().setRemoteSourceAddedCallback(uriStr_, [this, selectedRemoteSignal](opendigitizer::RemoteSourceModel& remoteSource) {
+        const auto& uriStr = selectedRemoteSignal.uri();
+        // Switching state for the signal -- from "adding the source block"
+        // to "waiting for sink block to be created"
+        _addedSourceBlocksWaitingForSink[uriStr] = SourceBlockInWaiting{
+            .signalData      = std::move(_addingRemoteSignals[uriStr]), //
+            .sourceBlockName = remoteSource.uniqueName()                //
+        };
+        _addingRemoteSignals.erase(uriStr);
+
+        // Can be opendigitizer::RemoteStreamSource<float32> or opendigitizer::RemoteDataSetSource<float32>
+        // for the time being, but let's support double (float64) out of the box as well
+        const std::string remoteSourceType = remoteSource.typeName();
+
+        auto                   it = std::ranges::find(remoteSourceType, '<');
+        const std::string_view remoteSourceBaseType(remoteSourceType.begin(), it);
+        const std::string_view remoteSourceTypeParams(it, remoteSourceType.end());
+
+        std::string sinkBlockType   = "opendigitizer::ImPlotSink";
+        std::string sinkBlockParams =                                                                                                             //
+            (remoteSourceBaseType == "opendigitizer::RemoteStreamSource" && remoteSourceTypeParams == "<float32>")    ? "<float32>"s              //
+            : (remoteSourceBaseType == "opendigitizer::RemoteStreamSource" && remoteSourceTypeParams == "<float64>")  ? "<float64>"s              //
+            : (remoteSourceBaseType == "opendigitizer::RemoteDataSetSource" && remoteSourceTypeParams == "<float32>") ? "<gr::DataSet<float32>>"s //
+            : (remoteSourceBaseType == "opendigitizer::RemoteDataSetSource" && remoteSourceTypeParams == "<float64>") ? "<gr::DataSet<float64>>"s //
+                                                                                                                      : /* otherwise error */ ""s;
+
+        gr::Message message;
+        message.cmd      = gr::message::Command::Set;
+        message.endpoint = gr::scheduler::property::kEmplaceBlock;
+        // The root block needs to be a scheduler
+        message.serviceName = _dashboard->graphModel.rootBlock.ownerSchedulerUniqueName();
+        message.data        = gr::property_map{
+                   {"type", sinkBlockType + sinkBlockParams}, //
+                   {
+                "properties",
+                gr::property_map{
+                           {"signal_name", selectedRemoteSignal.signalName}, //
+                           {"signal_unit", selectedRemoteSignal.unit}        //
+                } //
+            } //
+        };
+        _dashboard->graphModel.sendMessage(std::move(message));
+    });
+}
+
+DashboardPage::LegendItemClickResult DashboardPage::drawLegend(Mode mode, ImVec2 chartPaneSize) noexcept {
+    IMW::Group group;
+
+    LegendItemClickResult clickResult;
+
+    const float plotButtonSize = 40.f;
+
+    if (mode != Mode::View) {
+        namespace dnd = opendigitizer::charts::dnd;
+        if (plotButton("\u{F201}", "create new chart", plotButtonSize)) {
+            clickResult.shouldOpenNewPlotModal = true;
+        }
+        const bool dropped = dnd::handleDropTarget(
+            [&clickResult](const dnd::Payload& payload) {
+                clickResult.sinkForNewPlot = payload.sink_name;
+                return true;
+            },
+            dnd::kPayloadType);
+        clickResult.shouldOpenNewPlotModal = clickResult.shouldOpenNewPlotModal || dropped;
+        ImGui::SameLine();
+    }
+
+    // Render Toolbar blocks (legend, layout buttons, etc.) - centre-aligned
+    alignForWidth(std::max(10.f, _legendBox.x), 0.5f);
+    _legendBox.x = 0.f;
+    if (mode == Mode::Layout) {
+        this->drawToolbarLayoutButtons(plotButtonSize);
+        _legendBox = ImGui::GetItemRectSize();
+    } else {
+        _legendBox = this->drawLegendCenter(mode, chartPaneSize);
+    }
+
+    if (mode == Mode::Interaction && _dashboard && _remoteSignalSelector) {
+        ImGui::SameLine();
+        if (plotButton("\u{F067}", "add signal", plotButtonSize)) {
+            // 'plus' button in the global legend, adds a new signal
+            // to the dashboard
+            _remoteSignalSelector->open();
+        }
+
+        for (const auto& selectedRemoteSignal : _remoteSignalSelector->drawAndReturnSelected()) {
+            this->addSelectedRemoteSignal(selectedRemoteSignal);
+        }
+    }
+
+    ImGui::SameLine();
+    alignForWidth(plotButtonSize, 1.0);
+    const float cursorBeforeLockButton = ImGui::GetCursorPosX();
+    if (mode == Mode::Interaction && plotButton("\uF023", "Lock the dashboard", plotButtonSize)) {
+        clickResult.shouldOpenEnterViewOnlyModeModal = true;
+    }
+
+    if (LookAndFeel::instance().prototypeMode) {
+        ImGui::SameLine();
+        // Retrieve FPS and milliseconds per iteration
+        const float fps     = ImGui::GetIO().Framerate;
+        const auto  str     = std::format("FPS:{:5.0f}({:2}ms)", fps, LookAndFeel::instance().execTime.count());
+        const auto  estSize = ImGui::CalcTextSize(str.c_str());
+        ImGui::SetCursorPosX(cursorBeforeLockButton - estSize.x - ImGui::GetStyle().ItemSpacing.x);
+        ImGui::Text("%s", str.c_str());
+    }
+    ImGui::Dummy(ImVec2(0.f, 0.f));
+
+    _legendBox.y = std::max(_legendBox.y, plotButtonSize);
+
+    return clickResult;
+}
+
 void DashboardPage::draw(Mode mode) noexcept {
     processPendingTransmutation();
     processPendingRemovals();
@@ -107,6 +342,7 @@ void DashboardPage::draw(Mode mode) noexcept {
     ImGui::SetCursorPosX(left);
     ImGui::SetCursorPosY(top);
 
+    LegendItemClickResult legendClickResult;
     {
         IMW::Child plotsChild("##plots", horizontalSplit ? ImVec2(size.x * (1.f - ratio) - halfSplitterWidth, size.y) : ImVec2(size.x, size.y * (1.f - ratio) - halfSplitterWidth), false, ImGuiWindowFlags_NoScrollbar);
 
@@ -115,57 +351,7 @@ void DashboardPage::draw(Mode mode) noexcept {
         }
 
         // Render ChartPane blocks
-        {
-            IMW::Group group;
-
-            _paneSize = ImGui::GetContentRegionAvail();
-            _paneSize.y -= _legendBox.y;
-
-            const float w = _paneSize.x / float(kGridWidth);
-            const float h = _paneSize.y / float(kGridHeight);
-
-            // Draw layout grid in Layout mode
-            if (mode == Mode::Layout) {
-                const uint32_t gridLineColor = LookAndFeel::instance().style == LookAndFeel::Style::Light ? 0x40000000 : 0x40ffffff;
-                auto           pos           = ImGui::GetCursorScreenPos();
-                for (float x = pos.x; x < pos.x + _paneSize.x; x += w) {
-                    ImGui::GetWindowDrawList()->AddLine({x, pos.y}, {x, pos.y + _paneSize.y}, gridLineColor);
-                }
-                for (float y = pos.y; y < pos.y + _paneSize.y; y += h) {
-                    ImGui::GetWindowDrawList()->AddLine({pos.x, y}, {pos.x + _paneSize.x, y}, gridLineColor);
-                }
-            }
-
-            DockSpace::Windows windows;
-
-            // Iterate uiGraph blocks filtered by ChartPane category
-            for (auto& blockPtr : _dashboard->uiGraph.blocks()) {
-                if (blockPtr->uiCategory() != gr::UICategory::Content) {
-                    continue;
-                }
-
-                // Get or create UIWindow for this block (lazy creation)
-                auto& uiWindow = _dashboard->getOrCreateUIWindow(blockPtr);
-                if (!uiWindow.window) {
-                    continue;
-                }
-
-                windows.push_back(uiWindow.window);
-                // Capture shared_ptr by value to ensure block stays alive during render
-                uiWindow.window->renderFunc = [this, block = blockPtr, mode] {
-                    gr::property_map drawConfig;
-                    drawConfig["chartMode"] = magic_enum::enum_name(mode);
-                    block->draw(drawConfig);
-                };
-
-                uiWindow.window->renderDockingContextMenuFunc = [block = blockPtr] {
-                    opendigitizer::charts::drawDuplicateChartMenuItem(block->uniqueName());
-                    opendigitizer::charts::drawRemoveChartMenuItem(block->uniqueName());
-                };
-            }
-
-            _dockSpace.render(windows, _paneSize, mode == Mode::Layout);
-        }
+        const auto paneSize = this->drawCharts(mode);
         ImGui::SetCursorPos(ImVec2(0, ImGui::GetWindowHeight() - _legendBox.y));
 
         // quickfix for an imgui bug?: the SetCursorPos above does not seem to
@@ -178,169 +364,10 @@ void DashboardPage::draw(Mode mode) noexcept {
         ImGui::ItemSize(ImVec2{}, 0.f);
         ImGui::SameLine();
 
-        // Legend
-        {
-            IMW::Group group;
+        legendClickResult = this->drawLegend(mode, paneSize);
 
-            const float plotButtonSize = 40.f;
-
-            if (mode != Mode::View) {
-                namespace dnd = opendigitizer::charts::dnd;
-                if (plotButton("\uF201", "create new chart", plotButtonSize)) {
-                    _showNewPlotModal = true;
-                    _sinkForNewPlot   = {};
-                }
-                const bool dropped = dnd::handleDropTarget(
-                    [this](const dnd::Payload& payload) {
-                        _sinkForNewPlot = payload.sink_name;
-                        return true;
-                    },
-                    dnd::kPayloadType);
-                _showNewPlotModal = _showNewPlotModal || dropped;
-                ImGui::SameLine();
-            }
-
-            // Render Toolbar blocks (legend, layout buttons, etc.) - centre-aligned
-            alignForWidth(std::max(10.f, _legendBox.x), 0.5f);
-            _legendBox.x = 0.f;
-            if (mode == Mode::Layout) {
-                {
-                    IMW::Group layout;
-                    if (plotButton("\uF7A5", "change to the horizontal layout", plotButtonSize)) {
-                        _dockSpace.setLayoutType(DockingLayoutType::Row);
-                    }
-                    ImGui::SameLine();
-                    if (plotButton("\uF7A4", "change to the vertical layout", plotButtonSize)) {
-                        _dockSpace.setLayoutType(DockingLayoutType::Column);
-                    }
-                    ImGui::SameLine();
-                    if (plotButton("\uF58D", "change to the grid layout", plotButtonSize)) {
-                        _dockSpace.setLayoutType(DockingLayoutType::Grid);
-                    }
-                    ImGui::SameLine();
-                    if (plotButton("\uF248", "change to the free layout", plotButtonSize)) {
-                        _dockSpace.setLayoutType(DockingLayoutType::Free);
-                    }
-                    ImGui::SameLine();
-                }
-                _legendBox = ImGui::GetItemRectSize();
-            } else {
-                static constexpr std::string_view kLegendBlockType = "DigitizerUi::GlobalSignalLegend";
-
-                ImVec2 totalSize{0.f, 0.f};
-                for (auto& blockPtr : _dashboard->uiGraph.blocks()) {
-                    if (blockPtr->uiCategory() != gr::UICategory::Toolbar) {
-                        continue;
-                    }
-
-                    // Configure GlobalSignalLegend before drawing
-                    const bool isLegendBlock = (blockPtr->typeName() == kLegendBlockType);
-                    if (isLegendBlock) {
-                        auto* legendBlock = static_cast<GlobalSignalLegend*>(blockPtr->raw());
-                        legendBlock->setPaneWidth(_paneSize.x);
-                        legendBlock->setRightClickCallback([this, mode](std::string_view sinkUniqueName) {
-                            if (mode == Mode::Layout) {
-                                return;
-                            }
-                            auto found = _dashboard->graphModel.recursiveFindBlockByUniqueName(std::string(sinkUniqueName));
-                            if (found) {
-                                _editPane.setSelectedBlock(found.block, std::addressof(_dashboard->graphModel));
-                                _editPane.closeTime = std::chrono::system_clock::now() + LookAndFeel::instance().editPaneCloseDelay;
-                            }
-                        });
-                        legendBlock->setDragDropEnabled(mode == Mode::Interaction);
-                    }
-
-                    // Draw the toolbar block
-                    gr::property_map drawConfig;
-                    drawConfig["paneWidth"] = _paneSize.x;
-                    blockPtr->draw(drawConfig);
-
-                    // Track legend size
-                    if (isLegendBlock) {
-                        auto* legendBlock = static_cast<GlobalSignalLegend*>(blockPtr->raw());
-                        totalSize         = legendBlock->legendSize();
-                    }
-                }
-
-                _legendBox = totalSize;
-            }
-
-            if (_dashboard && _remoteSignalSelector) {
-                // Post button strip
-                if (mode == Mode::Interaction) {
-                    ImGui::SameLine();
-                    if (plotButton("\uf067", "add signal", plotButtonSize)) {
-                        // 'plus' button in the global legend, adds a new signal
-                        // to the dashboard
-                        _remoteSignalSelector->open();
-                    }
-
-                    for (const auto& selectedRemoteSignal : _remoteSignalSelector->drawAndReturnSelected()) {
-                        const auto& uriStr_           = selectedRemoteSignal.uri();
-                        _addingRemoteSignals[uriStr_] = selectedRemoteSignal;
-
-                        _dashboard->addRemoteSignal(selectedRemoteSignal);
-
-                        opendigitizer::RemoteSourceManager::instance().setRemoteSourceAddedCallback(uriStr_, [this, selectedRemoteSignal](opendigitizer::RemoteSourceModel& remoteSource) {
-                            const auto& uriStr = selectedRemoteSignal.uri();
-                            // Switching state for the signal -- from "adding the source block"
-                            // to "waiting for sink block to be created"
-                            _addedSourceBlocksWaitingForSink[uriStr] = SourceBlockInWaiting{
-                                .signalData      = std::move(_addingRemoteSignals[uriStr]), //
-                                .sourceBlockName = remoteSource.uniqueName()                //
-                            };
-                            _addingRemoteSignals.erase(uriStr);
-
-                            // Can be opendigitizer::RemoteStreamSource<float32> or opendigitizer::RemoteDataSetSource<float32>
-                            // for the time being, but let's support double (float64) out of the box as well
-                            const std::string remoteSourceType = remoteSource.typeName();
-
-                            auto                   it = std::ranges::find(remoteSourceType, '<');
-                            const std::string_view remoteSourceBaseType(remoteSourceType.begin(), it);
-                            const std::string_view remoteSourceTypeParams(it, remoteSourceType.end());
-
-                            std::string sinkBlockType   = "opendigitizer::ImPlotSink";
-                            std::string sinkBlockParams =                                                                                                             //
-                                (remoteSourceBaseType == "opendigitizer::RemoteStreamSource" && remoteSourceTypeParams == "<float32>")    ? "<float32>"s              //
-                                : (remoteSourceBaseType == "opendigitizer::RemoteStreamSource" && remoteSourceTypeParams == "<float64>")  ? "<float64>"s              //
-                                : (remoteSourceBaseType == "opendigitizer::RemoteDataSetSource" && remoteSourceTypeParams == "<float32>") ? "<gr::DataSet<float32>>"s //
-                                : (remoteSourceBaseType == "opendigitizer::RemoteDataSetSource" && remoteSourceTypeParams == "<float64>") ? "<gr::DataSet<float64>>"s //
-                                                                                                                                          : /* otherwise error */ ""s;
-
-                            gr::Message message;
-                            message.cmd      = gr::message::Command::Set;
-                            message.endpoint = gr::scheduler::property::kEmplaceBlock;
-                            // The root block needs to be a scheduler
-                            message.serviceName = _dashboard->graphModel.rootBlock.ownerSchedulerUniqueName();
-                            message.data        = gr::property_map{
-                                       {"type", sinkBlockType + sinkBlockParams}, //
-                                       {
-                                    "properties",
-                                    gr::property_map{
-                                               {"signal_name", selectedRemoteSignal.signalName}, //
-                                               {"signal_unit", selectedRemoteSignal.unit}        //
-                                    } //
-                                } //
-                            };
-                            _dashboard->graphModel.sendMessage(std::move(message));
-                        });
-                    }
-                }
-            }
-
-            if (LookAndFeel::instance().prototypeMode) {
-                ImGui::SameLine();
-                // Retrieve FPS and milliseconds per iteration
-                const float fps     = ImGui::GetIO().Framerate;
-                const auto  str     = std::format("FPS:{:5.0f}({:2}ms)", fps, LookAndFeel::instance().execTime.count());
-                const auto  estSize = ImGui::CalcTextSize(str.c_str());
-                alignForWidth(estSize.x, 1.0);
-                ImGui::Text("%s", str.c_str());
-            }
-            ImGui::Dummy(ImVec2(0.f, 0.f));
-
-            _legendBox.y = std::max(_legendBox.y, plotButtonSize);
+        if (!legendClickResult.sinkForNewPlot.empty()) {
+            _sinkForNewPlot = legendClickResult.sinkForNewPlot;
         }
     }
 
@@ -353,7 +380,21 @@ void DashboardPage::draw(Mode mode) noexcept {
     }
 
     // Modal dialogs
+    if (legendClickResult.shouldOpenNewPlotModal) {
+        ImGui::OpenPopup(addChartPopupID);
+    }
     drawNewPlotModal();
+
+    if (legendClickResult.shouldOpenEnterViewOnlyModeModal) {
+        ImGui::OpenPopup(enterViewOnlyModePopupID);
+    }
+    using namespace components;
+    if (const auto popup = beginYesNoPopup(enterViewOnlyModePopupID); isPopupOpen(popup)) {
+        if (isPopupConfirmed(popup) && this->_requestViewOnlyMode) {
+            this->_requestViewOnlyMode();
+        }
+        ImGui::EndPopup();
+    }
 }
 
 DigitizerUi::Dashboard::UIWindow* DashboardPage::newUIBlock(std::string_view chartType, std::string_view initialSignal) {
@@ -370,42 +411,26 @@ DigitizerUi::Dashboard::UIWindow* DashboardPage::newUIBlock(std::string_view cha
 void DashboardPage::drawNewPlotModal() {
     using namespace opendigitizer::charts;
 
-    if (!_showNewPlotModal) {
-        return;
-    }
-
-    ImGui::OpenPopup("New Chart");
-
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
     ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
     ImGui::SetNextWindowSize(ImVec2(300, 0), ImGuiCond_Appearing);
 
-    if (ImGui::BeginPopupModal("New Chart", &_showNewPlotModal, ImGuiWindowFlags_AlwaysAutoResize)) {
+    bool showCloseButton = true; // just pass this to imgui to cause it to put an (X) button on the popup
+    if (auto popup = IMW::ModalPopup(addChartPopupID, &showCloseButton, ImGuiWindowFlags_AlwaysAutoResize)) {
         ImGui::Text("Select chart type:");
         ImGui::Separator();
 
         auto chartTypes = opendigitizer::charts::registeredChartTypes();
         for (const auto& type : chartTypes) {
-            bool selected = (_selectedChartType == type);
-            if (ImGui::Selectable(type.c_str(), selected)) {
-                _selectedChartType = type;
+            if (ImGui::Selectable(type.c_str())) {
+                newUIBlock(type, _sinkForNewPlot);
             }
         }
 
         ImGui::Separator();
-
-        if (ImGui::Button("Create", ImVec2(120, 0))) {
-            newUIBlock(_selectedChartType, _sinkForNewPlot);
-            _showNewPlotModal = false;
+        if (ImGui::Button("Cancel", ImVec2(ImGui::GetWindowSize().x - (ImGui::GetStyle().WindowPadding.x * 2.f), 0))) {
             ImGui::CloseCurrentPopup();
         }
-        ImGui::SameLine();
-        if (ImGui::Button("Cancel", ImVec2(120, 0))) {
-            _showNewPlotModal = false;
-            ImGui::CloseCurrentPopup();
-        }
-
-        ImGui::EndPopup();
     }
 }
 

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -102,7 +102,7 @@ void DashboardPage::draw(Mode mode) noexcept {
     const bool      horizontalSplit   = size.x > size.y;
     constexpr float splitterWidth     = 6;
     constexpr float halfSplitterWidth = splitterWidth / 2.f;
-    const float     ratio             = components::Splitter(size, horizontalSplit, splitterWidth, 0.2f, !_editPane.selectedBlock());
+    const float     ratio             = mode == Mode::Interaction ? components::Splitter(size, horizontalSplit, splitterWidth, 0.2f, !_editPane.selectedBlock()) : 0.f;
 
     ImGui::SetCursorPosX(left);
     ImGui::SetCursorPosY(top);

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -28,13 +28,9 @@ constexpr inline auto kGridWidth  = 16u;
 constexpr inline auto kGridHeight = 16u;
 } // namespace
 
-static bool plotButton(const char* glyph, const char* tooltip, float buttonSize, bool transparentInactiveBg = false) noexcept {
+static bool plotButton(const char* glyph, const char* tooltip, float buttonSize) noexcept {
     const bool ret = [&] {
-        auto bgColor = LookAndFeel::instance().palette().mainWindowButtonBgInactive;
-        if (transparentInactiveBg) {
-            bgColor.w = 0.0f;
-        }
-        IMW::StyleColor buttonStyle(ImGuiCol_Button, bgColor);
+        IMW::StyleColor buttonStyle(ImGuiCol_Button, LookAndFeel::instance().palette().mainWindowButtonBgInactive);
         IMW::StyleColor textStyle(ImGuiCol_Text, LookAndFeel::instance().palette().mainWindowButtonIcon);
         IMW::StyleColor buttonActiveStyle(ImGuiCol_ButtonActive, LookAndFeel::instance().palette().mainWindowButtonBgActive);
         IMW::StyleColor buttonHoveredStyle(ImGuiCol_ButtonHovered, LookAndFeel::instance().palette().mainWindowButtonBgHovered);
@@ -272,7 +268,7 @@ DashboardPage::LegendItemClickResult DashboardPage::drawLegend(Mode mode, ImVec2
 
     LegendItemClickResult clickResult;
 
-    const float plotButtonSize = 40.f;
+    const float plotButtonSize = LookAndFeel::instance().mainWindowIconButtonSize();
 
     if (mode != Mode::View) {
         namespace dnd = opendigitizer::charts::dnd;
@@ -301,7 +297,7 @@ DashboardPage::LegendItemClickResult DashboardPage::drawLegend(Mode mode, ImVec2
 
     if (mode == Mode::Interaction && _dashboard && _remoteSignalSelector) {
         ImGui::SameLine();
-        if (plotButton("\u{F067}", "add signal", plotButtonSize, true)) {
+        if (plotButton("\u{F067}", "add signal", plotButtonSize)) {
             // 'plus' button in the global legend, adds a new signal
             // to the dashboard
             _remoteSignalSelector->open();

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -27,13 +27,13 @@ constexpr inline auto kGridWidth  = 16u;
 constexpr inline auto kGridHeight = 16u;
 } // namespace
 
-static bool plotButton(const char* glyph, const char* tooltip) noexcept {
+static bool plotButton(const char* glyph, const char* tooltip, float buttonSize) noexcept {
     const bool ret = [&] {
         IMW::StyleColor normal(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
         IMW::StyleColor hovered(ImGuiCol_ButtonHovered, ImVec4(0, 0, 0, 0.1f));
         IMW::StyleColor active(ImGuiCol_ButtonActive, ImVec4(0, 0, 0, 0.2f));
-        IMW::Font       font(LookAndFeel::instance().fontIconsSolid);
-        return ImGui::Button(glyph);
+        IMW::Font       font(LookAndFeel::instance().fontIconsSolidLarge);
+        return ImGui::Button(glyph, {buttonSize, buttonSize});
     }();
 
     if (ImGui::IsItemHovered()) {
@@ -182,9 +182,11 @@ void DashboardPage::draw(Mode mode) noexcept {
         {
             IMW::Group group;
 
+            const float plotButtonSize = 40.f;
+
             if (mode != Mode::View) {
                 namespace dnd = opendigitizer::charts::dnd;
-                if (plotButton("\uF201", "create new chart")) {
+                if (plotButton("\uF201", "create new chart", plotButtonSize)) {
                     _showNewPlotModal = true;
                     _sinkForNewPlot   = {};
                 }
@@ -204,24 +206,24 @@ void DashboardPage::draw(Mode mode) noexcept {
             if (mode == Mode::Layout) {
                 {
                     IMW::Group layout;
-                    if (plotButton("\uF7A5", "change to the horizontal layout")) {
+                    if (plotButton("\uF7A5", "change to the horizontal layout", plotButtonSize)) {
                         _dockSpace.setLayoutType(DockingLayoutType::Row);
                     }
                     ImGui::SameLine();
-                    if (plotButton("\uF7A4", "change to the vertical layout")) {
+                    if (plotButton("\uF7A4", "change to the vertical layout", plotButtonSize)) {
                         _dockSpace.setLayoutType(DockingLayoutType::Column);
                     }
                     ImGui::SameLine();
-                    if (plotButton("\uF58D", "change to the grid layout")) {
+                    if (plotButton("\uF58D", "change to the grid layout", plotButtonSize)) {
                         _dockSpace.setLayoutType(DockingLayoutType::Grid);
                     }
                     ImGui::SameLine();
-                    if (plotButton("\uF248", "change to the free layout")) {
+                    if (plotButton("\uF248", "change to the free layout", plotButtonSize)) {
                         _dockSpace.setLayoutType(DockingLayoutType::Free);
                     }
                     ImGui::SameLine();
                 }
-                _legendBox.x = ImGui::GetItemRectSize().x;
+                _legendBox = ImGui::GetItemRectSize();
             } else {
                 static constexpr std::string_view kLegendBlockType = "DigitizerUi::GlobalSignalLegend";
 
@@ -268,7 +270,7 @@ void DashboardPage::draw(Mode mode) noexcept {
                 // Post button strip
                 if (mode == Mode::Interaction) {
                     ImGui::SameLine();
-                    if (plotButton("\uf067", "add signal")) {
+                    if (plotButton("\uf067", "add signal", plotButtonSize)) {
                         // 'plus' button in the global legend, adds a new signal
                         // to the dashboard
                         _remoteSignalSelector->open();
@@ -337,8 +339,9 @@ void DashboardPage::draw(Mode mode) noexcept {
                 ImGui::Text("%s", str.c_str());
             }
             ImGui::Dummy(ImVec2(0.f, 0.f));
+
+            _legendBox.y = std::max(_legendBox.y, plotButtonSize);
         }
-        _legendBox.y = std::floor(ImGui::GetItemRectSize().y * 1.5f);
     }
 
     if (horizontalSplit) {

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -303,11 +303,39 @@ DashboardPage::LegendItemClickResult DashboardPage::drawLegend(Mode mode, ImVec2
         }
     }
 
+    struct Button {
+        const char*           icon    = nullptr;
+        const char*           tooltip = nullptr;
+        std::function<void()> action;
+    };
+
+    std::vector<Button> buttons;
+
+    if (mode == Mode::Interaction) {
+        buttons.emplace_back("\u{F248}", "Enter layout mode", [this] {
+            if (this->_requestSetLayoutMode) {
+                this->_requestSetLayoutMode(true);
+            }
+        });
+        buttons.emplace_back("\u{F023}", "Lock the dashboard", [&clickResult] { clickResult.shouldOpenEnterViewOnlyModeModal = true; });
+    } else if (mode == Mode::Layout) {
+        buttons.emplace_back("\u{F52B}", "Finish layouting", [this] {
+            if (this->_requestSetLayoutMode) {
+                this->_requestSetLayoutMode(false);
+            }
+        });
+    }
+
     ImGui::SameLine();
-    alignForWidth(plotButtonSize, 1.0);
-    const float cursorBeforeLockButton = ImGui::GetCursorPosX();
-    if (mode == Mode::Interaction && plotButton("\uF023", "Lock the dashboard", plotButtonSize)) {
-        clickResult.shouldOpenEnterViewOnlyModeModal = true;
+    const float spacing = ImGui::GetStyle().ItemSpacing.x;
+    alignForWidth(spacing + (spacing + plotButtonSize) * static_cast<float>(buttons.size()), 1.0);
+    const float cursorBeforeButtons = ImGui::GetCursorPosX();
+
+    for (const auto& button : buttons) {
+        if (plotButton(button.icon, button.tooltip, plotButtonSize)) {
+            button.action();
+        }
+        ImGui::SameLine();
     }
 
     if (LookAndFeel::instance().prototypeMode) {
@@ -316,7 +344,7 @@ DashboardPage::LegendItemClickResult DashboardPage::drawLegend(Mode mode, ImVec2
         const float fps     = ImGui::GetIO().Framerate;
         const auto  str     = std::format("FPS:{:5.0f}({:2}ms)", fps, LookAndFeel::instance().execTime.count());
         const auto  estSize = ImGui::CalcTextSize(str.c_str());
-        ImGui::SetCursorPosX(cursorBeforeLockButton - estSize.x - ImGui::GetStyle().ItemSpacing.x);
+        ImGui::SetCursorPosX(cursorBeforeButtons - estSize.x - spacing);
         ImGui::Text("%s", str.c_str());
     }
     ImGui::Dummy(ImVec2(0.f, 0.f));

--- a/src/ui/DashboardPage.hpp
+++ b/src/ui/DashboardPage.hpp
@@ -29,8 +29,8 @@ private:
 
     ImVec2 _legendBox{500, 40}; // updated by drawLegend(...)
 
-    std::function<void()> _requestViewOnlyMode;
-    std::function<void()> _requestExitViewOnlyMode;
+    std::function<void()>     _requestViewOnlyMode;
+    std::function<void(bool)> _requestSetLayoutMode;
 
     // signals which are scheduled to be added
     // (source block creation requested)
@@ -82,8 +82,8 @@ public:
 
     void draw(Mode mode = Mode::View) noexcept;
     void setLayoutType(DockingLayoutType);
-    void setRequestViewOnlyModeHandler(auto&& function) { _requestViewOnlyMode = std::move(function); }
-    void setRequestExitViewOnlyModeHandler(auto&& function) { _requestExitViewOnlyMode = std::move(function); }
+    void setRequestViewOnlyModeHandler(std::function<void()>&& function) { _requestViewOnlyMode = std::move(function); }
+    void setRequestSetLayoutModeHandler(std::function<void(bool)>&& function) { _requestSetLayoutMode = std::move(function); }
 
     /* no optional of ref yet */ DigitizerUi::Dashboard::UIWindow* newUIBlock(std::string_view chartType = "XYChart", std::string_view initialSignal = {});
 

--- a/src/ui/DashboardPage.hpp
+++ b/src/ui/DashboardPage.hpp
@@ -21,7 +21,7 @@ namespace DigitizerUi {
 
 class DashboardPage {
 public:
-    enum class Mode { View, Layout };
+    enum class Mode { View, Interaction, Layout };
 
 private:
     ImVec2 _paneSize{0, 0};     // updated by drawPlots(...)

--- a/src/ui/DashboardPage.hpp
+++ b/src/ui/DashboardPage.hpp
@@ -24,8 +24,13 @@ public:
     enum class Mode { View, Interaction, Layout };
 
 private:
-    ImVec2 _paneSize{0, 0};     // updated by drawPlots(...)
+    static constexpr const char* addChartPopupID          = "New Chart";
+    static constexpr const char* enterViewOnlyModePopupID = "Lock the dashboard?##lockMode";
+
     ImVec2 _legendBox{500, 40}; // updated by drawLegend(...)
+
+    std::function<void()> _requestViewOnlyMode;
+    std::function<void()> _requestExitViewOnlyMode;
 
     // signals which are scheduled to be added
     // (source block creation requested)
@@ -45,9 +50,7 @@ private:
     Dashboard* _dashboard = nullptr;
 
     // modal dialog state for new plot creation
-    bool        _showNewPlotModal = false;
     std::string _sinkForNewPlot;
-    std::string _selectedChartType = "XYChart";
 
     // deferred chart transmutation request (processed at start of next frame)
     struct PendingTransmutation {
@@ -59,15 +62,30 @@ private:
     // deferred chart removal requests (processed at start of next frame)
     std::vector<std::string> _pendingRemovals;
 
+    struct LegendItemClickResult {
+        bool        shouldOpenEnterViewOnlyModeModal = false;
+        bool        shouldOpenNewPlotModal           = false;
+        std::string sinkForNewPlot;
+    };
+
+    void                                drawNewPlotModal();                                         // modifies _showNewPlotModal if close is requested
+    [[nodiscard]] ImVec2                drawCharts(Mode mode) noexcept;                             // returns the size of area used for charts
+    [[nodiscard]] LegendItemClickResult drawLegend(Mode mode, ImVec2 chartPaneSize) noexcept;       // sets _legendBox
+    [[nodiscard]] ImVec2                drawLegendCenter(Mode mode, ImVec2 chartPaneSize) noexcept; // returns total size of centered legend part
+    void                                drawToolbarLayoutButtons(float plotButtonSize) noexcept;
+    void                                addSelectedRemoteSignal(const SignalData& selectedRemoteSignal) noexcept;
+    void                                doViewModeOverlayArea() noexcept;
+
 public:
     DashboardPage();
     ~DashboardPage();
 
     void draw(Mode mode = Mode::View) noexcept;
     void setLayoutType(DockingLayoutType);
+    void setRequestViewOnlyModeHandler(auto&& function) { _requestViewOnlyMode = std::move(function); }
+    void setRequestExitViewOnlyModeHandler(auto&& function) { _requestExitViewOnlyMode = std::move(function); }
 
     /* no optional of ref yet */ DigitizerUi::Dashboard::UIWindow* newUIBlock(std::string_view chartType = "XYChart", std::string_view initialSignal = {});
-    void                                                           drawNewPlotModal();
 
     void setDashboard(Dashboard& dashboard) {
         _dashboard = std::addressof(dashboard);

--- a/src/ui/DashboardPage.hpp
+++ b/src/ui/DashboardPage.hpp
@@ -45,7 +45,8 @@ private:
     Dashboard* _dashboard = nullptr;
 
     // modal dialog state for new plot creation
-    bool        _showNewPlotModal  = false;
+    bool        _showNewPlotModal = false;
+    std::string _sinkForNewPlot;
     std::string _selectedChartType = "XYChart";
 
     // deferred chart transmutation request (processed at start of next frame)
@@ -65,7 +66,7 @@ public:
     void draw(Mode mode = Mode::View) noexcept;
     void setLayoutType(DockingLayoutType);
 
-    /* no optional of ref yet */ DigitizerUi::Dashboard::UIWindow* newUIBlock(std::string_view chartType = "XYChart");
+    /* no optional of ref yet */ DigitizerUi::Dashboard::UIWindow* newUIBlock(std::string_view chartType = "XYChart", std::string_view initialSignal = {});
     void                                                           drawNewPlotModal();
 
     void setDashboard(Dashboard& dashboard) {

--- a/src/ui/FlowgraphPage.cpp
+++ b/src/ui/FlowgraphPage.cpp
@@ -818,7 +818,7 @@ void FlowgraphPage::pushEditor(std::string name, UiGraphModel& graphModel, UiGra
 
     auto& editor = _editors.emplace_back(name, graphModel, rootBlock, _editors.size());
 
-    editor.setStyle(LookAndFeel::instance().style);
+    editor.updateStyle();
     editor.requestBlockControlsPanel = requestBlockControlsPanel;
 
     editor.requestGraphEdit = [&](UiGraphBlock* block) { pushEditor(block->blockUniqueName, graphModel, block); };
@@ -854,9 +854,9 @@ void FlowgraphPage::popEditor() {
     }
 }
 
-void FlowgraphPage::setStyle(LookAndFeel::Style style) {
+void FlowgraphPage::updateStyle() {
     for (auto& editor : _editors) {
-        editor.setStyle(style);
+        editor.updateStyle();
     }
 }
 

--- a/src/ui/FlowgraphPage.hpp
+++ b/src/ui/FlowgraphPage.hpp
@@ -87,25 +87,16 @@ public:
         ax::NodeEditor::DestroyEditor(_editorPtr);
     }
 
-    void setStyle(LookAndFeel::Style s) {
+    void updateStyle() {
         makeCurrent();
 
         auto& style        = ax::NodeEditor::GetStyle();
         style.NodeRounding = 0;
         style.PinRounding  = 0;
 
-        switch (s) {
-        case LookAndFeel::Style::Dark:
-            style.Colors[ax::NodeEditor::StyleColor_Bg]         = {0.1f, 0.1f, 0.1f, 1.f};
-            style.Colors[ax::NodeEditor::StyleColor_NodeBg]     = {0.2f, 0.2f, 0.2f, 1.f};
-            style.Colors[ax::NodeEditor::StyleColor_NodeBorder] = {0.7f, 0.7f, 0.7f, 1.f};
-            break;
-        case LookAndFeel::Style::Light:
-            style.Colors[ax::NodeEditor::StyleColor_Bg]         = {1.f, 1.f, 1.f, 1.f};
-            style.Colors[ax::NodeEditor::StyleColor_NodeBg]     = {0.94f, 0.92f, 1.f, 1.f};
-            style.Colors[ax::NodeEditor::StyleColor_NodeBorder] = {0.38f, 0.38f, 0.38f, 1.f};
-            break;
-        }
+        style.Colors[ax::NodeEditor::StyleColor_Bg]         = LookAndFeel::instance().palette().flowgraphBg;
+        style.Colors[ax::NodeEditor::StyleColor_NodeBg]     = LookAndFeel::instance().palette().flowgraphNodeBg;
+        style.Colors[ax::NodeEditor::StyleColor_NodeBorder] = LookAndFeel::instance().palette().flowgraphNodeBorder;
     }
 
     void draw(const ImVec2& contentTopLeft, const ImVec2& contentSize, bool isCurrentEditor);
@@ -202,7 +193,7 @@ public:
     void pushEditor(std::string name, UiGraphModel& model, UiGraphBlock* rootBlock);
     void popEditor();
 
-    void setStyle(LookAndFeel::Style style);
+    void updateStyle(); // reads from LookAndFeel::instance().style
 
     static const DataTypeStyle& styleForDataType(std::string_view type);
 

--- a/src/ui/blocks/GlobalSignalLegend.hpp
+++ b/src/ui/blocks/GlobalSignalLegend.hpp
@@ -52,15 +52,20 @@ struct GlobalSignalLegend : gr::Block<GlobalSignalLegend, gr::Drawable<gr::UICat
         ClickResult                result = ClickResult::None;
         constexpr ImGuiMouseButton kRMB   = ImGuiMouseButton_Right;
 
-        const ImVec2 cursorPos = ImGui::GetCursorScreenPos();
-        const ImVec2 rectSize(ImGui::GetTextLineHeight() - 4, ImGui::GetTextLineHeight());
+        IMW::StyleVar resetSpacing(ImGuiStyleVar_ItemSpacing, ImVec2{});     // no space between button and color rect
+        const ImVec2  innerPad      = ImPlot::GetStyle().LegendInnerPadding; // mimic implot legends
+        const auto    textSize      = ImGui::CalcTextSize(text.data());
+        const auto    buttonSize    = textSize + innerPad * 2;
+        const ImVec2  colorRectSize = {ImGui::GetTextLineHeight(), ImGui::GetTextLineHeight()};
 
-        // colour indicator square
-        ImGui::GetWindowDrawList()->AddRectFilled(cursorPos + ImVec2(0, 2), cursorPos + rectSize - ImVec2(0, 2), rgbToImGuiABGR(color));
-
-        if (ImGui::InvisibleButton("##ColorBox", rectSize)) {
+        // colour indicator square, centered vertically next to the text
+        const auto cursorOriginalY = ImGui::GetCursorPosY();
+        ImGui::SetCursorPosY(cursorOriginalY + (buttonSize.y - colorRectSize.y) / 2.f);
+        if (ImGui::InvisibleButton("##ColorBox", colorRectSize)) {
             result = ClickResult::Left;
         }
+        ImGui::GetWindowDrawList()->AddRectFilled(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), rgbToImGuiABGR(color));
+
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup)) {
             ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeAll);
             if (ImGui::IsMouseReleased(kRMB)) {
@@ -70,8 +75,6 @@ struct GlobalSignalLegend : gr::Block<GlobalSignalLegend, gr::Drawable<gr::UICat
         ImGui::SameLine();
 
         // signal name button with transparent background
-        ImVec2 buttonSize(rectSize.x + ImGui::CalcTextSize(text.data()).x - 4, ImGui::GetTextLineHeight());
-
         IMW::StyleColor buttonStyle(ImGuiCol_Button, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
         IMW::StyleColor hoveredStyle(ImGuiCol_ButtonHovered, ImVec4(0.0f, 0.0f, 0.0f, 0.1f));
         IMW::StyleColor activeStyle(ImGuiCol_ButtonActive, ImVec4(0.0f, 0.0f, 0.0f, 0.2f));

--- a/src/ui/charts/Chart.hpp
+++ b/src/ui/charts/Chart.hpp
@@ -722,19 +722,25 @@ struct State {
 };
 inline State g_state;
 
-inline bool handleLegendDropTarget(const char* payloadType = kPayloadType) {
+template<typename Callable>
+requires std::is_invocable_r_v<bool, Callable, const Payload&>
+inline bool handleDropTarget(Callable&& handler, const char* payloadType) {
     bool dropped = false;
     if (ImGui::BeginDragDropTarget()) {
         if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(payloadType)) {
             const auto* dnd = static_cast<const Payload*>(payload->Data);
-            if (dnd && dnd->isValid() && dnd->hasSource()) {
-                g_state.accepted = true;
-                dropped          = true;
+            if (dnd && dnd->isValid()) {
+                g_state.accepted = std::invoke(handler, *dnd);
+                dropped          = g_state.accepted;
             }
         }
         ImGui::EndDragDropTarget();
     }
     return dropped;
+}
+
+inline bool handleLegendDropTarget(const char* payloadType = kPayloadType) {
+    return handleDropTarget([](const Payload& payload) { return payload.hasSource(); }, payloadType);
 }
 
 inline void setupPayload(const std::shared_ptr<SignalSink>& sink, std::string_view sourceChartId, const char* payloadType = kPayloadType) {
@@ -2064,6 +2070,7 @@ struct Chart {
 
         ImGui::Separator();
         self.drawChartTypeSubmenu();
+        opendigitizer::charts::drawRemoveChartMenuItem(self.unique_name);
     }
 
     /// draws axis-specific or full context menu depending on what was right-clicked

--- a/src/ui/charts/Chart.hpp
+++ b/src/ui/charts/Chart.hpp
@@ -866,11 +866,17 @@ inline void drawRemoveChartMenuItem(std::string_view uniqueName) {
     }
 }
 
+enum class ChartMode : std::uint8_t {
+    Interaction,
+    View,
+    Layout,
+};
+
 struct DrawPrologue {
     ImPlotFlags plotFlags;
     ImVec2      plotSize;
     bool        showLegend;
-    bool        layoutMode;
+    ChartMode   chartMode;
     bool        showGrid;
 };
 
@@ -1680,27 +1686,28 @@ struct Chart {
         self.syncSinksIfNeeded(self.data_sinks.value);
         self.refreshCapacityIfNeeded();
 
-        bool layoutMode = false;
-        if (const auto it = config.find("layoutMode"); it != config.end()) {
-            layoutMode = it->second.value_or(false);
+        ChartMode chartMode = ChartMode::View;
+        if (const auto it = config.find("chartMode"); it != config.end()) {
+            if (auto mode = magic_enum::enum_cast<ChartMode>(it->second.value_or(std::string_view{}))) {
+                chartMode = *mode;
+            }
         }
+        const bool layoutMode = chartMode == ChartMode::Layout;
 
         bool effectiveShowLegend = false;
         if constexpr (requires { self.show_legend; }) {
-            // show_legend is unused for now, as there is no view-only mode where you *wouldn't* already show_legend
-            effectiveShowLegend = !layoutMode; // self.show_legend.value || layoutMode;
+            effectiveShowLegend = chartMode == ChartMode::Interaction || self.show_legend.value;
         }
 
         float       layoutOffset = layoutMode ? 5.f : 0.f;
         ImVec2      plotSize     = ImGui::GetContentRegionAvail() - ImVec2(2 * layoutOffset, 2 * layoutOffset);
-        ImPlotFlags plotFlags    = ImPlotFlags_NoMouseText | ImPlotFlags_NoTitle | ImPlotFlags_NoMenus;
+        ImPlotFlags plotFlags    = ImPlotFlags_NoMouseText | ImPlotFlags_NoTitle | ImPlotFlags_NoMenus | ImPlotFlags_NoFrame;
         if (!effectiveShowLegend) {
             plotFlags |= ImPlotFlags_NoLegend;
         }
 
-        if (layoutMode) {
-            // not strictly necessary, the drag and drop buttons in layoutmode already cover the plot
-            plotFlags |= ImPlotFlags_NoInputs;
+        if (chartMode == ChartMode::View || chartMode == ChartMode::Layout) {
+            plotFlags |= ImPlotFlags_NoInputs | ImPlotFlags_NoBoxSelect;
         }
 
         bool effectiveShowGrid = true;
@@ -1708,7 +1715,7 @@ struct Chart {
             effectiveShowGrid = self.show_grid.value;
         }
 
-        return DrawPrologue{plotFlags, plotSize, effectiveShowLegend, layoutMode, effectiveShowGrid};
+        return DrawPrologue{.plotFlags = plotFlags, .plotSize = plotSize, .showLegend = effectiveShowLegend, .chartMode = chartMode, .showGrid = effectiveShowGrid};
     }
 
     template<typename Self>
@@ -1793,7 +1800,11 @@ struct Chart {
     }
 
     template<typename Self>
-    void handleCommonInteractions(this Self& self) {
+    void handleCommonInteractions(this Self& self, ChartMode mode) {
+        if (mode == ChartMode::View || mode == ChartMode::Layout) {
+            return;
+        }
+
         if constexpr (requires {
                           self.x_auto_scale;
                           self.y_auto_scale;
@@ -1849,7 +1860,7 @@ struct Chart {
     }
 
     template<typename Self>
-    void drawEmptyPlot(this Self& self, const char* message, ImPlotFlags plotFlags, const ImVec2& size) {
+    void drawEmptyPlot(this Self& self, const char* message, ImPlotFlags plotFlags, const ImVec2& size, ChartMode chartMode) {
         if (DigitizerUi::TouchHandler<>::BeginZoomablePlot(self.chart_name.value, size, plotFlags)) {
             ImPlot::SetupAxis(ImAxis_X1, "X", ImPlotAxisFlags_None);
             ImPlot::SetupAxis(ImAxis_Y1, "Y", ImPlotAxisFlags_None);
@@ -1859,7 +1870,7 @@ struct Chart {
             auto limits = ImPlot::GetPlotLimits();
             ImPlot::PlotText(message, (limits.X.Min + limits.X.Max) / 2, (limits.Y.Min + limits.Y.Max) / 2);
             tooltip::showPlotMouseTooltip();
-            self.handleCommonInteractions();
+            self.handleCommonInteractions(chartMode);
             DigitizerUi::TouchHandler<>::EndZoomablePlot();
         }
     }

--- a/src/ui/charts/SpectrumDensity.hpp
+++ b/src/ui/charts/SpectrumDensity.hpp
@@ -75,10 +75,10 @@ struct SpectrumDensity : gr::Block<SpectrumDensity, gr::Drawable<gr::UICategory:
     void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) { handleSettingsChanged(newSettings); }
 
     gr::work::Status draw(const gr::property_map& config = {}) {
-        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, layoutMode, showGrid] = prepareDrawPrologue(config);
+        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, chartMode, showGrid] = prepareDrawPrologue(config);
 
         if (_signalSinks.empty()) {
-            drawEmptyPlot("No signals", plotFlags, plotSize);
+            drawEmptyPlot("No signals", plotFlags, plotSize, chartMode);
             return gr::work::Status::OK;
         }
 
@@ -116,7 +116,7 @@ struct SpectrumDensity : gr::Block<SpectrumDensity, gr::Drawable<gr::UICategory:
 
         drawDensitySignals();
         tooltip::showPlotMouseTooltip();
-        handleCommonInteractions();
+        handleCommonInteractions(chartMode);
         DigitizerUi::TouchHandler<>::EndZoomablePlot();
         ImPlot::PopStyleColor();
 

--- a/src/ui/charts/SpectrumPlot.hpp
+++ b/src/ui/charts/SpectrumPlot.hpp
@@ -64,10 +64,10 @@ struct SpectrumPlot : gr::Block<SpectrumPlot, gr::Drawable<gr::UICategory::Conte
     void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) { handleSettingsChanged(newSettings); }
 
     gr::work::Status draw(const gr::property_map& config = {}) {
-        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, layoutMode, showGrid] = prepareDrawPrologue(config);
+        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, chartMode, showGrid] = prepareDrawPrologue(config);
 
         if (_signalSinks.empty()) {
-            drawEmptyPlot("No signals", plotFlags, plotSize);
+            drawEmptyPlot("No signals", plotFlags, plotSize, chartMode);
             return gr::work::Status::OK;
         }
 
@@ -82,7 +82,7 @@ struct SpectrumPlot : gr::Block<SpectrumPlot, gr::Drawable<gr::UICategory::Conte
         ImPlot::SetupFinish();
         drawSpectrumSignals();
         tooltip::showPlotMouseTooltip();
-        handleCommonInteractions();
+        handleCommonInteractions(chartMode);
         DigitizerUi::TouchHandler<>::EndZoomablePlot();
 
         return gr::work::Status::OK;

--- a/src/ui/charts/SpectrumView.hpp
+++ b/src/ui/charts/SpectrumView.hpp
@@ -104,7 +104,7 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
     }
 
     gr::work::Status draw(const gr::property_map& config = {}) {
-        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, layoutMode, showGrid] = prepareDrawPrologue(config);
+        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, chartMode, showGrid] = prepareDrawPrologue(config);
 
         _waterfall.setPreferGpu(gpu_acceleration);
         if (_pendingResizeTime == 0.0 && _waterfall.width() > 0) {
@@ -112,7 +112,7 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
         }
 
         if (_signalSinks.empty()) {
-            drawEmptyPlot("No signals", plotFlags, plotSize);
+            drawEmptyPlot("No signals", plotFlags, plotSize, chartMode);
             return gr::work::Status::OK;
         }
 
@@ -140,7 +140,7 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
             return gr::work::Status::OK;
         }
 
-        drawTopPane(plotFlags, showGrid);
+        drawTopPane(plotFlags, showGrid, chartMode);
         drawBottomPane(plotFlags, showGrid);
 
         ImPlot::EndSubplots();
@@ -149,7 +149,7 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
 
     void setupFrequencyAxis(bool showGrid) { setupSingleAxis(true, ImAxis_X1, showGrid, LabelFormat::MetricInline, /*foreground=*/true, _sharedXCond); }
 
-    void drawTopPane(ImPlotFlags plotFlags, bool showGrid) {
+    void drawTopPane(ImPlotFlags plotFlags, bool showGrid, ChartMode chartMode) {
         const bool isDensity = (top_pane_mode.value == TopPaneMode::Density);
 
         ImGui::PushID("top");
@@ -170,7 +170,7 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
             }
 
             tooltip::showPlotMouseTooltip();
-            handleCommonInteractions();
+            handleCommonInteractions(chartMode);
 
             auto yLimits = ImPlot::GetPlotLimits(ImAxis_X1, ImAxis_Y1).Y;
             _topPaneYMin = yLimits.Min;

--- a/src/ui/charts/SurfacePlot.hpp
+++ b/src/ui/charts/SurfacePlot.hpp
@@ -740,7 +740,7 @@ struct SurfacePlot : gr::Block<SurfacePlot, gr::Drawable<gr::UICategory::Content
     void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) { handleSettingsChanged(newSettings); }
 
     gr::work::Status draw(const gr::property_map& config = {}) {
-        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, layoutMode, showGrid] = prepareDrawPrologue(config);
+        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, chartMode, showGrid] = prepareDrawPrologue(config);
 
         if (_pendingResizeTime == 0.0 && _surface.width() > 0) {
             if (_surface._historyDepth != static_cast<std::size_t>(n_history)) {
@@ -750,14 +750,14 @@ struct SurfacePlot : gr::Block<SurfacePlot, gr::Drawable<gr::UICategory::Content
         }
 
         if (_signalSinks.empty()) {
-            drawEmptyPlot("No signals", plotFlags, plotSize);
+            drawEmptyPlot("No signals", plotFlags, plotSize, chartMode);
             return gr::work::Status::OK;
         }
 
         fetchAndPushData();
 
         if (_surface.filledRows() < 2 || _surface._freqAxis.empty()) {
-            drawEmptyPlot("Waiting for data", plotFlags, plotSize);
+            drawEmptyPlot("Waiting for data", plotFlags, plotSize, chartMode);
             return gr::work::Status::OK;
         }
 

--- a/src/ui/charts/WaterfallPlot.hpp
+++ b/src/ui/charts/WaterfallPlot.hpp
@@ -78,7 +78,7 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
     void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) { handleSettingsChanged(newSettings); }
 
     gr::work::Status draw(const gr::property_map& config = {}) {
-        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, layoutMode, showGrid] = prepareDrawPrologue(config);
+        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, chartMode, showGrid] = prepareDrawPrologue(config);
 
         // sync GPU preference with setting
         _waterfall.setPreferGpu(gpu_acceleration);
@@ -90,7 +90,7 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
         }
 
         if (_signalSinks.empty()) {
-            drawEmptyPlot("No signals", plotFlags, plotSize);
+            drawEmptyPlot("No signals", plotFlags, plotSize, chartMode);
             return gr::work::Status::OK;
         }
 
@@ -134,7 +134,7 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
         }
 
         tooltip::showPlotMouseTooltip();
-        handleCommonInteractions();
+        handleCommonInteractions(chartMode);
         DigitizerUi::TouchHandler<>::EndZoomablePlot();
         ImPlot::PopStyleColor();
 

--- a/src/ui/charts/XYChart.hpp
+++ b/src/ui/charts/XYChart.hpp
@@ -83,10 +83,10 @@ struct XYChart : gr::Block<XYChart, gr::Drawable<gr::UICategory::Content, "ImGui
     void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) { handleSettingsChanged(newSettings); }
 
     gr::work::Status draw(const gr::property_map& config = {}) {
-        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, layoutMode, showGrid] = prepareDrawPrologue(config);
+        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, chartMode, showGrid] = prepareDrawPrologue(config);
 
         if (_signalSinks.empty()) {
-            drawEmptyPlot("No signals", plotFlags, plotSize);
+            drawEmptyPlot("No signals", plotFlags, plotSize, chartMode);
             return gr::work::Status::OK;
         }
 
@@ -100,7 +100,7 @@ struct XYChart : gr::Block<XYChart, gr::Drawable<gr::UICategory::Content, "ImGui
         ImPlot::SetupFinish();
         drawSignals();
         tooltip::showPlotMouseTooltip();
-        handleCommonInteractions();
+        handleCommonInteractions(chartMode);
         DigitizerUi::TouchHandler<>::EndZoomablePlot();
 
         return gr::work::Status::OK;

--- a/src/ui/charts/YYChart.hpp
+++ b/src/ui/charts/YYChart.hpp
@@ -60,24 +60,24 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
     void settingsChanged(const gr::property_map& /*oldSettings*/, const gr::property_map& newSettings) { handleSettingsChanged(newSettings); }
 
     gr::work::Status draw(const gr::property_map& config = {}) {
-        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, layoutMode, showGrid] = prepareDrawPrologue(config);
+        [[maybe_unused]] auto [plotFlags, plotSize, showLegend, chartMode, showGrid] = prepareDrawPrologue(config);
 
         if (_signalSinks.empty()) {
-            drawEmptyPlot("No signals", plotFlags, plotSize);
+            drawEmptyPlot("No signals", plotFlags, plotSize, chartMode);
             return gr::work::Status::OK;
         }
 
         if (_signalSinks.size() == 1) {
-            drawXYFallback(plotFlags, plotSize, showGrid);
+            drawXYFallback(plotFlags, plotSize, chartMode, showGrid);
             return gr::work::Status::OK;
         }
 
         if (_signalSinks.size() == 2) {
-            drawCorrelation(plotFlags, plotSize, showGrid);
+            drawCorrelation(plotFlags, plotSize, chartMode, showGrid);
             return gr::work::Status::OK;
         }
 
-        drawMultiCorrelation(plotFlags, plotSize, showGrid);
+        drawMultiCorrelation(plotFlags, plotSize, chartMode, showGrid);
         return gr::work::Status::OK;
     }
 
@@ -93,23 +93,23 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
         }
     }
 
-    void drawXYFallback(ImPlotFlags plotFlags, const ImVec2& size, bool showGrid = true) {
+    void drawXYFallback(ImPlotFlags plotFlags, const ImVec2& size, ChartMode chartMode, bool showGrid = true) {
         const std::shared_ptr<SignalSink>& sinkPtr = _signalSinks[0];
         if (!sinkPtr) {
-            drawEmptyPlot("No data", plotFlags, size);
+            drawEmptyPlot("No data", plotFlags, size, chartMode);
             return;
         }
 
         // Skip if signal is hidden
         if (!sinkPtr->drawEnabled()) {
-            drawEmptyPlot("Signal hidden", plotFlags, size);
+            drawEmptyPlot("Signal hidden", plotFlags, size, chartMode);
             return;
         }
 
         // Acquire lock for thread-safe data access
         DataGuard dataLock = sinkPtr->dataGuard();
         if (sinkPtr->size() == 0) {
-            drawEmptyPlot("No data", plotFlags, size);
+            drawEmptyPlot("No data", plotFlags, size, chartMode);
             return;
         }
 
@@ -165,22 +165,22 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
             &ctx, static_cast<int>(dataCount));
 
         tooltip::showPlotMouseTooltip();
-        handleCommonInteractions();
+        handleCommonInteractions(chartMode);
         DigitizerUi::TouchHandler<>::EndZoomablePlot();
     }
 
-    void drawCorrelation(ImPlotFlags plotFlags, const ImVec2& size, bool showGrid = true) {
+    void drawCorrelation(ImPlotFlags plotFlags, const ImVec2& size, ChartMode chartMode, bool showGrid = true) {
         const auto& sinkXPtr = _signalSinks[0];
         const auto& sinkYPtr = _signalSinks[1];
 
         if (!sinkXPtr || !sinkYPtr) {
-            drawEmptyPlot("Invalid sinks", plotFlags, size);
+            drawEmptyPlot("Invalid sinks", plotFlags, size, chartMode);
             return;
         }
 
         // Skip if any signal is hidden
         if (!sinkXPtr->drawEnabled() || !sinkYPtr->drawEnabled()) {
-            drawEmptyPlot("Signal hidden", plotFlags, size);
+            drawEmptyPlot("Signal hidden", plotFlags, size, chartMode);
             return;
         }
 
@@ -191,7 +191,7 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
 
         std::size_t totalCount = std::min(sinkXPtr->size(), sinkYPtr->size());
         if (totalCount == 0) {
-            drawEmptyPlot("No data", plotFlags, size);
+            drawEmptyPlot("No data", plotFlags, size, chartMode);
             return;
         }
 
@@ -255,7 +255,7 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
             &ctx, static_cast<int>(count));
 
         tooltip::showPlotMouseTooltip();
-        handleCommonInteractions();
+        handleCommonInteractions(chartMode);
         DigitizerUi::TouchHandler<>::EndZoomablePlot();
     }
 
@@ -282,14 +282,14 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
         return result;
     }
 
-    void drawMultiCorrelation(ImPlotFlags plotFlags, const ImVec2& size, bool showGrid = true) {
+    void drawMultiCorrelation(ImPlotFlags plotFlags, const ImVec2& size, ChartMode chartMode, bool showGrid = true) {
         const auto& sinkXPtr = _signalSinks[0];
         if (!sinkXPtr) {
-            drawEmptyPlot("No X data", plotFlags, size);
+            drawEmptyPlot("No X data", plotFlags, size, chartMode);
             return;
         }
         if (!sinkXPtr->drawEnabled()) {
-            drawEmptyPlot("X signal hidden", plotFlags, size);
+            drawEmptyPlot("X signal hidden", plotFlags, size, chartMode);
             return;
         }
 
@@ -297,7 +297,7 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
         {
             DataGuard lockX = sinkXPtr->dataGuard();
             if (sinkXPtr->size() == 0) {
-                drawEmptyPlot("No X data", plotFlags, size);
+                drawEmptyPlot("No X data", plotFlags, size, chartMode);
                 return;
             }
         }
@@ -400,7 +400,7 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
         }
 
         tooltip::showPlotMouseTooltip();
-        handleCommonInteractions();
+        handleCommonInteractions(chartMode);
         DigitizerUi::TouchHandler<>::EndZoomablePlot();
     }
 };

--- a/src/ui/common/AppDefinitions.hpp
+++ b/src/ui/common/AppDefinitions.hpp
@@ -4,9 +4,10 @@
 namespace DigitizerUi {
 enum class ViewMode {
     VIEW,
+    INTERACTION,
     LAYOUT,
     FLOWGRAPH,
-    OPEN_SAVE_DASHBOARD
+    OPEN_SAVE_DASHBOARD,
 };
 }
 

--- a/src/ui/common/LookAndFeel.cpp
+++ b/src/ui/common/LookAndFeel.cpp
@@ -16,6 +16,41 @@ LookAndFeel& LookAndFeel::mutableInstance() {
 
 const LookAndFeel& LookAndFeel::instance() { return mutableInstance(); }
 
+const Palette& LookAndFeel::palette() const noexcept {
+    static const ImVec4  quarterTransparentWhite = {1.0f, 1.0f, 1.0f, 0.25f};
+    static const ImVec4  quarterTransparentBlack = {0.0f, 0.0f, 0.0f, 0.25f};
+    static const Palette darkModePalette{
+        .gridLines = quarterTransparentWhite,
+
+        .mainWindowButtonIcon       = {1.f, 1.f, 1.f, 1.f},
+        .mainWindowButtonBgInactive = {1.f, 1.f, 1.f, 0.0f},
+        .mainWindowButtonBgHovered  = {1.f, 1.f, 1.f, 0.1f},
+        .mainWindowButtonBgActive   = {1.f, 1.f, 1.f, 0.2f},
+
+        .notificationWindowBg = {0.10f, 0.10f, 0.10f, 1.00f},
+        .toolbarLineColor     = quarterTransparentWhite,
+        .flowgraphBg          = {0.1f, 0.1f, 0.1f, 1.f},
+        .flowgraphNodeBg      = {0.2f, 0.2f, 0.2f, 1.f},
+        .flowgraphNodeBorder  = {0.7f, 0.7f, 0.7f, 1.f},
+    };
+    static const Palette lightModePalette{
+        .gridLines = quarterTransparentBlack,
+
+        .mainWindowButtonIcon       = {0.f, 0.f, 0.f, 1.f},
+        .mainWindowButtonBgInactive = {0.f, 0.f, 0.f, 0.0f},
+        .mainWindowButtonBgHovered  = {0.f, 0.f, 0.f, 0.1f},
+        .mainWindowButtonBgActive   = {0.f, 0.f, 0.f, 0.2f},
+
+        .notificationWindowBg = {1.00f, 1.00f, 1.00f, 1.00f},
+        .toolbarLineColor     = quarterTransparentBlack,
+        .flowgraphBg          = {1.f, 1.f, 1.f, 1.f},
+        .flowgraphNodeBg      = {0.94f, 0.92f, 1.f, 1.f},
+        .flowgraphNodeBorder  = {0.38f, 0.38f, 0.38f, 1.f},
+    };
+
+    return style == Style::Light ? lightModePalette : darkModePalette;
+}
+
 void LookAndFeel::loadFonts() {
     // static const ImWchar fullRange[] = {
     //     0x0020, 0XFFFF, 0, 0 // '0', '0' are the end marker

--- a/src/ui/common/LookAndFeel.cpp
+++ b/src/ui/common/LookAndFeel.cpp
@@ -7,6 +7,22 @@
 CMRC_DECLARE(fonts);
 CMRC_DECLARE(ui_assets);
 
+enum FontSizeIndex { FontSizeTiny = 0, FontSizeSmall, FontSizeNormal, FontSizeBig, FontSizeBigger, FontSizeLarge, FontSizeCount };
+
+template<size_t sizeIndex>
+requires(sizeIndex < FontSizeCount)
+static float fontSize(const DigitizerUi::LookAndFeel& instance) {
+    using Sizes = std::array<float, FontSizeCount>;
+    if (std::abs(instance.verticalDPI - instance.defaultDPI) < 8.f) {
+        return Sizes{12, 17, 20, 24, 28, 46}[sizeIndex]; // 28" monitor
+    } else if (instance.verticalDPI > 200) {
+        return Sizes{8, 13, 16, 22, 23, 38}[sizeIndex]; // likely mobile monitor
+    } else if (std::abs(instance.defaultDPI - instance.verticalDPI) >= 8.f) {
+        return Sizes{12, 18, 22, 26, 30, 46}[sizeIndex]; // likely large fixed display monitor
+    }
+    return Sizes{12, 16, 18, 24, 26, 46}[sizeIndex]; // default
+};
+
 namespace DigitizerUi {
 
 LookAndFeel& LookAndFeel::mutableInstance() {
@@ -22,7 +38,7 @@ const Palette& LookAndFeel::palette() const noexcept {
     static const Palette darkModePalette{
         .gridLines = quarterTransparentWhite,
 
-        .mainWindowButtonIcon       = {1.f, 1.f, 1.f, 1.f},
+        .mainWindowButtonIcon       = {.8f, .8f, .8f, 1.0f},
         .mainWindowButtonBgInactive = {1.f, 1.f, 1.f, 0.0f},
         .mainWindowButtonBgHovered  = {1.f, 1.f, 1.f, 0.1f},
         .mainWindowButtonBgActive   = {1.f, 1.f, 1.f, 0.2f},
@@ -36,7 +52,7 @@ const Palette& LookAndFeel::palette() const noexcept {
     static const Palette lightModePalette{
         .gridLines = quarterTransparentBlack,
 
-        .mainWindowButtonIcon       = {0.f, 0.f, 0.f, 1.f},
+        .mainWindowButtonIcon       = {.8f, .8f, .8f, 0.6f},
         .mainWindowButtonBgInactive = {0.f, 0.f, 0.f, 0.0f},
         .mainWindowButtonBgHovered  = {0.f, 0.f, 0.f, 0.1f},
         .mainWindowButtonBgActive   = {0.f, 0.f, 0.f, 0.2f},
@@ -50,6 +66,8 @@ const Palette& LookAndFeel::palette() const noexcept {
 
     return style == Style::Light ? lightModePalette : darkModePalette;
 }
+
+[[nodiscard]] float LookAndFeel::mainWindowIconButtonSize() const noexcept { return fontSize<3>(*this) * 1.7f; }
 
 void LookAndFeel::loadFonts() {
     // static const ImWchar fullRange[] = {
@@ -79,19 +97,6 @@ void LookAndFeel::loadFonts() {
         0XEF819A, 0XEF819A,               // notification ICON_FA_CIRCLE_INFO
         0, 0};
 
-    enum FontSizeIndex { FontSizeTiny = 0, FontSizeSmall, FontSizeNormal, FontSizeBig, FontSizeBigger, FontSizeLarge, FontSizeCount };
-
-    static const auto fontSize = []() -> std::array<float, FontSizeCount> {
-        if (std::abs(LookAndFeel::instance().verticalDPI - LookAndFeel::instance().defaultDPI) < 8.f) {
-            return {12, 17, 20, 24, 28, 46}; // 28" monitor
-        } else if (LookAndFeel::instance().verticalDPI > 200) {
-            return {8, 13, 16, 22, 23, 38}; // likely mobile monitor
-        } else if (std::abs(LookAndFeel::instance().defaultDPI - LookAndFeel::instance().verticalDPI) >= 8.f) {
-            return {12, 18, 22, 26, 30, 46}; // likely large fixed display monitor
-        }
-        return {12, 16, 18, 24, 26, 46}; // default
-    }();
-
     static ImFontConfig config;
     // Originally oversampling of 4 was used to ensure good looking text for all zoom levels, but this led to huge texture atlas sizes, which did not work on mobile
     config.OversampleH          = 2;
@@ -111,12 +116,12 @@ void LookAndFeel::loadFonts() {
         };
 
         auto& lookAndFeel             = LookAndFeel::mutableInstance();
-        lookAndFeel.fontTiny[index]   = loadFont(fontSize[FontSizeTiny]);
-        lookAndFeel.fontSmall[index]  = loadFont(fontSize[FontSizeSmall]);
-        lookAndFeel.fontNormal[index] = loadFont(fontSize[FontSizeNormal]);
-        lookAndFeel.fontBig[index]    = loadFont(fontSize[FontSizeBig]);
-        lookAndFeel.fontBigger[index] = loadFont(fontSize[FontSizeBigger]);
-        lookAndFeel.fontLarge[index]  = loadFont(fontSize[FontSizeLarge]);
+        lookAndFeel.fontTiny[index]   = loadFont(fontSize<FontSizeTiny>(lookAndFeel));
+        lookAndFeel.fontSmall[index]  = loadFont(fontSize<FontSizeSmall>(lookAndFeel));
+        lookAndFeel.fontNormal[index] = loadFont(fontSize<FontSizeNormal>(lookAndFeel));
+        lookAndFeel.fontBig[index]    = loadFont(fontSize<FontSizeBig>(lookAndFeel));
+        lookAndFeel.fontBigger[index] = loadFont(fontSize<FontSizeBigger>(lookAndFeel));
+        lookAndFeel.fontLarge[index]  = loadFont(fontSize<FontSizeLarge>(lookAndFeel));
     };
 
     loadDefaultFont(cmrc::fonts::get_filesystem().open("Roboto-Medium.ttf"), cmrc::fonts::get_filesystem().open("Roboto-Medium.ttf"), 0, rangeLatinPlusExtended);
@@ -129,11 +134,11 @@ void LookAndFeel::loadFonts() {
     };
 
     auto& lookAndFeel               = LookAndFeel::mutableInstance();
-    lookAndFeel.fontIcons           = loadIconsFont("assets/fontawesome/fa-regular-400.otf", fontSize[0]);
-    lookAndFeel.fontIconsBig        = loadIconsFont("assets/fontawesome/fa-regular-400.otf", fontSize[1]);
-    lookAndFeel.fontIconsLarge      = loadIconsFont("assets/fontawesome/fa-regular-400.otf", fontSize[3]);
-    lookAndFeel.fontIconsSolid      = loadIconsFont("assets/fontawesome/fa-solid-900.otf", fontSize[0]);
-    lookAndFeel.fontIconsSolidBig   = loadIconsFont("assets/fontawesome/fa-solid-900.otf", fontSize[1]);
-    lookAndFeel.fontIconsSolidLarge = loadIconsFont("assets/fontawesome/fa-solid-900.otf", fontSize[3]);
+    lookAndFeel.fontIcons           = loadIconsFont("assets/fontawesome/fa-regular-400.otf", fontSize<0>(lookAndFeel));
+    lookAndFeel.fontIconsBig        = loadIconsFont("assets/fontawesome/fa-regular-400.otf", fontSize<1>(lookAndFeel));
+    lookAndFeel.fontIconsLarge      = loadIconsFont("assets/fontawesome/fa-regular-400.otf", fontSize<3>(lookAndFeel));
+    lookAndFeel.fontIconsSolid      = loadIconsFont("assets/fontawesome/fa-solid-900.otf", fontSize<0>(lookAndFeel));
+    lookAndFeel.fontIconsSolidBig   = loadIconsFont("assets/fontawesome/fa-solid-900.otf", fontSize<1>(lookAndFeel));
+    lookAndFeel.fontIconsSolidLarge = loadIconsFont("assets/fontawesome/fa-solid-900.otf", fontSize<3>(lookAndFeel));
 }
 } // namespace DigitizerUi

--- a/src/ui/common/LookAndFeel.hpp
+++ b/src/ui/common/LookAndFeel.hpp
@@ -76,6 +76,7 @@ struct LookAndFeel {
     std::chrono::seconds      editPaneCloseDelay{15};
 
     [[nodiscard]] const Palette& palette() const noexcept;
+    [[nodiscard]] float          mainWindowIconButtonSize() const noexcept;
 
     Style      style      = Style::Light;
     WindowMode windowMode = WindowMode::RESTORED;

--- a/src/ui/common/LookAndFeel.hpp
+++ b/src/ui/common/LookAndFeel.hpp
@@ -5,6 +5,8 @@
 #include <chrono>
 #include <cstdint>
 
+#include <imgui.h>
+
 enum class WindowMode { FULLSCREEN, MAXIMISED, MINIMISED, RESTORED };
 
 /**
@@ -23,6 +25,28 @@ constexpr std::uint32_t rgbToImGuiABGR(std::uint32_t rgb, std::uint8_t alpha = 0
 struct ImFont;
 
 namespace DigitizerUi {
+
+/// Colors that are not obviously included in the regular ImGuiStyle
+/// TODO: maybe include popup menu colors (light grey hamburger icon, green buttons
+/// on hamburger popup, red/violet buttons on radial menu) here, or make those use
+/// colors from a style
+struct Palette {
+    ImVec4 gridLines;
+
+    // main window buttons, shown on top of windowBg color, bg colors can be transparent
+    ImVec4 mainWindowButtonIcon;
+    ImVec4 mainWindowButtonBgInactive;
+    ImVec4 mainWindowButtonBgHovered;
+    ImVec4 mainWindowButtonBgActive;
+
+    ImVec4 notificationWindowBg;
+
+    ImVec4 toolbarLineColor;
+
+    ImVec4 flowgraphBg;
+    ImVec4 flowgraphNodeBg;
+    ImVec4 flowgraphNodeBorder;
+};
 
 struct LookAndFeel {
     enum class Style { Light, Dark };
@@ -50,6 +74,8 @@ struct LookAndFeel {
     ImFont*                   fontIconsSolidBig;
     ImFont*                   fontIconsSolidLarge;
     std::chrono::seconds      editPaneCloseDelay{15};
+
+    [[nodiscard]] const Palette& palette() const noexcept;
 
     Style      style      = Style::Light;
     WindowMode windowMode = WindowMode::RESTORED;

--- a/src/ui/components/AppHeader.hpp
+++ b/src/ui/components/AppHeader.hpp
@@ -150,8 +150,7 @@ public:
 
             {
                 IMW::StyleColor buttonStyle(ImGuiCol_Button, ImVec4{126.f / 255.f, 188.f / 255.f, 137.f / 255.f, 1.f}); // green
-                leftMenu.addButton("\uF023", [this]() { requestApplicationSwitchMode(ViewMode::VIEW); }, LookAndFeel::instance().fontIconsSolidLarge, "switch to view mode");
-                leftMenu.addButton("\uF201", [this]() { requestApplicationSwitchMode(ViewMode::INTERACTION); }, LookAndFeel::instance().fontIconsSolidLarge, "switch to interaction mode");
+                leftMenu.addButton("\uF201", [this]() { requestApplicationSwitchMode(ViewMode::INTERACTION); }, LookAndFeel::instance().fontIconsSolidLarge, "switch to chart view");
                 leftMenu.addButton("\uF248", [this]() { requestApplicationSwitchMode(ViewMode::LAYOUT); }, LookAndFeel::instance().fontIconsSolidLarge, "switch to layout mode");
                 leftMenu.addButton("\uF542", [this]() { requestApplicationSwitchMode(ViewMode::FLOWGRAPH); }, LookAndFeel::instance().fontIconsSolidLarge, "click to edit flow-graph");
                 leftMenu.addButton("", [this]() { requestApplicationSwitchMode(ViewMode::OPEN_SAVE_DASHBOARD); }, LookAndFeel::instance().fontIconsSolidLarge, "click to open/save new dashboards");

--- a/src/ui/components/AppHeader.hpp
+++ b/src/ui/components/AppHeader.hpp
@@ -150,8 +150,8 @@ public:
 
             {
                 IMW::StyleColor buttonStyle(ImGuiCol_Button, ImVec4{126.f / 255.f, 188.f / 255.f, 137.f / 255.f, 1.f}); // green
-                leftMenu.addButton("\uF201", [this]() { requestApplicationSwitchMode(ViewMode::VIEW); }, LookAndFeel::instance().fontIconsSolidLarge, "switch to view mode");
-
+                leftMenu.addButton("\uF023", [this]() { requestApplicationSwitchMode(ViewMode::VIEW); }, LookAndFeel::instance().fontIconsSolidLarge, "switch to view mode");
+                leftMenu.addButton("\uF201", [this]() { requestApplicationSwitchMode(ViewMode::INTERACTION); }, LookAndFeel::instance().fontIconsSolidLarge, "switch to interaction mode");
                 leftMenu.addButton("\uF248", [this]() { requestApplicationSwitchMode(ViewMode::LAYOUT); }, LookAndFeel::instance().fontIconsSolidLarge, "switch to layout mode");
                 leftMenu.addButton("\uF542", [this]() { requestApplicationSwitchMode(ViewMode::FLOWGRAPH); }, LookAndFeel::instance().fontIconsSolidLarge, "click to edit flow-graph");
                 leftMenu.addButton("", [this]() { requestApplicationSwitchMode(ViewMode::OPEN_SAVE_DASHBOARD); }, LookAndFeel::instance().fontIconsSolidLarge, "click to open/save new dashboards");

--- a/src/ui/components/AppHeader.hpp
+++ b/src/ui/components/AppHeader.hpp
@@ -151,7 +151,6 @@ public:
             {
                 IMW::StyleColor buttonStyle(ImGuiCol_Button, ImVec4{126.f / 255.f, 188.f / 255.f, 137.f / 255.f, 1.f}); // green
                 leftMenu.addButton("\uF201", [this]() { requestApplicationSwitchMode(ViewMode::INTERACTION); }, LookAndFeel::instance().fontIconsSolidLarge, "switch to chart view");
-                leftMenu.addButton("\uF248", [this]() { requestApplicationSwitchMode(ViewMode::LAYOUT); }, LookAndFeel::instance().fontIconsSolidLarge, "switch to layout mode");
                 leftMenu.addButton("\uF542", [this]() { requestApplicationSwitchMode(ViewMode::FLOWGRAPH); }, LookAndFeel::instance().fontIconsSolidLarge, "click to edit flow-graph");
                 leftMenu.addButton("", [this]() { requestApplicationSwitchMode(ViewMode::OPEN_SAVE_DASHBOARD); }, LookAndFeel::instance().fontIconsSolidLarge, "click to open/save new dashboards");
             }

--- a/src/ui/components/AppHeader.hpp
+++ b/src/ui/components/AppHeader.hpp
@@ -137,7 +137,10 @@ public:
 
         const auto& settings         = Digitizer::Settings::instance();
         const auto  menuButtonPushed = settings.editableMode && [&] {
-            IMW::StyleColor mainButtonStyle(ImGuiCol_Text, ImVec4(.8f, .8f, .8f, 0.6f));
+            IMW::StyleColor buttonStyle(ImGuiCol_Button, LookAndFeel::instance().palette().mainWindowButtonBgInactive);
+            IMW::StyleColor textStyle(ImGuiCol_Text, LookAndFeel::instance().palette().mainWindowButtonIcon);
+            IMW::StyleColor buttonActiveStyle(ImGuiCol_ButtonActive, LookAndFeel::instance().palette().mainWindowButtonBgActive);
+            IMW::StyleColor buttonHoveredStyle(ImGuiCol_ButtonHovered, LookAndFeel::instance().palette().mainWindowButtonBgHovered);
             IMW::Font       font(LookAndFeel::instance().fontIconsSolidLarge);
             return ImGui::Button(LookAndFeel::instance().prototypeMode ? "" : "");
         }();

--- a/src/ui/components/Docking.cpp
+++ b/src/ui/components/Docking.cpp
@@ -159,27 +159,20 @@ void DockSpace::drawEditableWindowDragArea() {
     if (GImGui->DragDropActive && !GImGui->DragDropPayload.IsDataType(IMGUI_PAYLOAD_TYPE_WINDOW)) {
         buttonFlags |= ImGuiButtonFlags_PressedOnDragDropHold;
     }
-    const bool pressed = ImGui::InvisibleButton("windowDragButton", dragArea.GetSize(), buttonFlags);
-    const bool held    = ImGui::IsItemActive();
-    const bool hovered = ImGui::IsItemHovered();
+    const bool     pressed        = ImGui::InvisibleButton("windowDragButton", dragArea.GetSize(), buttonFlags);
+    const bool     held           = ImGui::IsItemActive();
+    const bool     hovered        = ImGui::IsItemHovered();
+    const bool     isFloating     = !currentWindow->DockIsActive;
+    const uint32_t highlightColor = [&] {
+        if ((held || pressed) && !isFloating) {
+            return rgbToImGuiABGR(0x63e69f, 0x99); // mouse down, trying to undock
+        }
+        return rgbToImGuiABGR(hovered ? 0x6ec9cf : 0x9ef7f1, 0x99);
+    }();
 
-    const bool windowAlreadyBeingDragged = GImGui->MovingWindow == currentWindow;
-    const bool isFloating                = !currentWindow->DockIsActive;
+    currentWindow->DrawList->AddRectFilled(dragArea.GetTR(), dragArea.GetBL(), highlightColor);
 
-    if (hovered || pressed || held) {
-        const uint32_t highlightColor = [&] {
-            if (windowAlreadyBeingDragged) {
-                return 0x33333333U; // window is being dragged
-            } else if ((held || pressed) && !isFloating) {
-                return 0x3300FF00U; // almost dragging a docked window, but drag lock is in effect
-            } else {
-                return 0x33FF0000U; // just hovering
-            }
-        }();
-        currentWindow->DrawList->AddRectFilled(dragArea.GetTR(), dragArea.GetBL(), highlightColor);
-    }
-
-    if (!windowAlreadyBeingDragged && held) {
+    if (held) {
         const float dragMinimumDelta = isFloating ? 0.0f : 30.f;
 
         if (ImGui::IsMouseDragging(ImGuiMouseButton_Left, dragMinimumDelta)) {

--- a/src/ui/components/ImGuiNotify.hpp
+++ b/src/ui/components/ImGuiNotify.hpp
@@ -568,13 +568,7 @@ struct Notification {
         // Notifications style setup
         IMW::StyleFloatVar windowRounding(ImGuiStyleVar_WindowRounding, 0.5f);    // round borders
         IMW::StyleFloatVar windowBorderSize(ImGuiStyleVar_WindowBorderSize, 1.f); // visible borders
-
-        // Notifications color setup
-        if (LookAndFeel::instance().style == LookAndFeel::Style::Dark) {
-            IMW::StyleColor _(ImGuiCol_WindowBg, ImVec4(0.10f, 0.10f, 0.10f, 1.00f)); // Background color
-        } else {
-            IMW::StyleColor _(ImGuiCol_WindowBg, ImVec4(1.00f, 1.00f, 1.00f, 1.00f)); // White background
-        }
+        IMW::StyleColor    _(ImGuiCol_WindowBg, LookAndFeel::instance().palette().notificationWindowBg);
 
         // Main rendering function
         ImGui::RenderNotifications();

--- a/src/ui/components/PopupMenu.hpp
+++ b/src/ui/components/PopupMenu.hpp
@@ -165,7 +165,7 @@ class PopupMenu {
         std::size_t numberOfButtonRows{};
     };
 
-    ButtonsOutput doPopupAndButtons(ImVec2 popupCenter, float buttonSize) const {
+    ButtonsOutput doPopupAndButtons(ImVec2 popupCenter, float buttonSize) {
         ButtonsOutput out{};
         if (_animationProgress >= 0.0f) {
             const ImVec2 oldPos = ImGui::GetCursorPos();

--- a/src/ui/components/PopupMenu.hpp
+++ b/src/ui/components/PopupMenu.hpp
@@ -160,6 +160,39 @@ class PopupMenu {
         _menuSize            = _itemBoundaryBox.GetSize();
     }
 
+    struct ButtonsOutput {
+        bool        wasHovered{};
+        std::size_t numberOfButtonRows{};
+    };
+
+    ButtonsOutput doPopupAndButtons(ImVec2 popupCenter, float buttonSize) const {
+        ButtonsOutput out{};
+        if (_animationProgress >= 0.0f) {
+            const ImVec2 oldPos = ImGui::GetCursorPos();
+            if constexpr (menuType == MenuType::Radial) {
+                float requiredPopupSize = 2.f * (_extraRadius + (buttonSize + 2.f * _padding) * static_cast<float>(_buttons.size()));
+                ImGui::SetNextWindowSize(ImVec2(requiredPopupSize, requiredPopupSize));
+                ImGui::SetNextWindowPos(ImVec2(popupCenter.x - .5f * requiredPopupSize / 2, popupCenter.y - .5f * requiredPopupSize));
+            } else {
+                const ImVec2 size{buttonSize, static_cast<float>(_buttons.size() + 1UL) * (buttonSize + ImGui::GetStyle().ItemSpacing.y)};
+                const ImVec2 pos = _itemBoundaryBox.GetTL();
+                ImGui::SetNextWindowSize(size);
+                ImGui::SetNextWindowPos(pos);
+                out.wasHovered = ImGui::IsMouseHoveringRect(pos, pos + size);
+            }
+
+            if (auto popup = IMW::Window(_popupId.c_str(), nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoFocusOnAppearing)) {
+                if constexpr (menuType == MenuType::Radial) {
+                    out.numberOfButtonRows = drawButtonsOnArc(popupCenter, _extraRadius + .5f * buttonSize + _padding);
+                } else {
+                    out.numberOfButtonRows = drawButtonsVertically();
+                }
+            }
+            ImGui::SetCursorScreenPos(oldPos);
+        }
+        return out;
+    }
+
 public:
     float frameRounding = 6.f;
 
@@ -201,7 +234,7 @@ public:
     }
 
     void updateAndDraw() {
-        static float timeOutOfRadius = 0.0f;
+        static float timeOutOfBoundingArea = 0.0f;
 
         const float deltaTime = ImGui::GetIO().DeltaTime;
         _animationProgress    = _isOpen ? std::min(1.0f, _animationProgress + deltaTime / _animationSpeed) : std::max(0.0f, _animationProgress - deltaTime / _animationSpeed);
@@ -217,23 +250,15 @@ public:
         }
         const ImVec2 centre = _itemBoundaryBox.GetCenter();
 
-        std::size_t nButtonRows = 1UL;
-        const float buttonSize  = maxButtonSize();
-        if (_animationProgress >= 0.0f) {
-            const ImVec2 oldPos            = ImGui::GetCursorPos();
-            float        requiredPopupSize = 2.f * (_extraRadius + (buttonSize + 2.f * _padding) * static_cast<float>(_buttons.size()));
-            ImGui::SetNextWindowSize(ImVec2(requiredPopupSize, requiredPopupSize));
-            ImGui::SetNextWindowPos(ImVec2(centre.x - .5f * requiredPopupSize / 2, centre.y - .5f * requiredPopupSize));
+        const float buttonSize                               = maxButtonSize();
+        const auto [rectangularPopupWasHovered, nButtonRows] = doPopupAndButtons(centre, buttonSize);
 
-            ImGui::OpenPopup(_popupId.c_str());
-            if (auto popup = IMW::Popup(_popupId.c_str(), ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration)) {
-                if constexpr (menuType == MenuType::Radial) {
-                    nButtonRows = drawButtonsOnArc(centre, _extraRadius + .5f * buttonSize + _padding);
-                } else {
-                    nButtonRows = drawButtonsVertically();
-                }
+        if constexpr (menuType == MenuType::Horizontal || menuType == MenuType::Vertical) {
+            timeOutOfBoundingArea = !rectangularPopupWasHovered ? timeOutOfBoundingArea + deltaTime : 0.f;
+            if (timeOutOfBoundingArea >= _timeOut || (!rectangularPopupWasHovered && (ImGui::IsMouseClicked(ImGuiMouseButton_Left) || ImGui::IsMouseClicked(ImGuiMouseButton_Right)))) {
+                _isOpen = false;
             }
-            ImGui::SetCursorScreenPos(oldPos);
+            return;
         }
 
         const ImVec2 mousePos      = ImGui::GetMousePos();
@@ -242,12 +267,8 @@ public:
         const float  arcRadius     = _extraRadius + static_cast<float>(nButtonRows + 1) * (buttonSize + _padding);
         // the last statement is to keep the menu open when the mouse is outside the arc segment but on the calling button.
         const bool mouseInArc = (mouseDistance <= arcRadius && mouseAngle >= _startAngle && mouseAngle <= _stopAngle) || mouseDistance <= std::max(_menuSize.x, _menuSize.y);
-        timeOutOfRadius       = !mouseInArc ? timeOutOfRadius + deltaTime : 0.f;
-        if (timeOutOfRadius >= _timeOut) {
-            _isOpen = false;
-        }
-
-        if (timeOutOfRadius >= _timeOut) {
+        timeOutOfBoundingArea = !mouseInArc ? timeOutOfBoundingArea + deltaTime : 0.f;
+        if (timeOutOfBoundingArea >= _timeOut) {
             _isOpen = false;
         }
 

--- a/src/ui/components/PopupMenu.hpp
+++ b/src/ui/components/PopupMenu.hpp
@@ -182,6 +182,7 @@ class PopupMenu {
             }
 
             if (auto popup = IMW::Window(_popupId.c_str(), nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoFocusOnAppearing)) {
+                ImGui::BringWindowToDisplayFront(ImGui::GetCurrentWindow());
                 if constexpr (menuType == MenuType::Radial) {
                     out.numberOfButtonRows = drawButtonsOnArc(popupCenter, _extraRadius + .5f * buttonSize + _padding);
                 } else {

--- a/src/ui/components/Toolbar.hpp
+++ b/src/ui/components/Toolbar.hpp
@@ -24,7 +24,7 @@ struct ToolbarRAII {
             const float    width     = ImGui::GetWindowWidth();
             const float    y         = (ImGui::GetWindowPos().y + ImGui::GetWindowHeight()) - 1;
             const float    x         = ImGui::GetWindowPos().x;
-            const uint32_t lineColor = LookAndFeel::instance().style == LookAndFeel::Style::Light ? 0x40000000 : 0x40ffffff;
+            const uint32_t lineColor = ImGui::ColorConvertFloat4ToU32(LookAndFeel::instance().palette().toolbarLineColor);
             ImGui::GetWindowDrawList()->AddLine(ImVec2(x, y), ImVec2(width, y), lineColor);
 
             ImGui::EndChild();

--- a/src/ui/components/YesNoPopup.hpp
+++ b/src/ui/components/YesNoPopup.hpp
@@ -1,0 +1,46 @@
+#ifndef OPENDIGITIZER_UI_COMPONENTS_YES_NO_POPUP_HPP_
+#define OPENDIGITIZER_UI_COMPONENTS_YES_NO_POPUP_HPP_
+
+#include <imgui.h>
+
+#include <optional>
+
+namespace DigitizerUi::components {
+
+enum class YesNoPopupResult {
+    PopupNotOpen,
+    PopupOpen_NothingPressed,
+    PopupOpen_YesPressed,
+};
+
+[[nodiscard]] constexpr bool isPopupOpen(YesNoPopupResult result) { return result != YesNoPopupResult::PopupNotOpen; }
+[[nodiscard]] constexpr bool isPopupConfirmed(YesNoPopupResult result) { return result == YesNoPopupResult::PopupOpen_YesPressed; }
+
+inline YesNoPopupResult beginYesNoPopup(const char* id) {
+    const auto   spacing       = ImGui::GetStyle().ItemSpacing;
+    const auto   windowPadding = ImGui::GetStyle().FramePadding;
+    const float  buttonSizeY   = ImGui::GetTextLineHeight() + spacing.y * 2;
+    const ImVec2 popupCenter   = ImGui::GetMainViewport()->GetCenter();
+    const ImVec2 popupSize{300.f, (buttonSizeY * 3.f) + (spacing.y * 2.f)};
+    ImGui::SetNextWindowPos(popupCenter - popupSize / 2.f, ImGuiCond_Appearing, ImVec2{0.5f, 0.5f});
+    ImGui::SetNextWindowSize(ImVec2{300, 0}, ImGuiCond_Appearing);
+
+    using enum YesNoPopupResult;
+    if (ImGui::BeginPopupModal(id)) {
+        bool        pressedYes  = false;
+        const float buttonSizeX = ImGui::GetWindowSize().x - (windowPadding.x * 4.f);
+
+        if (ImGui::Button("Yes", {buttonSizeX, buttonSizeY})) {
+            pressedYes = true;
+            ImGui::CloseCurrentPopup();
+        }
+        if (ImGui::Button("Cancel", {buttonSizeX, buttonSizeY * 2.f})) {
+            ImGui::CloseCurrentPopup();
+        }
+        return pressedYes ? PopupOpen_YesPressed : PopupOpen_NothingPressed;
+    }
+    return PopupNotOpen;
+}
+} // namespace DigitizerUi::components
+
+#endif

--- a/src/ui/test/qa_popup_menu.cpp
+++ b/src/ui/test/qa_popup_menu.cpp
@@ -53,10 +53,9 @@ private:
         t->TestFunc = [](ImGuiTestContext* ctx) {
             ut::test("my test") = [ctx] {
                 ctx->SetRef("Test Window");
-                const ImGuiID popupId = ctx->PopupGetWindowID("MenuPopup_1");
                 captureScreenshot(*ctx);
 
-                ctx->SetRef(popupId);
+                ctx->SetRef("MenuPopup_1");
                 ctx->ItemClick("button");
 
                 auto& vars = ctx->GetVars<TestState>();


### PR DESCRIPTION
<img width="1588" height="893" alt="image" src="https://github.com/user-attachments/assets/f3a68a8b-8626-4264-857e-40531644c3c4" />

*The application immediately after opening*

The main change in this PR is the addition of the dashboard lock. It is accessible by pressing the lock button in the bottom right of the main interaction mode. After pressing it, there will be a yes/cancel popup dialog. If the user presses yes, the dashboard will lock. Any press anywhere on the dashboard after that will result in a new popup opening which asks if the user wants to unlock the screen, which switches back to regular view mode with the lock off.
The user can also exit screen lock by pressing the hamburger menu and navigating to the main chart view mode (the lock does not affect the topmost bar of the application).

You can now add and remove charts from view mode- previously only layout mode could do this. Layout mode can still only resize and redock charts, though.

Additionally, layout mode has been changed to be more visually different from view mode:

<img width="1588" height="893" alt="image" src="https://github.com/user-attachments/assets/a5073022-1124-443b-9f75-27d7a972525d" />

In the screenshots above, you will notice that layout mode button is no longer in the hamburger menu, it is in the bottom right of the view mode. When in layout mode, there is a button in the same place to exit layout mode. You can also exit layout mode by going to view mode from the hamburger menu. Open to feedback on this.

Finally there are some other minor changes, like making the toolbar buttons bigger, centering the colored rects next to the signals in the signal legend, disabling the edit signal pane in modes other than the main interaction mode, and fixing some frustrating behavior where the hamburger menu would swallow inputs in unexpected ways.