### PR TITLE
Make free layout allow more complex and changing layouts

### DIFF
--- a/src/ui/App.hpp
+++ b/src/ui/App.hpp
@@ -282,7 +282,7 @@ public:
                     loadedDashboard = dashboard.get();
                     dashboardPage   = std::make_unique<DashboardPage>();
                     dashboardPage->setDashboard(*dashboard.get());
-                    dashboardPage->setLayoutType(loadedDashboard->layout);
+                    dashboardPage->setLayoutConfiguration(loadedDashboard->layoutType, loadedDashboard->windowLayout);
                     dashboardPage->setRequestViewOnlyModeHandler([this] { mainViewMode = ViewMode::VIEW; });
                     dashboardPage->setRequestSetLayoutModeHandler([this](bool isLayout) { mainViewMode = isLayout ? ViewMode::LAYOUT : ViewMode::INTERACTION; });
                     flowgraphPage.reset();
@@ -312,7 +312,7 @@ public:
                     flowgraphPage.draw();
                 }
             } else if (mainViewMode == ViewMode::OPEN_SAVE_DASHBOARD) {
-                openDashboardPage.draw(dashboard.get());
+                openDashboardPage.draw(dashboard.get(), dashboardPage.get());
             } else {
                 auto msg = std::format("unknown view mode {}", static_cast<int>(mainViewMode));
                 components::Notification::warning(msg);

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -212,6 +212,7 @@ add_library(
   components/Toolbar.hpp
   components/YesNoPopup.hpp
   utils/stb_impl.cpp # STB is a library with linking issues -- impl instantiated only here
+  utils/ImGuiDockSpaceState.cpp
   common/AppDefinitions.hpp
   common/Events.hpp
   common/ImguiWrap.hpp

--- a/src/ui/Dashboard.cpp
+++ b/src/ui/Dashboard.cpp
@@ -350,7 +350,11 @@ void Dashboard::doLoad(const gr::property_map& dashboard) {
     };
 
     if (dashboard.contains("layout") && dashboard.at("layout").is_string()) {
-        layout = magic_enum::enum_cast<DockingLayoutType>(dashboard.at("layout").value_or(std::string()), magic_enum::case_insensitive).value_or(DockingLayoutType::Grid);
+        layoutType = magic_enum::enum_cast<DockingLayoutType>(dashboard.at("layout").value_or(std::string()), magic_enum::case_insensitive).value_or(DockingLayoutType::Grid);
+    }
+    const bool hasWindowLayout = dashboard.contains("windowLayout");
+    if (hasWindowLayout && dashboard.at("windowLayout").is_map()) {
+        windowLayout = dashboard.at("windowLayout").value_or(gr::property_map{});
     }
 
     auto sources = *readField.operator()<Tensor<pmt::Value>>(dashboard, "sources");
@@ -385,8 +389,16 @@ void Dashboard::doLoad(const gr::property_map& dashboard) {
 
         const auto name        = *readField.operator()<std::string>(plotMap, "name");
         const auto plotSources = *readField.operator()<Tensor<pmt::Value>>(plotMap, "sources");
-        const auto rect        = *readField.operator()<Tensor<pmt::Value>>(plotMap, "rect");
-        if (rect.size() != 4) {
+        auto       rect        = readField.operator()<Tensor<pmt::Value>>(plotMap, "rect", false);
+        if (!rect && !hasWindowLayout) {
+            throw gr::exception("Missing one of two possible required keys for describing dashboard window UI:"
+                                " [\"dashboard\"][\"windowLayout\"] or per-plot [\"rect\"] field");
+        }
+        if (rect && hasWindowLayout) {
+            std::println(stderr, "WARNING: plot rect and dashboard windowLayout both specified, ignoring rect");
+            rect = std::nullopt;
+        }
+        if (rect && rect->size() != 4) {
             throw gr::exception("invalid plot definition rect.size() != 4");
         }
 
@@ -427,13 +439,22 @@ void Dashboard::doLoad(const gr::property_map& dashboard) {
 
         // Set uiConstraints on the block (axes config and window layout for chart to read in draw())
         blockPtr->uiConstraints()["axes"] = axesConfig;
-        auto rectValue                    = [](const gr::pmt::Value& v) -> std::uint64_t {
+
+        constexpr auto rectValue = [](const gr::pmt::Value& v) -> std::uint64_t {
             if (auto converted = gr::pmt::convert_safely<std::uint64_t>(v); converted) {
                 return *converted;
             }
             return 0ULL;
         };
-        blockPtr->uiConstraints()["window"] = gr::property_map{{"x", rectValue(rect[0])}, {"y", rectValue(rect[1])}, {"width", rectValue(rect[2])}, {"height", rectValue(rect[3])}};
+
+        if (rect) {
+            blockPtr->uiConstraints()["window"] = gr::property_map{
+                {"x", rectValue((*rect)[0])},
+                {"y", rectValue((*rect)[1])},
+                {"width", rectValue((*rect)[2])},
+                {"height", rectValue((*rect)[3])},
+            };
+        }
 
         // Find the shared_ptr for this block in uiGraph
         std::shared_ptr<gr::BlockModel> blockShared;
@@ -446,11 +467,14 @@ void Dashboard::doLoad(const gr::property_map& dashboard) {
 
         // Create UIWindow for this chart (sink management done via settings interface)
         UIWindow uiWindow(blockShared, name);
-        if (uiWindow.window) {
-            uiWindow.window->x      = rectValue(rect[0]);
-            uiWindow.window->y      = rectValue(rect[1]);
-            uiWindow.window->width  = rectValue(rect[2]);
-            uiWindow.window->height = rectValue(rect[3]);
+
+        if (rect) {
+            uiWindow.window->freeLayoutPosition = {
+                .x      = static_cast<std::size_t>(rectValue((*rect)[0])),
+                .y      = static_cast<std::size_t>(rectValue((*rect)[1])),
+                .width  = static_cast<std::size_t>(rectValue((*rect)[2])),
+                .height = static_cast<std::size_t>(rectValue((*rect)[3])),
+            };
         }
 
         uiWindows.push_back(std::move(uiWindow));
@@ -488,6 +512,8 @@ void Dashboard::save() {
     });
     dashboardYaml["sources"] = sources;
 
+    dashboardYaml["windowLayout"] = windowLayout;
+
     gr::Tensor<gr::pmt::Value> plots;
     // Iterate UIWindows for chart serialization (new API)
     for (const auto& w : uiWindows) {
@@ -520,7 +546,7 @@ void Dashboard::save() {
         }
         plotMap["sources"] = plotSinkBlockNames;
 
-        // Serialize window rect from uiConstraints or DockSpace::Window
+        // Serialize window rect from uiConstraints, if present
         gr::Tensor<gr::pmt::Value> rectTensor(gr::extents_from, {std::size_t(4)});
         if (constraints.contains("window")) {
             if (const auto* windowMap = constraints.at("window").get_if<property_map>()) {
@@ -535,16 +561,6 @@ void Dashboard::save() {
                 rectTensor[2] = toUInt64(windowMap->at("width"));
                 rectTensor[3] = toUInt64(windowMap->at("height"));
             }
-        } else if (w.window) {
-            rectTensor[0] = static_cast<std::uint64_t>(w.window->x);
-            rectTensor[1] = static_cast<std::uint64_t>(w.window->y);
-            rectTensor[2] = static_cast<std::uint64_t>(w.window->width);
-            rectTensor[3] = static_cast<std::uint64_t>(w.window->height);
-        } else {
-            rectTensor[0] = std::uint64_t{0};
-            rectTensor[1] = std::uint64_t{0};
-            rectTensor[2] = std::uint64_t{1};
-            rectTensor[3] = std::uint64_t{1};
         }
         plotMap["rect"] = std::move(rectTensor);
 
@@ -607,7 +623,7 @@ void Dashboard::save() {
     }
 }
 
-DigitizerUi::Dashboard::UIWindow& Dashboard::newUIBlock(int x, int y, int w, int h, std::string_view chartType, const gr::property_map& chartInitialParameters) {
+DigitizerUi::Dashboard::UIWindow& Dashboard::newUIBlock(std::string_view chartType, const gr::property_map& chartInitialParameters) {
     std::string chartTypeName = chartType.empty() ? "XYChart" : std::string(chartType);
 
     // Generate a unique name for the chart
@@ -623,14 +639,6 @@ DigitizerUi::Dashboard::UIWindow& Dashboard::newUIBlock(int x, int y, int w, int
         return emptyWindow;
     }
 
-    // Store window layout and default axes in uiConstraints
-    blockPtr->uiConstraints()["window"] = gr::property_map{
-        {"x", static_cast<std::uint64_t>(x)},
-        {"y", static_cast<std::uint64_t>(y)},
-        {"width", static_cast<std::uint64_t>(w)},
-        {"height", static_cast<std::uint64_t>(h)},
-    };
-
     // Find the shared_ptr for this block in uiGraph
     std::shared_ptr<gr::BlockModel> blockShared;
     for (auto& blk : uiGraph.blocks()) {
@@ -641,11 +649,7 @@ DigitizerUi::Dashboard::UIWindow& Dashboard::newUIBlock(int x, int y, int w, int
     }
 
     // Create UIWindow for this chart
-    UIWindow win(blockShared, chartName);
-    if (win.window) {
-        win.window->setGeometry({static_cast<float>(x), static_cast<float>(y)}, {static_cast<float>(w), static_cast<float>(h)});
-    }
-    uiWindows.push_back(std::move(win));
+    uiWindows.emplace_back(std::move(blockShared), std::move(chartName));
 
     return uiWindows.back();
 }

--- a/src/ui/Dashboard.cpp
+++ b/src/ui/Dashboard.cpp
@@ -447,15 +447,6 @@ void Dashboard::doLoad(const gr::property_map& dashboard) {
             return 0ULL;
         };
 
-        if (rect) {
-            blockPtr->uiConstraints()["window"] = gr::property_map{
-                {"x", rectValue((*rect)[0])},
-                {"y", rectValue((*rect)[1])},
-                {"width", rectValue((*rect)[2])},
-                {"height", rectValue((*rect)[3])},
-            };
-        }
-
         // Find the shared_ptr for this block in uiGraph
         std::shared_ptr<gr::BlockModel> blockShared;
         for (auto& blk : uiGraph.blocks()) {
@@ -545,25 +536,6 @@ void Dashboard::save() {
             plotSinkBlockNames.emplace_back(sinkName);
         }
         plotMap["sources"] = plotSinkBlockNames;
-
-        // Serialize window rect from uiConstraints, if present
-        gr::Tensor<gr::pmt::Value> rectTensor(gr::extents_from, {std::size_t(4)});
-        if (constraints.contains("window")) {
-            if (const auto* windowMap = constraints.at("window").get_if<property_map>()) {
-                auto toUInt64 = [](const gr::pmt::Value& v) -> std::uint64_t {
-                    if (auto converted = gr::pmt::convert_safely<std::uint64_t>(v); converted) {
-                        return *converted;
-                    }
-                    return 0ULL;
-                };
-                rectTensor[0] = toUInt64(windowMap->at("x"));
-                rectTensor[1] = toUInt64(windowMap->at("y"));
-                rectTensor[2] = toUInt64(windowMap->at("width"));
-                rectTensor[3] = toUInt64(windowMap->at("height"));
-            }
-        }
-        plotMap["rect"] = std::move(rectTensor);
-
         plots.emplace_back(plotMap);
     }
     dashboardYaml["plots"] = plots;

--- a/src/ui/Dashboard.cpp
+++ b/src/ui/Dashboard.cpp
@@ -559,21 +559,24 @@ void Dashboard::save() {
         hcommand.command          = opencmw::mdp::Command::Set;
         std::string headerYamlStr = pmt::yaml::serialize(headerYaml);
         hcommand.data.put(std::string_view(headerYamlStr.c_str(), headerYamlStr.size()));
-        hcommand.topic = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", "header").build();
+        hcommand.topic    = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", "header").build();
+        hcommand.callback = [](const opencmw::mdp::Message&) {};
         restClient->request(hcommand);
 
         opencmw::client::Command dcommand;
         dcommand.command             = opencmw::mdp::Command::Set;
         std::string dashboardYamlStr = pmt::yaml::serialize(dashboardYaml);
         dcommand.data.put(std::string_view(dashboardYamlStr.c_str(), dashboardYamlStr.size()));
-        dcommand.topic = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", "dashboard").build();
+        dcommand.topic    = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", "dashboard").build();
+        dcommand.callback = [](const opencmw::mdp::Message&) {};
         restClient->request(dcommand);
 
         opencmw::client::Command fcommand;
         fcommand.command = opencmw::mdp::Command::Set;
         std::stringstream stream;
         fcommand.data.put(stream.str());
-        fcommand.topic = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", "flowgraph").build();
+        fcommand.topic    = opencmw::URI<opencmw::STRICT>::UriFactory().path(path.native()).addQueryParameter("what", "flowgraph").build();
+        fcommand.callback = [](const opencmw::mdp::Message&) {};
         restClient->request(fcommand);
     } else {
 #ifndef EMSCRIPTEN

--- a/src/ui/Dashboard.hpp
+++ b/src/ui/Dashboard.hpp
@@ -134,7 +134,8 @@ struct Dashboard {
     std::shared_ptr<opencmw::client::RestClient> restClient;
     std::shared_ptr<const DashboardDescription>  description = nullptr;
     std::vector<UIWindow>                        uiWindows;
-    DockingLayoutType                            layout;
+    DockingLayoutType                            layoutType;
+    gr::property_map                             windowLayout;
     std::unordered_map<std::string, std::string> flowgraphUriByRemoteSource;
     plf::colony<Service>                         services;
     std::atomic<bool>                            isInitialised = false;
@@ -152,7 +153,7 @@ struct Dashboard {
     void save();
     void doLoad(const gr::property_map& dashboard);
 
-    UIWindow& newUIBlock(int x, int y, int w, int h, std::string_view chartType = "XYChart", const gr::property_map& chartInitialParameters = {});
+    UIWindow& newUIBlock(std::string_view chartType = "XYChart", const gr::property_map& chartInitialParameters = {});
     void      deleteChart(UIWindow* uiWindow);
     UIWindow* copyChart(std::string_view sourceChartId);
     bool      transmuteUIWindow(UIWindow& uiWindow, std::string_view newChartType);

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -84,7 +84,7 @@ DashboardPage::DashboardPage() {
             {std::pmr::string(gr::serialization_fields::EDGE_NAME), "edge"}};
         _dashboard->graphModel.sendMessage(std::move(message));
 
-        auto& uiWindow = _dashboard->newUIBlock(0, 0, 1, 1);
+        auto& uiWindow = _dashboard->newUIBlock();
         auto  names    = grc_compat::getBlockSinkNames(uiWindow.block.get());
         names.push_back(sourceInWaiting.signalData.signalName);
         grc_compat::setBlockSinkNames(uiWindow.block.get(), names);
@@ -436,7 +436,7 @@ DigitizerUi::Dashboard::UIWindow* DashboardPage::newUIBlock(std::string_view cha
         if (!initialSignal.empty()) {
             chartInitialParameters["data_sinks"] = gr::Tensor<gr::pmt::Value>{initialSignal};
         }
-        return std::addressof(_dashboard->newUIBlock(0, 0, 1, 1, chartType, chartInitialParameters));
+        return std::addressof(_dashboard->newUIBlock(chartType, chartInitialParameters));
     }
     return nullptr;
 }
@@ -467,6 +467,13 @@ void DashboardPage::drawNewPlotModal() {
     }
 }
 
-void DashboardPage::setLayoutType(DockingLayoutType type) { _dockSpace.setLayoutType(type); }
+void DashboardPage::setLayoutConfiguration(DockingLayoutType type, std::optional<gr::property_map> freeLayoutDescription) {
+    _dockSpace.setLayoutType(type);
+    if (freeLayoutDescription) {
+        _dockSpace.loadFreeLayout(*freeLayoutDescription);
+    }
+}
+
+std::pair<DockingLayoutType, gr::property_map> DashboardPage::saveLayoutConfiguration() const { return {_dockSpace.layoutType(), _dockSpace.saveFreeLayout()}; }
 
 } // namespace DigitizerUi

--- a/src/ui/DashboardPage.hpp
+++ b/src/ui/DashboardPage.hpp
@@ -81,9 +81,12 @@ public:
     ~DashboardPage();
 
     void draw(Mode mode = Mode::View) noexcept;
-    void setLayoutType(DockingLayoutType);
+
     void setRequestViewOnlyModeHandler(std::function<void()>&& function) { _requestViewOnlyMode = std::move(function); }
     void setRequestSetLayoutModeHandler(std::function<void(bool)>&& function) { _requestSetLayoutMode = std::move(function); }
+
+    void                                           setLayoutConfiguration(DockingLayoutType type, std::optional<gr::property_map> freeLayoutDescription);
+    std::pair<DockingLayoutType, gr::property_map> saveLayoutConfiguration() const;
 
     /* no optional of ref yet */ DigitizerUi::Dashboard::UIWindow* newUIBlock(std::string_view chartType = "XYChart", std::string_view initialSignal = {});
 

--- a/src/ui/OpenDashboardPage.cpp
+++ b/src/ui/OpenDashboardPage.cpp
@@ -12,6 +12,7 @@
 #include "common/Events.hpp"
 #include "common/LookAndFeel.hpp"
 
+#include "DashboardPage.hpp"
 #include "OpenDashboardPage.hpp"
 
 #include "components/Dialog.hpp"
@@ -118,7 +119,7 @@ void OpenDashboardPage::unsubscribeSource(const std::shared_ptr<DashboardStorage
 static constexpr float indent = 20;
 
 //
-void OpenDashboardPage::dashboardControls(Dashboard* optionalDashboard) {
+void OpenDashboardPage::dashboardControls(Dashboard* optionalDashboard, DashboardPage* optionalDashboardPage) {
     IMW::Font titleFont(LookAndFeel::instance().fontBigger[LookAndFeel::instance().prototypeMode]);
 
     if (optionalDashboard != nullptr && optionalDashboard->isInitialised) {
@@ -137,6 +138,9 @@ void OpenDashboardPage::dashboardControls(Dashboard* optionalDashboard) {
     {
         IMW::Disabled innerDisabled(dashboardLoaded && optionalDashboard->description->storageInfo->isInMemoryDashboardStorage());
         if (dashboardLoaded && ImGui::Button("Save")) {
+            if (optionalDashboardPage) {
+                std::tie(optionalDashboard->layoutType, optionalDashboard->windowLayout) = optionalDashboardPage->saveLayoutConfiguration();
+            }
             optionalDashboard->save();
         }
     }
@@ -151,10 +155,10 @@ void OpenDashboardPage::dashboardControls(Dashboard* optionalDashboard) {
     }
 }
 
-void OpenDashboardPage::draw(Dashboard* optionalDashboard) {
+void OpenDashboardPage::draw(Dashboard* optionalDashboard, DashboardPage* optionalDashboardPage) {
     ImGui::Spacing();
 
-    dashboardControls(optionalDashboard);
+    dashboardControls(optionalDashboard, optionalDashboardPage);
 
     ImGui::SetNextWindowSize({600, 300}, ImGuiCond_Once);
     if (auto popup = IMW::ModalPopup("saveAsDialog", nullptr, 0)) {
@@ -197,6 +201,11 @@ void OpenDashboardPage::draw(Dashboard* optionalDashboard) {
 
             if (optionalDashboard != nullptr && optionalDashboard->isInitialised) {
                 optionalDashboard->setNewDescription(newDesc);
+
+                if (optionalDashboardPage) {
+                    std::tie(optionalDashboard->layoutType, optionalDashboard->windowLayout) = optionalDashboardPage->saveLayoutConfiguration();
+                }
+
                 optionalDashboard->save();
             }
         }

--- a/src/ui/OpenDashboardPage.hpp
+++ b/src/ui/OpenDashboardPage.hpp
@@ -12,6 +12,7 @@ class RestClient;
 }
 
 namespace DigitizerUi {
+class DashboardPage;
 
 class OpenDashboardPage {
 public:
@@ -21,7 +22,7 @@ public:
     std::function<void()>                                                   requestCloseDashboard;
     std::function<void(const std::shared_ptr<const DashboardDescription>&)> requestLoadDashboard;
 
-    void draw(Dashboard* optionalDashboard);
+    void draw(Dashboard* optionalDashboard, DashboardPage* optionalDashboardPage);
 
     void addDashboard(std::string_view path);
     void addDashboard(const std::shared_ptr<DashboardStorageInfo>& storageInfo, const auto& n);
@@ -29,7 +30,7 @@ public:
     std::shared_ptr<const DashboardDescription> get(const size_t index);
 
 private:
-    void dashboardControls(Dashboard* optionalDashboard);
+    void dashboardControls(Dashboard* optionalDashboard, DashboardPage* optionalDashboardPage);
     void drawAddSourcePopup();
     void unsubscribeSource(const std::shared_ptr<DashboardStorageInfo>& source);
 

--- a/src/ui/assets/sampleDashboards/DemoDashboard.grc
+++ b/src/ui/assets/sampleDashboards/DemoDashboard.grc
@@ -232,6 +232,21 @@ connections:
   - [SpectrumGenerator, 0, spectrumSink, 0]
 dashboard:
   layout: Free
+  windowLayout:
+    floatingWindows:  {}
+    dockSpace:
+      hsplit:
+        second:  "Spectrum View"
+        first:
+          vsplit:
+            second:  "Function Generators"
+            first:
+              hsplit:
+                second:  "FFT Spectrum"
+                first:  "Raw Signal"
+                ratio: !!float32 0.498815
+            ratio: !!float32 0.497561
+        ratio: !!float32 0.665091
   sources:
     - name: sinesSink
       block: sinesSink
@@ -264,7 +279,6 @@ dashboard:
           format: Default # options: Auto, Metric, MetricInline, Scientific, None, Default
       sources:
         - sinesSink
-      rect: [0, 0, 1, 1]
     - name: FFT Spectrum
       axes:
         - axis: X
@@ -277,7 +291,6 @@ dashboard:
           max: NaN
       sources:
         - fftSink
-      rect: [ 1, 0, 1, 1 ]
     - name: Function Generators
       parameters:
         n_history: 10000 # number of samples to plot
@@ -296,7 +309,6 @@ dashboard:
       sources:
         - IntensitySink
         - DipoleCurrentSink
-      rect: [ 0, 1, 2, 1 ] # x, y, width, height - spans 3 columns
     - name: Spectrum View
       type: opendigitizer::charts::SpectrumView
       parameters:
@@ -320,4 +332,3 @@ dashboard:
           max: -55
       sources:
         - spectrumSink
-      rect: [ 2, 0, 1, 2 ] # 1 column wide, spans 2 rows

--- a/src/ui/common/ImguiXKCD.hpp
+++ b/src/ui/common/ImguiXKCD.hpp
@@ -21,10 +21,11 @@ void Init();
 void Apply(ImDrawData* drawData);
 void Shutdown();
 
-inline bool  enabled   = true;
-inline float amplitude = 7.f;    // pixel displacement strength
-inline float frequency = 0.002f; // noise frequency (lower = smoother wobble)
-inline float seed      = 42.0f;  // deterministic noise seed
+inline bool         enabled      = true;
+inline float        amplitude    = 7.f;    // pixel displacement strength
+inline float        frequency    = 0.002f; // noise frequency (lower = smoother wobble)
+inline float        seed         = 42.0f;  // deterministic noise seed
+inline unsigned int minElemCount = 50;     // skip draw commands below this index count (filters grid/axis lines)
 
 } // namespace ImXkcd
 
@@ -39,18 +40,20 @@ inline float seed      = 42.0f;  // deterministic noise seed
 #include <SDL3/SDL_opengl.h>
 #endif
 
+#include <algorithm>
 #include <array>
 #include <print>
 
 namespace ImXkcd {
 namespace detail {
 
-inline GLuint g_program = 0;
-inline GLint  g_locProj = -1;
-inline GLint  g_locAmp  = -1;
-inline GLint  g_locFreq = -1;
-inline GLint  g_locSeed = -1;
-inline GLint  g_locTex  = -1;
+inline GLuint g_program     = 0;
+inline GLint  g_locProj     = -1;
+inline GLint  g_locAmp      = -1;
+inline GLint  g_locFreq     = -1;
+inline GLint  g_locSeed     = -1;
+inline GLint  g_locTex      = -1;
+inline GLint  g_locUtilMaxY = -1;
 
 #ifdef __EMSCRIPTEN__
 static constexpr auto* kGlslPrefix = "#version 300 es\nprecision mediump float;\n";
@@ -67,6 +70,7 @@ uniform mat4  ProjMtx;
 uniform float u_amplitude;
 uniform float u_frequency;
 uniform float u_seed;
+uniform float u_utilMaxY;
 
 out vec2 Frag_UV;
 out vec4 Frag_Color;
@@ -93,10 +97,10 @@ void main() {
     Frag_Color = Color;
     vec2 pos   = Position;
 
-    // only wobble untextured geometry — ImGui's white pixel at UV near (0,0)
-    // is used for all solid-color primitives (lines, fills, grid).
-    // text vertices have font atlas UVs well above this threshold.
-    if (UV.x < 0.01 && UV.y < 0.01) {
+    // wobble untextured geometry: white pixel, baked line textures, and cursor
+    // data all live in the top rows of the atlas (low V). Glyph UVs are below.
+    // u_utilMaxY is computed at runtime to stay correct across ImGui versions.
+    if (UV.y < u_utilMaxY) {
         // vertex-ID noise: travels with the line (dominant for dense polylines)
         float lineSeed = dot(Color.rgb, vec3(7.13, 157.7, 1117.3));
         float t = float(gl_VertexID) * u_frequency + lineSeed;
@@ -167,6 +171,15 @@ inline void enableCallback(const ImDrawList*, const ImDrawCmd*) {
     glUniform1f(g_locFreq, frequency);
     glUniform1f(g_locSeed, seed);
     glUniform1i(g_locTex, 0);
+
+    // Y threshold covering all atlas utility data (white pixel + baked line textures)
+    ImFontAtlas* atlas = ImGui::GetIO().Fonts;
+    float        maxY  = ImGui::GetFontTexUvWhitePixel().y;
+    for (int n = 0; n < IM_DRAWLIST_TEX_LINES_WIDTH_MAX + 1; ++n) {
+        maxY = std::max(maxY, atlas->TexUvLines[n].y);
+        maxY = std::max(maxY, atlas->TexUvLines[n].w);
+    }
+    glUniform1f(g_locUtilMaxY, maxY + 0.03f);
 }
 
 } // namespace detail
@@ -201,16 +214,17 @@ inline void Init() {
         return;
     }
 
-    g_locProj = glGetUniformLocation(g_program, "ProjMtx");
-    g_locAmp  = glGetUniformLocation(g_program, "u_amplitude");
-    g_locFreq = glGetUniformLocation(g_program, "u_frequency");
-    g_locSeed = glGetUniformLocation(g_program, "u_seed");
-    g_locTex  = glGetUniformLocation(g_program, "Texture");
+    g_locProj     = glGetUniformLocation(g_program, "ProjMtx");
+    g_locAmp      = glGetUniformLocation(g_program, "u_amplitude");
+    g_locFreq     = glGetUniformLocation(g_program, "u_frequency");
+    g_locSeed     = glGetUniformLocation(g_program, "u_seed");
+    g_locTex      = glGetUniformLocation(g_program, "Texture");
+    g_locUtilMaxY = glGetUniformLocation(g_program, "u_utilMaxY");
 
     glDeleteShader(vs);
     glDeleteShader(fs);
 
-    std::println("[ImXkcd] initialised (program={}, uniforms: proj={} amp={} freq={} seed={} tex={})", g_program, g_locProj, g_locAmp, g_locFreq, g_locSeed, g_locTex);
+    std::println("[ImXkcd] initialised (program={}, uniforms: proj={} amp={} freq={} seed={} tex={} utilMaxY={})", g_program, g_locProj, g_locAmp, g_locFreq, g_locSeed, g_locTex, g_locUtilMaxY);
 }
 
 inline void Apply(ImDrawData* drawData) {
@@ -232,7 +246,7 @@ inline void Apply(ImDrawData* drawData) {
 
             if (cmd.UserCallback) {
                 patched.push_back(cmd);
-            } else {
+            } else if (cmd.ElemCount >= minElemCount) {
                 ImDrawCmd enableCmd    = {};
                 enableCmd.UserCallback = enableCallback;
                 patched.push_back(enableCmd);
@@ -242,6 +256,8 @@ inline void Apply(ImDrawData* drawData) {
                 ImDrawCmd resetCmd    = {};
                 resetCmd.UserCallback = ImDrawCallback_ResetRenderState;
                 patched.push_back(resetCmd);
+            } else {
+                patched.push_back(cmd);
             }
         }
 

--- a/src/ui/components/Docking.cpp
+++ b/src/ui/components/Docking.cpp
@@ -3,7 +3,6 @@
 #include "../ui/components/ImGuiNotify.hpp"
 
 #include <algorithm>
-#include <format>
 #include <ranges>
 
 #include <imgui_internal.h>
@@ -59,6 +58,7 @@ static void dragWindow(ImGuiWindow* windowToDrag, ImRect boundingBox) {
 void DockSpace::setLayoutType(DockingLayoutType type) {
     if (type != _layoutType) {
         _layoutType = type;
+
         setNeedsRelayout(true);
         if (type == DockingLayoutType::Free) {
             // isEditable passed to nodeFlags is always true- because layout type can only change in the editable mode
@@ -67,14 +67,8 @@ void DockSpace::setLayoutType(DockingLayoutType type) {
     }
 }
 
-void DockSpace::clearWindowGeometry(const Windows& windows) {
-    for (auto w : windows) {
-        w->clearGeometry();
-    }
-}
-
 void DockSpace::render(const Windows& windows, ImVec2 paneSize, bool isEditable) {
-
+    const bool requestsExactFreeLayout = std::ranges::any_of(windows, [](const auto& w) { return w->freeLayoutPosition.has_value(); });
     {
         ImGui::SetNextWindowSize(paneSize);
 
@@ -87,10 +81,18 @@ void DockSpace::render(const Windows& windows, ImVec2 paneSize, bool isEditable)
         _lastWindowCount = windows.size();
 
         if (_needsRelayout) {
-            relayout(windows, isEditable);
+            relayout(windows, isEditable, requestsExactFreeLayout);
         } else if (_lastIsEditable != isEditable) {
             setFlagsForAllDockNodes(nodeFlags(isEditable));
             _lastIsEditable = isEditable;
+        }
+
+        // save a description of split layout and floating windows every frame. this could instead
+        // occur only before relayouting + before switching to the dashboard load/save page.
+        if (!_needsRelayout && !requestsExactFreeLayout && layoutType() == DockingLayoutType::Free) {
+            constexpr auto toWindowName = [](const auto& ptr) { return std::string_view{ptr->name}; };
+            const auto     windowNames  = windows | std::views::transform(toWindowName) | std::ranges::to<std::vector<std::string_view>>();
+            _lastFreeLayout             = DigitizerUi::saveDockSpaceState(windowNames, dockspaceID()); // saves nothing on first frame, before windows exist
         }
 
         ImGuiDockNodeFlags dockspace_flags = ImGuiDockNodeFlags_PassthruCentralNode;
@@ -133,10 +135,7 @@ void DockSpace::renderWindows(const Windows& windows, bool isEditable) {
             node->SetLocalFlags(nodeFlags(isEditable));
         }
 
-        // Write back geometry info, as user might have used the splitters
-        if (isBoxLayout()) {
-            // window->setGeometry(ImGui::GetWindowPos(), ImGui::GetWindowSize());
-        } else if (layoutType() == DockingLayoutType::Free) {
+        if (layoutType() == DockingLayoutType::Free) {
             if (auto node = ImGui::GetWindowDockNode()) {
                 node->SetLocalFlags(node->LocalFlags | ImGuiDockNodeFlags_NoDockingOverMe);
             }
@@ -249,46 +248,56 @@ void DockSpace::layoutInGrid(const Windows& windows, bool isEditable) {
     }
 }
 
-void DockSpace::layoutInFree(const Windows& windows, bool isEditable) {
+bool DockSpace::layoutInExactFree(const Windows& windows, bool isEditable) {
     if (windows.empty()) {
-        return;
+        return false;
     }
 
+    std::unordered_map<std::size_t, Window::FreeGeometry> windowAreasByOriginalIndex;
+    windowAreasByOriginalIndex.reserve(windows.size());
+
     // Assume that minX = 0, minY = 0
-    std::size_t maxX = std::ranges::max(windows | std::views::transform([](auto const& w) { return w->x + w->width; }));
-    std::size_t maxY = std::ranges::max(windows | std::views::transform([](auto const& w) { return w->y + w->height; }));
-    if (maxX == 0 || maxY == 0) {
-        return;
+    std::size_t maxX  = 0UL;
+    std::size_t maxY  = 0UL;
+    std::size_t index = 0UL;
+    for (const auto& windowPtr : windows) {
+        ++index;
+        if (!windowPtr->freeLayoutPosition.has_value()) {
+            continue;
+        }
+        maxX = std::max(maxX, windowPtr->freeLayoutPosition->x + windowPtr->freeLayoutPosition->width);
+        maxY = std::max(maxY, windowPtr->freeLayoutPosition->y + windowPtr->freeLayoutPosition->height);
+        windowAreasByOriginalIndex.try_emplace(static_cast<std::size_t>(index - 1), *windowPtr->freeLayoutPosition);
+        windowPtr->freeLayoutPosition.reset();
     }
 
     std::vector<std::vector<int>> grid(maxX, std::vector<int>(maxY, -1));
 
     // No overlap -> each cell belongs to exactly one window
     bool isOverlapDetected = false;
-    for (std::size_t i = 0; i < windows.size(); i++) {
-        const auto& w = windows[i];
-        for (std::size_t x = w->x; x < w->x + w->width; x++) {
-            for (std::size_t y = w->y; y < w->y + w->height; y++) {
+    for (auto [originalIndex, geo] : windowAreasByOriginalIndex) {
+        for (std::size_t x = geo.x; x < geo.x + geo.width; x++) {
+            for (std::size_t y = geo.y; y < geo.y + geo.height; y++) {
                 if (grid[x][y] != -1) {
                     isOverlapDetected = true;
                 }
-                grid[x][y] = static_cast<int>(i);
+                grid[x][y] = static_cast<int>(originalIndex);
             }
         }
     }
 
     const bool isEmptyCellDetected = std::ranges::any_of(grid | std::views::join, [](int cellValue) { return cellValue == -1; });
 
+    layoutInFreeRegion(grid, windows, 0, maxX, 0, maxY, dockspaceID(), isEditable);
+
     // if layout is ill-formed -> inform user and use grid layout
     if (isOverlapDetected) {
         components::Notification::error("Free layout is ill-formed, overlapped cells detected.");
-        layoutInGrid(windows, isEditable);
     } else if (isEmptyCellDetected) {
         components::Notification::error("Free layout is ill-formed, empty cells detected.");
-        layoutInGrid(windows, isEditable);
-    } else {
-        layoutInFreeRegion(grid, windows, 0, maxX, 0, maxY, dockspaceID(), isEditable);
     }
+
+    return !isEmptyCellDetected && !isOverlapDetected;
 }
 
 void DockSpace::layoutInFreeRegion(const std::vector<std::vector<int>>& grid, const Windows& windows, std::size_t x0, std::size_t x1, std::size_t y0, std::size_t y1, ImGuiID nodeId, bool isEditable) {
@@ -340,7 +349,7 @@ void DockSpace::layoutInFreeRegion(const std::vector<std::vector<int>>& grid, co
     }
 }
 
-void DockSpace::relayout(const Windows& windows, bool isEditable) {
+void DockSpace::relayout(const Windows& windows, bool isEditable, bool exactFreeLayoutRequested) {
     const ImGuiID dockspaceID = this->dockspaceID();
     ImGui::DockBuilderAddNode(dockspaceID);
     ImGui::DockBuilderSetNodeSize(dockspaceID, ImGui::GetWindowSize());
@@ -348,7 +357,13 @@ void DockSpace::relayout(const Windows& windows, bool isEditable) {
     if (isBoxLayout()) {
         layoutInBox(windows, _layoutType == DockingLayoutType::Row ? ImGuiDir_Left : ImGuiDir_Up, isEditable);
     } else if (isFreeLayout()) {
-        layoutInFree(windows, isEditable);
+        if (exactFreeLayoutRequested) {
+            if (!layoutInExactFree(windows, isEditable)) {
+                layoutInGrid(windows, isEditable); // fallback, will be saved as state of free layout
+            }
+        } else {
+            restoreDockSpaceState(_lastFreeLayout, dockspaceID);
+        }
     } else {
         layoutInGrid(windows, isEditable);
     }

--- a/src/ui/components/Docking.hpp
+++ b/src/ui/components/Docking.hpp
@@ -1,12 +1,14 @@
 #ifndef OPENDIGITIZER_DOCKING_H
 #define OPENDIGITIZER_DOCKING_H
 
+#include "../utils/ImGuiDockSpaceState.hpp"
+
 #include <imgui.h>
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
-#include <vector>
 
 /// Place for Docking related components generic and agnostic to Opendigitizer code
 
@@ -27,6 +29,7 @@ inline constexpr const char* dockingLayoutName(DockingLayoutType type) {
 
 /// Hosts a group of dock windows
 class DockSpace {
+    gr::property_map  _lastFreeLayout;
     DockingLayoutType _layoutType      = DockingLayoutType::Free;
     bool              _needsRelayout   = true;
     bool              _lastIsEditable  = false;
@@ -43,7 +46,12 @@ public:
     void setLayoutType(DockingLayoutType);
 
     /// Renders the specified windows in an area of size paneSize
+    /// May modify windows by setting Window::freeLayoutPosition to nullopt
     void render(const Windows& windows, ImVec2 paneSize, bool isEditable);
+
+    // save and load the free layout (including any floating windows)
+    const gr::property_map& saveFreeLayout() const { return _lastFreeLayout; }
+    void                    loadFreeLayout(const gr::property_map& layout) { _lastFreeLayout = layout; }
 
 private:
     static ImGuiID dockspaceID();
@@ -51,18 +59,18 @@ private:
     void renderWindows(const Windows& windows, bool isEditable);
     void drawEditableWindowDragArea();
 
-    void clearWindowGeometry(const Windows& windows);
-
     // positions all windows according to the current layout type
-    void relayout(const Windows& windows, bool isEditable);
+    // this function does not restore the location of floating windows, renderWindows() will do that
+    void relayout(const Windows& windows, bool isEditable, bool exactFreeLayoutRequested);
 
     // perform a box layout (aka row or column layout)
     void layoutInBox(const Windows& windows, ImGuiDir, bool isEditable);
 
     void layoutInGrid(const Windows& windows, bool isEditable);
 
-    void layoutInFree(const Windows& windows, bool isEditable);
-    void layoutInFreeRegion(const std::vector<std::vector<int>>& grid, const Windows& windows, std::size_t x0, std::size_t x1, std::size_t y0, std::size_t y1, ImGuiID nodeId, bool isEditable);
+    // returns false if layout in the exactly requested geometries fails
+    [[nodiscard]] bool layoutInExactFree(const Windows& windows, bool isEditable);
+    void               layoutInFreeRegion(const std::vector<std::vector<int>>& grid, const Windows& windows, std::size_t x0, std::size_t x1, std::size_t y0, std::size_t y1, ImGuiID nodeId, bool isEditable);
 
     // triggers a relayout for the next frame
     void setNeedsRelayout(bool);
@@ -77,23 +85,20 @@ struct DockSpace::Window {
     explicit Window(const std::string& n) : name(n) {}
 
     std::string           name;
-    std::size_t           x      = 0UZ;
-    std::size_t           y      = 0UZ;
-    std::size_t           width  = 0UZ;
-    std::size_t           height = 0UZ;
     std::function<void()> renderFunc;
     std::function<void()> renderDockingContextMenuFunc;
 
-    void clearGeometry() { setGeometry({}, {}); }
+    struct FreeGeometry {
+        std::size_t x      = 0UL;
+        std::size_t y      = 0UL;
+        std::size_t width  = 0UL;
+        std::size_t height = 0UL;
+    };
 
-    void setGeometry(ImVec2 pos, ImVec2 size) {
-        x      = static_cast<std::size_t>(pos.x);
-        y      = static_cast<std::size_t>(pos.y);
-        width  = static_cast<std::size_t>(size.x);
-        height = static_cast<std::size_t>(size.y);
-    }
-
-    [[nodiscard]] bool hasSize() const { return width > 0 && height > 0; }
+    /// If set, this is applied on call to render(). Requires that windows with this set collectively cover all of paneSize
+    /// Min point of the pane is (0, 0).
+    /// This is only used at startup, loaded from "rect" field of plots in dashboard yaml
+    std::optional<FreeGeometry> freeLayoutPosition;
 };
 
 } // namespace DigitizerUi

--- a/src/ui/test/qa_layout.cpp
+++ b/src/ui/test/qa_layout.cpp
@@ -51,7 +51,7 @@ struct TestApp : public DigitizerUi::test::ImGuiTestApp {
             if (g_state->dashboard) {
                 DigitizerUi::DashboardPage page;
                 page.setDashboard(*g_state->dashboard);
-                page.setLayoutType(vars.layoutType);
+                page.setLayoutConfiguration(vars.layoutType, {});
                 page.draw();
                 ut::expect(!g_state->dashboard->uiWindows.empty()) << ut::fatal;
             }

--- a/src/ui/utils/ImGuiDockSpaceState.cpp
+++ b/src/ui/utils/ImGuiDockSpaceState.cpp
@@ -1,0 +1,176 @@
+#include "ImGuiDockSpaceState.hpp"
+
+#include <array>
+#include <print>
+#include <string>
+#include <unordered_map>
+
+#include <imgui_internal.h>
+
+namespace {
+constexpr auto defaultSplitRatio = 1.F;
+
+gr::property_map saveLayoutVisitor(ImGuiDockNode* node, std::unordered_map<std::string_view, ImGuiWindow*>& remainingWindowsByName) noexcept {
+    const auto [left, right] = node->ChildNodes;
+
+    if (node->Windows.size() > 0) {
+        // this seems to only really be possible for floating windows, you can dock
+        // onto the window frame and both windows will take up the same node. We
+        // just don't save this
+        return {};
+    }
+    if (!left && !right && node->Windows.size() == 0UL) {
+        // this node has no children or windows so it does not need to be
+        // remembered, probably the root node with nothing docked in it
+        return {};
+    }
+
+    gr::property_map out;
+
+    const auto splitRatio = !left && !right ? defaultSplitRatio : [node, left, right] {
+        if (node->SplitAxis == ImGuiAxis_X) {
+            return (left ? left->Size.x : right->Size.x) / node->Size.x;
+        } else {
+            return (right ? right->Size.y : left->Size.y) / node->Size.y;
+        }
+    }();
+
+    if (splitRatio != defaultSplitRatio) {
+        out.try_emplace("ratio", splitRatio);
+    }
+
+    const auto branch = [&remainingWindowsByName](auto* child) {
+        gr::pmt::Value childBranch;
+        if (child) {
+            if (child->ChildNodes[0] == nullptr && child->ChildNodes[1] == nullptr && child->Windows.size() == 1) {
+                childBranch = child->Windows.front()->Name;
+                if (auto iter = remainingWindowsByName.find(child->Windows.front()->Name); iter != remainingWindowsByName.end()) {
+                    remainingWindowsByName.erase(iter);
+                }
+            } else {
+                childBranch = saveLayoutVisitor(child, remainingWindowsByName);
+            }
+        }
+        return childBranch;
+    };
+
+    if (auto firstChild = branch(left)) {
+        out.try_emplace("first", std::move(firstChild));
+    }
+    if (auto secondChild = branch(right)) {
+        out.try_emplace("second", std::move(secondChild));
+    }
+
+    return gr::property_map{{node->SplitAxis == ImGuiAxis_X ? "hsplit" : "vsplit", std::move(out)}};
+};
+
+void applyLayoutVisitor(const gr::property_map& region, ImGuiID nodeId) noexcept {
+    auto hsplit = region.find("hsplit");
+    auto vsplit = region.find("vsplit");
+    if (hsplit == region.end() && vsplit == region.end()) { // invalid yaml
+        return;
+    }
+    const bool splitIsHorizontal = hsplit != region.end();
+    const auto split             = splitIsHorizontal ? hsplit : vsplit;
+
+    if (const auto* regionInner = split->second.get_if<gr::property_map>()) {
+        const auto  ratioIter = regionInner->find("ratio");
+        const float ratio     = ratioIter != regionInner->end() ? ratioIter->second.value_or(defaultSplitRatio) : defaultSplitRatio;
+
+        const auto firstIter  = regionInner->find("first");
+        const auto secondIter = regionInner->find("second");
+        if (firstIter != regionInner->end() && secondIter != regionInner->end()) {
+            ImGuiID topNode;
+            ImGuiID bottomNode;
+            ImGui::DockBuilderSplitNode(nodeId, splitIsHorizontal ? ImGuiDir_Left : ImGuiDir_Down, ratio, &topNode, &bottomNode);
+
+            const auto doChild = [](const auto& iter, ImGuiID node) {
+                if (const auto* map = iter->second.template get_if<gr::property_map>()) {
+                    applyLayoutVisitor(*map, node);
+                } else if (const auto* windowNameStr = iter->second.template get_if<std::pmr::string>()) {
+                    ImGui::DockBuilderDockWindow(windowNameStr->c_str(), node);
+                }
+            };
+
+            doChild(firstIter, splitIsHorizontal ? topNode : bottomNode);
+            doChild(secondIter, splitIsHorizontal ? bottomNode : topNode);
+        }
+    }
+};
+} // namespace
+
+namespace DigitizerUi {
+/// Custom serialization of ImGui dockspace state. ImGui::SaveIniSettingsToMemory()
+/// and ImGui::LoadIniSettingsFromMemory() are also available and they mostly
+/// handle this, but then we end up doing something like putting an entire INI file
+/// as a string into our dashboard yaml, and we can't control what gets serialized.
+gr::property_map saveDockSpaceState(std::span<const std::string_view> relevantWindowsNames, ImGuiID dockspaceNodeID) noexcept {
+    ImGuiContext&  g                    = *GImGui;
+    ImGuiDockNode* centralDockspaceNode = ImGui::DockBuilderGetNode(dockspaceNodeID);
+    assert(centralDockspaceNode);
+
+    // pair up relevant window names with their imgui windows
+    std::unordered_map<std::string_view, ImGuiWindow*> remainingWindowsByName;
+    remainingWindowsByName.reserve(relevantWindowsNames.size());
+    for (std::string_view windowName : relevantWindowsNames) {
+        auto [_, wasEmplaced] = remainingWindowsByName.try_emplace(windowName, nullptr);
+        assert(wasEmplaced); // non-unique window names
+    }
+    for (ImGuiWindow* window : g.Windows) {
+        if (auto iter = remainingWindowsByName.find(window->Name); iter != std::end(remainingWindowsByName)) {
+            assert(iter->second == nullptr); // non-unique window names, not in relevantWindowsNames, but in imgui
+            iter->second = window;
+        }
+    }
+
+    gr::property_map dockSpace = saveLayoutVisitor(centralDockspaceNode, remainingWindowsByName);
+
+    gr::property_map floatingWindows;
+    for (const auto [windowName, windowPtr] : remainingWindowsByName) {
+        if (windowPtr == nullptr) {
+#ifndef NDEBUG
+            std::println(stderr, "WARNING: attempt to save state for window {} but no such window exists, or it was deemed invalid", windowName);
+#endif
+            continue;
+        }
+
+        floatingWindows[std::pmr::string{windowName}] = gr::property_map{
+            {"x", windowPtr->Pos.x},
+            {"y", windowPtr->Pos.y},
+            {"width", windowPtr->Size.x},
+            {"height", windowPtr->Size.y},
+        };
+    }
+
+    return {
+        {"dockSpace", std::move(dockSpace)},
+        {"floatingWindows", std::move(floatingWindows)},
+    };
+}
+
+void restoreDockSpaceState(const gr::property_map& state, ImGuiID rootNodeID) noexcept {
+    auto dockSpaceIter = state.find("dockSpace");
+    auto floatingIter  = state.find("floatingWindows");
+    if (floatingIter == state.end() || dockSpaceIter == state.end()) {
+        return;
+    }
+
+    if (const auto* dockMap = dockSpaceIter->second.get_if<gr::property_map>()) {
+        applyLayoutVisitor(*dockMap, rootNodeID);
+    }
+
+    if (const auto* floatingWindowsMap = floatingIter->second.get_if<gr::property_map>()) {
+        for (const auto& [windowName, windowDescriptionPmtValue] : *floatingWindowsMap) {
+            if (const auto* windowDescription = windowDescriptionPmtValue.get_if<gr::property_map>()) {
+                auto get = [windowDescription](const auto& key) -> float {
+                    auto iter = windowDescription->find(key);
+                    return iter == std::end(*windowDescription) ? 0.F : iter->second.value_or(0.F);
+                };
+
+                ImGui::SetWindowPos(windowName.c_str(), {get("x"), get("y")});
+                ImGui::SetWindowSize(windowName.c_str(), {get("width"), get("height")});
+            }
+        }
+    }
+}
+} // namespace DigitizerUi

--- a/src/ui/utils/ImGuiDockSpaceState.hpp
+++ b/src/ui/utils/ImGuiDockSpaceState.hpp
@@ -1,0 +1,19 @@
+#ifndef OPENDIGITIZER_UTILS_IMGUI_DOCK_SPACE_LAYOUT_SERIALIZATION_HPP
+#define OPENDIGITIZER_UTILS_IMGUI_DOCK_SPACE_LAYOUT_SERIALIZATION_HPP
+
+#include <gnuradio-4.0/Tag.hpp>
+#include <imgui.h>
+#include <span>
+
+namespace DigitizerUi {
+/// Save the state of all relevant windows and how they are docked within a given
+/// dockspace. Additionally saves the state of any floating windows whose names
+/// are found in relevantWindowsNames
+gr::property_map saveDockSpaceState(std::span<const std::string_view> relevantWindowsNames, ImGuiID dockspaceNodeID) noexcept;
+
+/// Restore the state of a dockspace, should be called within ImGui::DockBuilderAddNode()
+/// and ImGui::DockBuilderFinish().
+void restoreDockSpaceState(const gr::property_map& state, ImGuiID rootNodeID) noexcept;
+} // namespace DigitizerUi
+
+#endif


### PR DESCRIPTION
Previously the free layout would be loaded from a file as x/y/width/height per window, and then never be altered. Relayouting in the context of free meant returning to the layout in the original yaml. I wanted to implement saving/restoring the free layout (to address #436 so windows would go back to their expected places when returning to free mode) but I struggled to do a good job of writing out the rect areas so they would be correctly parsed + restored by the `layoutInFreeRegion` function. Ultimately I switched gears and tried just saving the actual splits of the dockspace instead, and I think this ended up being simpler.

So the main changes of this PR are:
1. every frame while in free layout, the state of the dockspace and floating windows is saved to a `property_map`. It's restored on relayout, like when adding a window or switching back from another layout type.
2. the dashboard yaml also includes this serialized version of things under a new key `windowLayout`. New dashboards will no longer include the `rect` field for plots, though they can still read it from old dashboards.

The second point is sort of an additional/unasked-for feature, as it was relatively easy to do since there is now a way to serialize arbitrary layouts of chart windows. AFAICT, previously the chart layouts in yaml were written by hand.

The new yaml description of the layout looks like this:

```yaml
  windowLayout:
    floatingWindows:  {}
    dockSpace:
      hsplit:
        second:  "Spectrum View"
        first:
          vsplit:
            second:  "Function Generators"
            first:
              hsplit:
                second:  "FFT Spectrum"
                first:  "Raw Signal"
                ratio: !!float32 0.498815
            ratio: !!float32 0.497561
        ratio: !!float32 0.665091
```

And here's the behaviors of the programs demonstrated in the related issue after this change:

https://github.com/user-attachments/assets/d79cb7cc-5440-4e3a-ae88-4d37008e216a

I think this is more along the lines of what I would expect. Unfortunately if you add a chart in a grid/box layout and then switch back to free, the chart is floating (not bad) but often much bigger than I would expect and covering many charts (bad). I was working on a fix for this but it began to get complicated and I was already over time, so I stashed it. Maybe a separate issue / for later.

(Note to self: in the above video, you can spot another bug, which is that specifically the splitter in the center of a waterfall plot seems to not respect input ordering and takes input even if there is a window drag `InvisibleButton` over it).