### PR TITLE
Use latest DataSet for XYChart timing tags

### DIFF
--- a/src/ui/charts/XYChart.hpp
+++ b/src/ui/charts/XYChart.hpp
@@ -198,7 +198,7 @@ struct XYChart : gr::Block<XYChart, gr::Drawable<gr::UICategory::Content, "ImGui
                     if (show_tags.value && !tagsDrawnForFirstSink) {
                         auto allDataSets = sink->dataSets();
                         if (!allDataSets.empty()) {
-                            tags::drawDataSetTimingEvents(allDataSets[0], _xCategories[xAxisIdx].has_value() ? _xCategories[xAxisIdx]->scale : AxisScale::Linear, baseColor);
+                            tags::drawDataSetTimingEvents(allDataSets.back(), _xCategories[xAxisIdx].has_value() ? _xCategories[xAxisIdx]->scale : AxisScale::Linear, baseColor);
                         }
                         tagsDrawnForFirstSink = true;
                     }


### PR DESCRIPTION
## Summary

Fixes stale timing tag rendering for triggered/DataSet plots in `XYChart`.

`XYChart` already draws DataSet signal history from the latest retained DataSets, but the timing tag overlay was always taken from `allDataSets[0]`. For `ImPlotSink`/`HistoryBuffer` DataSet storage, `push_back()` keeps the span ordered oldest-to-newest, so index `0` is the oldest retained DataSet, not the current one.

As a result, triggered dashboard plots could show the latest DataSet curve while still displaying timing tags from an old trigger. 

## Fix
Use the newest retained DataSet for the timing tag overlay: `allDataSets.back()`

## Notes

This fixes the dashboard chart path used by YAML/GRC dashboards. The older direct ImPlotSink::draw() path is separate and was not changed here.
