### PR TITLE
Dashboard property control widgets

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -91,6 +91,7 @@ cmrc_add_resource_library(
   sample_dashboards
   assets/sampleDashboards/dashboard.grc
   assets/sampleDashboards/ExtendedDemoDashboard.grc
+  assets/sampleDashboards/PropertyControlDashboard.grc
   assets/sampleDashboards/DemoDashboard.grc)
 
 if(EMSCRIPTEN)
@@ -199,6 +200,8 @@ add_library(
   components/Dialog.hpp
   components/Docking.cpp
   components/Docking.hpp
+  components/ExportedPropertiesList.hpp
+  components/ExportedPropertiesList.cpp
   components/FilterComboBoxes.hpp
   components/Keypad.hpp
   components/ListBox.hpp
@@ -218,6 +221,7 @@ add_library(
   common/AppDefinitions.hpp
   common/Events.hpp
   common/ImguiWrap.hpp
+  common/ImguiWrap.cpp
   common/LookAndFeel.hpp
   common/LookAndFeel.cpp
   common/TouchHandler.hpp)

--- a/src/ui/Dashboard.cpp
+++ b/src/ui/Dashboard.cpp
@@ -1010,8 +1010,8 @@ void Dashboard::Service::reload() {
         auto        newFlowgraph = opendigitizer::flowgraph::getFlowgraphFromMessage(message);
 
         if (newFlowgraph) {
-            grc    = newFlowgraph->serialisedFlowgraph;
-            layout = newFlowgraph->serialisedUiLayout;
+            this->grc    = newFlowgraph->serialisedFlowgraph;
+            this->layout = newFlowgraph->serialisedUiLayout;
 
         } else {
             components::Notification::warning("Error reading flowgraph from the service reply");
@@ -1096,8 +1096,8 @@ void Dashboard::Service::execute() {
     command.command = opencmw::mdp::Command::Set;
 
     FlowgraphMessage request;
-    request.flowgraph = grc;
-    request.layout    = layout;
+    request.flowgraph = this->grc;
+    request.layout    = this->layout;
     opencmw::serialise<opencmw::Json>(command.data, request);
 
     command.topic    = opencmw::URI<>(uri);

--- a/src/ui/Dashboard.cpp
+++ b/src/ui/Dashboard.cpp
@@ -208,6 +208,74 @@ std::shared_ptr<DashboardStorageInfo> DashboardStorageInfo::memoryDashboardStora
     return storageInfo;
 }
 
+std::size_t& lastUsedWindowId() {
+    static std::size_t lastUsedWindowId = 0;
+    return lastUsedWindowId;
+}
+
+std::string Dashboard::generateUniqueNameForPropertyControlWindow(UiGraphBlock* block, std::string_view propertyName) {
+    auto        currentlyInUse = getAllWindowNamesInUse();
+    const char* blockName      = block ? block->blockName.c_str() : "UNKNOWN";
+    const auto  prefix         = std::format("Property control for {} of block {}", propertyName, blockName);
+    // imgui will try to remember the position of windows by name, and return
+    // them there if the window is drawn again later.
+    // so unlike generateUniqueNameForUiWindow, this will always append
+    // lastUsedWindowId, so that new property windows are treated as entirely
+    // new windows without their old position/size remembered.
+    std::string out;
+    do {
+        ++lastUsedWindowId();
+        out = std::format("{}{}", prefix, lastUsedWindowId());
+    } while (currentlyInUse.contains(out));
+    return out;
+}
+
+std::string Dashboard::generateUniqueNameForUiWindow(gr::BlockModel& block, std::string_view desiredName) {
+    auto              currentlyInUse = getAllWindowNamesInUse();
+    const std::string desiredNameString{desiredName.empty() ? block.uniqueName() : desiredName};
+    std::string       out = desiredNameString;
+    while (currentlyInUse.contains(out)) {
+        ++lastUsedWindowId();
+        out = std::format("{}{}", desiredNameString, lastUsedWindowId());
+    }
+    return out;
+}
+
+std::unordered_set<std::string_view> Dashboard::getAllWindowNamesInUse() const {
+    std::unordered_set<std::string_view> output;
+    for (const auto& window : uiWindows) {
+        auto [_, wasEmplaced] = output.emplace(std::string_view{window.window->name});
+        assert(wasEmplaced);
+    }
+    for (const auto& [id, controlWindow] : propertyControlWindows) {
+        auto [_, wasEmplaced] = output.emplace(std::string_view{controlWindow.window->name});
+        assert(wasEmplaced);
+    }
+    return output;
+}
+
+Dashboard::UIWindow::UIWindow(Dashboard& dashboard, std::shared_ptr<gr::BlockModel> blk, std::string_view name) //
+    : window(std::make_shared<DockSpace::Window>(dashboard.generateUniqueNameForUiWindow(*blk, name))), block(std::move(blk)) {}
+
+Dashboard::UIWindow::UIWindow(DeserializeTag, std::shared_ptr<gr::BlockModel> blk, std::string_view name) //
+    : window(std::make_shared<DockSpace::Window>(std::string{name})), block(std::move(blk)) {}
+
+Dashboard::PropertyControlWindow::PropertyControlWindow(DeserializeTag, std::string_view labelView, std::string_view windowName)
+    : window(std::make_shared<DockSpace::Window>(std::string{windowName})), //
+      label{labelView}                                                      //
+{}
+
+Dashboard::PropertyControlWindow::PropertyControlWindow(Dashboard& dashboard, UiGraphModel* graphModel, //
+    std::string_view propertyName, std::string_view labelView, std::string_view blockName)              //
+    : PropertyControlWindow(dashboard, graphModel->recursiveFindBlockByName(blockName).block, propertyName, labelView) {}
+
+Dashboard::PropertyControlWindow::PropertyControlWindow(Dashboard& dashboard, UiGraphBlock* block, std::string_view propertyName, std::string_view labelView) //
+    : window(std::make_shared<DockSpace::Window>(dashboard.generateUniqueNameForPropertyControlWindow(block, propertyName))),                                 //
+      label{labelView}                                                                                                                                        //
+{
+    assert(block && "trying to control property of nonexistent block");
+}
+
 Dashboard::Dashboard(PrivateTag, std::shared_ptr<opencmw::client::RestClient> client, const std::shared_ptr<const DashboardDescription>& desc) : restClient(std::move(client)), description(desc) {
     description->lastUsed = std::chrono::floor<std::chrono::days>(std::chrono::system_clock::now());
 
@@ -457,7 +525,7 @@ void Dashboard::doLoad(const gr::property_map& dashboard) {
         }
 
         // Create UIWindow for this chart (sink management done via settings interface)
-        UIWindow uiWindow(blockShared, name);
+        UIWindow uiWindow(DeserializeTag{}, blockShared, name);
 
         if (rect) {
             uiWindow.window->freeLayoutPosition = {
@@ -473,73 +541,28 @@ void Dashboard::doLoad(const gr::property_map& dashboard) {
 
     // Load sinks for all UIWindows (sinks should be registered in SinkRegistry by now)
     loadUIWindowSources();
+
+    if (dashboard.contains("exportedProperties")) {
+        // exportedProperties are stored in the graph model, so defer loading this until that is loaded
+        this->exportedProperties = dashboard.at("exportedProperties").value_or(gr::property_map{});
+    }
+    if (dashboard.contains("propertyControlWindows")) {
+        if (const auto* controlWindowsByWindowName = dashboard.at("propertyControlWindows").get_if<gr::property_map>()) {
+            for (const auto& [controlWindowName, controlWindowPropertiesValue] : *controlWindowsByWindowName) {
+                if (const auto* controlWindowProperties = controlWindowPropertiesValue.get_if<gr::property_map>()) {
+                    const auto* id    = controlWindowProperties->at("id").get_if<gr::Size_t>();
+                    const auto* label = controlWindowProperties->at("label").get_if<std::pmr::string>();
+                    if (id && label) {
+                        propertyControlWindows.try_emplace(*id, DeserializeTag{}, *label, controlWindowName);
+                    }
+                }
+            }
+        }
+    }
 }
 
-void Dashboard::save() {
+void Dashboard::saveStore(gr::property_map& headerYaml, gr::property_map& dashboardYaml) {
     using namespace gr;
-
-    if (description->storageInfo->isInMemoryDashboardStorage()) {
-        return;
-    }
-
-    property_map headerYaml;
-    headerYaml["favorite"] = description->isFavorite;
-    std::chrono::year_month_day ymd(std::chrono::floor<std::chrono::days>(description->lastUsed.value()));
-    char                        lastUsed[11];
-    std::format_to(lastUsed, "{:02}/{:02}/{:04}", static_cast<unsigned>(ymd.day()), static_cast<unsigned>(ymd.month()), static_cast<int>(ymd.year()));
-    headerYaml["lastUsed"] = std::string(lastUsed);
-
-    property_map dashboardYaml = gr::detail::saveGraphToMap(*pluginLoader, scheduler->graph());
-
-    gr::Tensor<gr::pmt::Value> sources;
-    // Use SinkRegistry with SignalSink interface for serialization
-    opendigitizer::charts::SinkRegistry::instance().forEach([&](const opendigitizer::charts::SignalSink& sink) {
-        // TODO: Port saving and loading flowgraph layouts
-        property_map map;
-        map["name"]  = std::string(sink.name());
-        map["color"] = sink.color();
-
-        sources.emplace_back(std::move(map));
-    });
-    dashboardYaml["sources"] = sources;
-
-    dashboardYaml["windowLayout"] = windowLayout;
-
-    gr::Tensor<gr::pmt::Value> plots;
-    // Iterate UIWindows for chart serialization (new API)
-    for (const auto& w : uiWindows) {
-        if (!w.isChart() || !w.block) {
-            continue;
-        }
-
-        property_map plotMap;
-        plotMap["name"] = w.window ? w.window->name : std::string(w.block->uniqueName());
-        // Extract short chart type name from fully-qualified name (e.g., "opendigitizer::charts::XYChart" -> "XYChart")
-        std::string fullTypeName = std::string(w.block->typeName());
-        if (auto pos = fullTypeName.rfind("::"); pos != std::string::npos) {
-            plotMap["type"] = fullTypeName.substr(pos + 2);
-        } else {
-            plotMap["type"] = fullTypeName;
-        }
-
-        // Serialize axes from uiConstraints
-        gr::Tensor<gr::pmt::Value> plotAxes;
-        const auto&                constraints = w.block->uiConstraints();
-        if (constraints.contains("axes")) {
-            plotAxes = constraints.at("axes").value_or(gr::Tensor<gr::pmt::Value>{});
-        }
-        plotMap["axes"] = plotAxes;
-
-        // Serialize signal sinks from data_sinks property
-        gr::Tensor<gr::pmt::Value> plotSinkBlockNames;
-        for (const auto& sinkName : grc_compat::getBlockSinkNames(w.block.get())) {
-            plotSinkBlockNames.emplace_back(sinkName);
-        }
-        plotMap["sources"] = plotSinkBlockNames;
-        plots.emplace_back(plotMap);
-    }
-    dashboardYaml["plots"] = plots;
-
     if (description->storageInfo->path.starts_with("http://") || description->storageInfo->path.starts_with("https://")) {
         auto path = std::filesystem::path(description->storageInfo->path) / description->filename;
 
@@ -595,10 +618,102 @@ void Dashboard::save() {
     }
 }
 
+void Dashboard::save() {
+    using namespace gr;
+
+    if (description->storageInfo->isInMemoryDashboardStorage()) {
+        return;
+    }
+
+    property_map headerYaml;
+    headerYaml["favorite"] = description->isFavorite;
+    std::chrono::year_month_day ymd(std::chrono::floor<std::chrono::days>(description->lastUsed.value()));
+    char                        lastUsed[11];
+    std::format_to(lastUsed, "{:02}/{:02}/{:04}", static_cast<unsigned>(ymd.day()), static_cast<unsigned>(ymd.month()), static_cast<int>(ymd.year()));
+    headerYaml["lastUsed"] = std::string(lastUsed);
+
+    property_map dashboardYaml = gr::detail::saveGraphToMap(*pluginLoader, scheduler->graph());
+
+    gr::Tensor<gr::pmt::Value> sources;
+    // Use SinkRegistry with SignalSink interface for serialization
+    opendigitizer::charts::SinkRegistry::instance().forEach([&](const opendigitizer::charts::SignalSink& sink) {
+        // TODO: Port saving and loading flowgraph layouts
+        property_map map;
+        map["name"]  = std::string(sink.name());
+        map["color"] = sink.color();
+
+        sources.emplace_back(std::move(map));
+    });
+    dashboardYaml["sources"] = sources;
+
+    dashboardYaml["windowLayout"] = windowLayout;
+
+    dashboardYaml["propertyControlWindows"] = [this] {
+        gr::property_map out;
+        for (const auto& [id, controlWindow] : propertyControlWindows) {
+            gr::property_map windowProperties = {{"id", static_cast<gr::Size_t>(id)}, {"label", controlWindow.label}};
+            out.try_emplace(std::pmr::string{controlWindow.window->name}, std::move(windowProperties));
+        }
+        return out;
+    }();
+
+    dashboardYaml["exportedProperties"] = [this] {
+        auto             exported = this->graphModel.recursiveGatherExportedProperties();
+        gr::property_map properties;
+        for (const auto& [block, exportedPropertiesPtr] : exported) {
+            gr::property_map blockProperties;
+            blockProperties.reserve(exportedPropertiesPtr->size());
+            for (const auto& [propertyName, info] : *exportedPropertiesPtr) {
+                blockProperties.try_emplace(std::pmr::string{propertyName}, info.windowId ? gr::pmt::Value{static_cast<gr::Size_t>(*info.windowId)} : gr::pmt::Value{});
+            }
+            properties[std::pmr::string{block}] = blockProperties;
+        }
+        return properties;
+    }();
+
+    gr::Tensor<gr::pmt::Value> plots;
+    // Iterate UIWindows for chart serialization (new API)
+    for (const auto& w : uiWindows) {
+        if (!w.isChart() || !w.block) {
+            continue;
+        }
+
+        property_map plotMap;
+        plotMap["name"] = w.window ? w.window->name : std::string(w.block->uniqueName());
+        // Extract short chart type name from fully-qualified name (e.g., "opendigitizer::charts::XYChart" -> "XYChart")
+        std::string fullTypeName = std::string(w.block->typeName());
+        if (auto pos = fullTypeName.rfind("::"); pos != std::string::npos) {
+            plotMap["type"] = fullTypeName.substr(pos + 2);
+        } else {
+            plotMap["type"] = fullTypeName;
+        }
+
+        // Serialize axes from uiConstraints
+        gr::Tensor<gr::pmt::Value> plotAxes;
+        const auto&                constraints = w.block->uiConstraints();
+        if (constraints.contains("axes")) {
+            plotAxes = constraints.at("axes").value_or(gr::Tensor<gr::pmt::Value>{});
+        }
+        plotMap["axes"] = plotAxes;
+
+        // Serialize signal sinks from data_sinks property
+        gr::Tensor<gr::pmt::Value> plotSinkBlockNames;
+        for (const auto& sinkName : grc_compat::getBlockSinkNames(w.block.get())) {
+            plotSinkBlockNames.emplace_back(sinkName);
+        }
+        plotMap["sources"] = plotSinkBlockNames;
+        plots.emplace_back(plotMap);
+    }
+    dashboardYaml["plots"] = plots;
+
+    saveStore(headerYaml, dashboardYaml);
+}
+
 DigitizerUi::Dashboard::UIWindow& Dashboard::newUIBlock(std::string_view chartType, const gr::property_map& chartInitialParameters) {
     std::string chartTypeName = chartType.empty() ? "XYChart" : std::string(chartType);
 
-    // Generate a unique name for the chart
+    // Generate a unique name for the chart. If this is not actually unique,
+    // then the UiWindow constructor will append another number.
     static int  chartCounter = 1;
     std::string chartName    = std::format("Chart {}", chartCounter++);
 
@@ -621,7 +736,7 @@ DigitizerUi::Dashboard::UIWindow& Dashboard::newUIBlock(std::string_view chartTy
     }
 
     // Create UIWindow for this chart
-    uiWindows.emplace_back(std::move(blockShared), std::move(chartName));
+    uiWindows.emplace_back(*this, std::move(blockShared), std::move(chartName));
 
     return uiWindows.back();
 }
@@ -764,6 +879,29 @@ bool Dashboard::transmuteUIWindow(UIWindow& win, std::string_view newChartType) 
     win.block = newBlockShared;
 
     return true;
+}
+
+std::pair<std::size_t, Dashboard::PropertyControlWindow&> Dashboard::newPropertyControlWindow(UiGraphBlock* block, std::string_view propertyName, std::string_view label) {
+    static std::size_t lastUsedId = 0;
+    do {
+        ++lastUsedId;
+    } while (this->propertyControlWindows.contains(lastUsedId));
+    auto [iter, _] = this->propertyControlWindows.try_emplace(lastUsedId, *this, block, propertyName, label);
+    return {lastUsedId, iter->second};
+}
+
+void Dashboard::applyExportedPropertiesToUiGraph() {
+    for (const auto& [blockNameKey, mapValue] : this->exportedProperties) {
+        const auto* exportedPropertiesForThisBlock = mapValue.get_if<gr::property_map>();
+        auto*       block                          = graphModel.recursiveFindBlockByName(blockNameKey).block;
+        if (block && exportedPropertiesForThisBlock) {
+            for (const auto& [propertyName, maybeWindowId] : *exportedPropertiesForThisBlock) {
+                auto optionalWindowId = maybeWindowId.is_unsigned_integral() ? std::optional<gr::Size_t>{maybeWindowId.value_or<>(gr::Size_t{})} : std::optional<gr::Size_t>{};
+                block->exportedProperties.try_emplace(std::string{propertyName}, optionalWindowId);
+            }
+        }
+    }
+    this->exportedProperties = {};
 }
 
 void Dashboard::removeSinkFromPlots(std::string_view sinkName) {

--- a/src/ui/Dashboard.cpp
+++ b/src/ui/Dashboard.cpp
@@ -288,9 +288,6 @@ Dashboard::Dashboard(PrivateTag, std::shared_ptr<opencmw::client::RestClient> cl
     ImPlot::GetStyle().Colors[ImPlotCol_FrameBg] = ImGui::GetStyle().Colors[ImGuiCol_WindowBg];
 
     graphModel.sendMessage_ = [this](gr::Message message, std::source_location location) { scheduler.sendMessage(std::move(message), std::move(location)); };
-
-    // Create the GlobalSignalLegend in uiGraph (Toolbar block showing all sinks)
-    uiGraph.emplaceBlock("DigitizerUi::GlobalSignalLegend", {});
 }
 
 Dashboard::~Dashboard() {}

--- a/src/ui/Dashboard.hpp
+++ b/src/ui/Dashboard.hpp
@@ -1,39 +1,37 @@
 #ifndef DASHBOARD_H
 #define DASHBOARD_H
 
-#include <chrono>
-#include <functional>
-#include <optional>
-#include <string>
-#include <string_view>
-#include <vector>
+#include "GraphModel.hpp"
+#include "Scheduler.hpp"
 
-#include <cmrc/cmrc.hpp>
-CMRC_DECLARE(sample_dashboards);
+#include "charts/Chart.hpp"
+
+#include "components/ColourManager.hpp"
+#include "components/Docking.hpp"
+#include "components/ExportedPropertiesList.hpp"
+
+#include <gnuradio-4.0/BlockRegistry.hpp>
+#include <gnuradio-4.0/Graph.hpp>
+#include <gnuradio-4.0/PluginLoader.hpp>
 
 #include <RestClient.hpp>
+
+#include <cmrc/cmrc.hpp>
 
 #ifdef EMSCRIPTEN
 #include "utils/emscripten_compat.hpp"
 #endif
 #include <plf_colony.h>
 
-#include <gnuradio-4.0/BlockRegistry.hpp>
-#include <gnuradio-4.0/Graph.hpp>
-#include <gnuradio-4.0/PluginLoader.hpp>
+#include <functional>
+#include <string>
+#include <string_view>
 
-#include "components/ColourManager.hpp"
-#include "components/Docking.hpp"
+CMRC_DECLARE(sample_dashboards);
 
 namespace detail {
 [[maybe_unused]] inline static opendigitizer::ColourManager& _colourManager = opendigitizer::ColourManager::instance();
 }
-
-#include "GraphModel.hpp"
-#include "Scheduler.hpp"
-#include "settings.hpp"
-
-#include "charts/Charts.hpp"
 
 namespace gr {
 class Graph;
@@ -94,17 +92,30 @@ struct DashboardDescription {
 struct Dashboard {
     using AxisConfig = opendigitizer::charts::AxisConfig;
     struct PrivateTag {};
+    struct DeserializeTag {};
 
     struct UIWindow {
         std::shared_ptr<DockSpace::Window> window;
         std::shared_ptr<gr::BlockModel>    block;
 
         UIWindow() = default;
-        explicit UIWindow(std::shared_ptr<gr::BlockModel> blk, std::string_view name = "") : window(std::make_shared<DockSpace::Window>(name.empty() ? std::string(blk->uniqueName()) : std::string(name))), block(std::move(blk)) {}
+        explicit UIWindow(Dashboard& dashboard, std::shared_ptr<gr::BlockModel> blk, std::string_view name = "");
+        explicit UIWindow(DeserializeTag, std::shared_ptr<gr::BlockModel> blk, std::string_view name = "");
 
         [[nodiscard]] bool           hasBlock() const noexcept { return block != nullptr; }
         [[nodiscard]] bool           isChart() const noexcept { return uiCategory() == gr::UICategory::Content; }
         [[nodiscard]] gr::UICategory uiCategory() const noexcept { return block ? block->uiCategory() : gr::UICategory::None; }
+    };
+
+    struct PropertyControlWindow {
+        std::shared_ptr<DockSpace::Window> window;
+        std::string                        label; // label for the editor widget, chosen by user
+
+        PropertyControlWindow(DeserializeTag, std::string_view labelView, std::string_view windowName);
+
+        // all the parameters of these constructors are just to know how to generate a good and unique name for the window
+        PropertyControlWindow(Dashboard& dashboard, UiGraphModel* graphModel, std::string_view propertyName, std::string_view labelView, std::string_view blockName);
+        PropertyControlWindow(Dashboard& dashboard, UiGraphBlock* block, std::string_view propertyName, std::string_view labelView);
     };
 
     struct Service {
@@ -131,17 +142,19 @@ struct Dashboard {
     std::atomic<bool>               isInUse = false;
     std::function<void(Dashboard*)> requestClose;
 
-    std::shared_ptr<opencmw::client::RestClient> restClient;
-    std::shared_ptr<const DashboardDescription>  description = nullptr;
-    std::vector<UIWindow>                        uiWindows;
-    DockingLayoutType                            layoutType;
-    gr::property_map                             windowLayout;
-    std::unordered_map<std::string, std::string> flowgraphUriByRemoteSource;
-    plf::colony<Service>                         services;
-    std::atomic<bool>                            isInitialised = false;
-    Scheduler                                    scheduler;
-    gr::Graph                                    uiGraph{*pluginLoader};
-    UiGraphModel                                 graphModel;
+    std::shared_ptr<opencmw::client::RestClient>           restClient;
+    std::shared_ptr<const DashboardDescription>            description = nullptr;
+    std::vector<UIWindow>                                  uiWindows;
+    std::unordered_map<std::size_t, PropertyControlWindow> propertyControlWindows;
+    DockingLayoutType                                      layoutType;
+    gr::property_map                                       windowLayout;
+    gr::property_map                                       exportedProperties;
+    std::unordered_map<std::string, std::string>           flowgraphUriByRemoteSource;
+    plf::colony<Service>                                   services;
+    std::atomic<bool>                                      isInitialised = false;
+    Scheduler                                              scheduler;
+    gr::Graph                                              uiGraph{*pluginLoader};
+    UiGraphModel                                           graphModel;
 
     explicit Dashboard(PrivateTag, std::shared_ptr<opencmw::client::RestClient> client, const std::shared_ptr<const DashboardDescription>& desc);
     ~Dashboard();
@@ -151,12 +164,20 @@ struct Dashboard {
     void load();
     void loadAndThen(std::string_view grcData, std::function<void(gr::Graph&&)> assignScheduler);
     void save();
+    void saveStore(gr::property_map& headerYaml, gr::property_map& dashboardYaml); // actually send message to save endpoint with serialized dashboard
     void doLoad(const gr::property_map& dashboard);
 
     UIWindow& newUIBlock(std::string_view chartType = "XYChart", const gr::property_map& chartInitialParameters = {});
     void      deleteChart(UIWindow* uiWindow);
     UIWindow* copyChart(std::string_view sourceChartId);
     bool      transmuteUIWindow(UIWindow& uiWindow, std::string_view newChartType);
+
+    std::pair<std::size_t, PropertyControlWindow&> newPropertyControlWindow(UiGraphBlock* block, std::string_view propertyName, std::string_view label);
+    void                                           applyExportedPropertiesToUiGraph();
+    [[nodiscard]] constexpr bool                   hasPendingExportedPropertiesConfiguration() const noexcept { return !this->exportedProperties.empty(); }
+    std::string                                    generateUniqueNameForPropertyControlWindow(UiGraphBlock* block, std::string_view propertyName);
+    std::string                                    generateUniqueNameForUiWindow(gr::BlockModel& block, std::string_view desiredName);
+    std::unordered_set<std::string_view>           getAllWindowNamesInUse() const;
 
     gr::BlockModel* emplaceChartBlock(std::string_view chartTypeName, const std::string& chartName, const gr::property_map& chartParameters = {});
     void            removeSinkFromPlots(std::string_view sinkName);
@@ -179,7 +200,16 @@ struct Dashboard {
         scheduler.emplaceGraph(std::forward<Args>(args)...);
     }
 
-    void handleMessages() { scheduler.handleMessages(graphModel); }
+    void handleMessages() {
+        scheduler.handleMessages(graphModel);
+
+        if (hasPendingExportedPropertiesConfiguration()) [[unlikely]] {
+            const auto* schedulerInfo = std::get_if<UiGraphBlock::SchedulerBlockInfo>(&graphModel.rootBlock.blockCategoryInfo);
+            if (schedulerInfo && schedulerInfo->childrenLoaded) {
+                applyExportedPropertiesToUiGraph();
+            }
+        }
+    }
 
     [[nodiscard]] UIWindow* findUIWindow(const std::shared_ptr<gr::BlockModel>& block) noexcept {
         if (!block) {
@@ -206,7 +236,7 @@ struct Dashboard {
         if (auto* existing = findUIWindow(block)) {
             return *existing;
         }
-        uiWindows.emplace_back(block);
+        uiWindows.emplace_back(*this, block);
         return uiWindows.back();
     }
 

--- a/src/ui/Dashboard.hpp
+++ b/src/ui/Dashboard.hpp
@@ -79,8 +79,6 @@ struct DashboardDescription {
     mutable bool                          isFavorite;
     mutable OptionalTimePoint             lastUsed;
 
-    static std::vector<std::shared_ptr<DashboardDescription>> s_knownDashboards;
-
     DashboardDescription(PrivateTag, std::string _name, std::shared_ptr<DashboardStorageInfo> _storageInfo, std::string _filename, bool _isFavorite, OptionalTimePoint _lastUsed) : name(std::move(_name)), storageInfo(std::move(_storageInfo)), filename(std::move(_filename)), isFavorite(_isFavorite), lastUsed(std::move(_lastUsed)) {}
 
     void save();

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -13,7 +13,6 @@
 #include "components/Splitter.hpp"
 #include "components/YesNoPopup.hpp"
 
-#include "blocks/GlobalSignalLegend.hpp"
 #include "blocks/ImPlotSink.hpp"
 #include "blocks/RemoteSource.hpp"
 #include "charts/Chart.hpp"
@@ -477,44 +476,15 @@ void DashboardPage::drawToolbarLayoutButtons(float plotButtonSize) noexcept {
 }
 
 ImVec2 DashboardPage::drawLegendCenter(Mode mode, ImVec2 chartPaneSize) noexcept {
-    static constexpr std::string_view kLegendBlockType = "DigitizerUi::GlobalSignalLegend";
-
-    ImVec2 totalSize{0.f, 0.f};
-    for (auto& blockPtr : _dashboard->uiGraph.blocks()) {
-        if (blockPtr->uiCategory() != gr::UICategory::Toolbar) {
-            continue;
-        }
-
-        // Configure GlobalSignalLegend before drawing
-        const bool isLegendBlock = (blockPtr->typeName() == kLegendBlockType);
-        if (isLegendBlock) {
-            auto* legendBlock = static_cast<GlobalSignalLegend*>(blockPtr->raw());
-            legendBlock->setPaneWidth(chartPaneSize.x);
-            legendBlock->setRightClickCallback([this, mode](std::string_view sinkUniqueName) {
-                if (mode == Mode::Layout) {
-                    return;
-                }
-                auto found = _dashboard->graphModel.recursiveFindBlockByUniqueName(std::string(sinkUniqueName));
-                if (found) {
-                    _editPane.setSelectedBlock(found.block, std::addressof(_dashboard->graphModel));
-                    _editPane.closeTime = std::chrono::system_clock::now() + LookAndFeel::instance().editPaneCloseDelay;
-                }
-            });
-            legendBlock->setDragDropEnabled(mode == Mode::Interaction);
-        }
-
-        // Draw the toolbar block
-        gr::property_map drawConfig;
-        drawConfig["paneWidth"] = chartPaneSize.x;
-        blockPtr->draw(drawConfig);
-
-        // Track legend size
-        if (isLegendBlock) {
-            auto* legendBlock = static_cast<GlobalSignalLegend*>(blockPtr->raw());
-            totalSize         = legendBlock->legendSize();
+    _signalLegend.setDragDropEnabled(mode == Mode::Interaction);
+    auto rightClickedSinkName = _signalLegend.draw(_dashboard->graphModel, chartPaneSize.x);
+    if (mode != Mode::Layout && !rightClickedSinkName.empty()) {
+        if (auto found = _dashboard->graphModel.recursiveFindBlockByUniqueName(std::string(rightClickedSinkName))) {
+            _editPane.setSelectedBlock(found.block, std::addressof(_dashboard->graphModel));
+            _editPane.closeTime = std::chrono::system_clock::now() + LookAndFeel::instance().editPaneCloseDelay;
         }
     }
-    return totalSize;
+    return _signalLegend.legendSize();
 }
 
 void DashboardPage::addSelectedRemoteSignal(const SignalData& selectedRemoteSignal) noexcept {

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -53,6 +53,38 @@ static void alignForWidth(float width, float alignment = 0.5f) noexcept {
     }
 }
 
+struct PropertyInfo {
+    const gr::pmt::Value&                        currentValue;
+    const UiGraphBlock::SettingsMetaInformation& meta;
+    UiGraphBlock&                                block;
+};
+
+static std::optional<PropertyInfo> getPropertyInfo(UiGraphModel& graphModel, const std::string& blockName, const std::string& propertyName) {
+    if (auto* block = graphModel.recursiveFindBlockByName(blockName).block) {
+        const auto propertyIter = block->blockSettings.find(propertyName);
+        const auto metaIter     = block->blockSettingsMetaInformation.find(propertyName);
+        if (propertyIter != std::end(block->blockSettings) && metaIter != std::end(block->blockSettingsMetaInformation)) {
+            return PropertyInfo{propertyIter->second, metaIter->second, *block};
+        }
+    }
+    return {};
+};
+
+static IMW::WidgetSize                                            //
+getEditorWidgetSize(UiGraphModel&                     graphModel, //
+    Dashboard::PropertyControlWindow&                 window,     //
+    std::span<const components::ExportedPropertyPair> properties) //
+{
+    if (!properties.empty()) {
+        const auto& [frontBlockName, frontPropertyName] = properties.front();
+        if (const auto propertyInfo = getPropertyInfo(graphModel, frontBlockName, frontPropertyName)) {
+            const auto& [currentValue, meta, _] = *propertyInfo;
+            return components::calcEditorSize(window.label.c_str(), frontPropertyName, currentValue, meta);
+        }
+    }
+    return {};
+};
+
 DashboardPage::DashboardPage() {
     // Use SinkRegistry for listening to sink registration events
     opendigitizer::charts::SinkRegistry::instance().addListener(this, [this](opendigitizer::charts::SignalSink& sink, bool wasAdded) {
@@ -93,7 +125,256 @@ DashboardPage::DashboardPage() {
 
 DashboardPage::~DashboardPage() { opendigitizer::charts::SinkRegistry::instance().removeListener(this); }
 
-ImVec2 DashboardPage::drawCharts(Mode mode) noexcept {
+DashboardPage::PropertyControlWindowContextMenuAction DashboardPage::drawPropertyControlWindowContextMenu(const PropertyControlWindowsDrawParams& params) {
+    auto action = PropertyControlWindowContextMenuAction::None;
+    if (auto contextPopup = IMW::Popup(propertyControLWindowContextWindowID, ImGuiPopupFlags_None)) {
+        namespace menu_icons = opendigitizer::charts::menu_icons;
+        if (menu_icons::menuItemWithIcon(menu_icons::kRemove, "Remove")) {
+            params.removeList.push_back(params.windowId);
+        }
+        ImGui::SetItemTooltip("Removes the window and unbinds the assigned properties from each other");
+        if (menu_icons::menuItemWithIcon(menu_icons::kDisconnect, "Disconnect")) {
+            this->_propertyControlWindowID = params.windowId;
+            action                         = PropertyControlWindowContextMenuAction::OpenDisconnectCurrentPropertiesPopup;
+        }
+        if (menu_icons::menuItemWithIcon(menu_icons::kFormat, "Change Label")) {
+            this->_propertyControlWindowID = params.windowId;
+            action                         = PropertyControlWindowContextMenuAction::OpenChangeLabelPopup;
+        }
+        ImGui::SetItemTooltip("Select properties to remove from this window's control");
+    }
+    return action;
+}
+
+DashboardPage::PropertyControlWindowContextMenuAction DashboardPage::drawPropertyControlWindow(const PropertyControlWindowsDrawParams& params) {
+    this->propertyControlWindowEditProperties(params);
+
+    // highlight drop target always even if there is no hovering from cursor, if the payload is compatible
+    using ControlTypeAndBlock            = std::pair<UiGraphBlock::SettingsControlType, UiGraphBlock&>;
+    const auto getControlTypeForProperty = [this](const components::ExportedPropertyPair& pair) -> std::optional<ControlTypeAndBlock> {
+        if (auto propertyInfo = getPropertyInfo(this->_dashboard->graphModel, pair.blockName, pair.propertyName)) {
+            const auto& [currentValue, meta, block] = *propertyInfo;
+            return ControlTypeAndBlock{meta.controlType(pair.propertyName, currentValue), block};
+        }
+        return {};
+    };
+    const auto controlTypeConstraint = params.properties.empty() //
+                                           ? std::optional<ControlTypeAndBlock>{}
+                                           : getControlTypeForProperty(params.properties.front());
+
+    const auto    draggedPropertyPair            = components::ExportedPropertyDragDropPayload::getCurrentPayload();
+    bool          isValidDragPayloadActive       = false;
+    UiGraphBlock* blockForDraggedPayloadProperty = nullptr;
+    if (draggedPropertyPair) {
+        if (auto maybeControlTypeAndProperty = getControlTypeForProperty(draggedPropertyPair)) {
+            const auto& [draggedControlType, block] = *maybeControlTypeAndProperty;
+            // property in the payload is valid, only now can we consider setting isValidDragPayloadActive to true
+            isValidDragPayloadActive       = !controlTypeConstraint || controlTypeConstraint->first == draggedControlType;
+            blockForDraggedPayloadProperty = std::addressof(block);
+        }
+    }
+
+    const auto dragTargetRect   = ImGui::GetCurrentWindow()->WorkRect;
+    const bool isHoveringTarget = ImGui::IsMouseHoveringRect(dragTargetRect.Min, dragTargetRect.Max);
+    const bool isRightClicked   = ImGui::IsMouseClicked(ImGuiMouseButton_Right);
+
+    // always draw outline rect when user is dragging something
+    if (draggedPropertyPair) {
+        constexpr auto green     = rgbToImGuiABGR(0x28d14c);
+        constexpr auto red       = rgbToImGuiABGR(0xf53333);
+        const float    thickness = isHoveringTarget && isValidDragPayloadActive ? 5.f : 1.f;
+        ImGui::GetCurrentWindow()->DrawList->AddRect(dragTargetRect.Min, dragTargetRect.Max, isValidDragPayloadActive ? green : red, 0, 0, thickness);
+    }
+
+    // install drop target over entire window
+    if (ImGui::BeginDragDropTargetCustom(dragTargetRect, ImGui::GetID(std::format("{}##", params.controlWindow.window->name).c_str()))) {
+        if (auto* accepted = ImGui::AcceptDragDropPayload(components::ExportedPropertyDragDropPayload::kType); isValidDragPayloadActive && accepted) {
+            assert(blockForDraggedPayloadProperty);
+            auto exportedIter = blockForDraggedPayloadProperty->exportedProperties.find(draggedPropertyPair.propertyName);
+            if (exportedIter != std::end(blockForDraggedPayloadProperty->exportedProperties)) {
+                exportedIter->second.windowId = params.windowId;
+            }
+        }
+        ImGui::EndDragDropTarget();
+    }
+
+    if (isHoveringTarget && isRightClicked) {
+        ImGui::OpenPopup(propertyControLWindowContextWindowID);
+    }
+
+    return this->drawPropertyControlWindowContextMenu(params);
+}
+
+void DashboardPage::propertyControlWindowEditProperties(const PropertyControlWindowsDrawParams& params) const {
+    if (params.properties.empty()) {
+        return;
+    }
+
+    const auto& [blockName, propertyName] = params.properties.front();
+
+    const auto optionalPropertyInfo = getPropertyInfo(this->_dashboard->graphModel, blockName, propertyName);
+    assert(optionalPropertyInfo && "property info should always be valid because its parameters were taken from the current graph");
+
+    const auto& [currentValue, meta, block] = *optionalPropertyInfo;
+
+    IMW::ChangeId id(static_cast<int>(params.windowId)); // push an ID in case the control label is empty and provides to differentiation
+
+    ImGui::SetNextItemWidth(params.editWidgetSize.preferred.x - params.editWidgetSize.labelPreferredWidth);
+    auto newPropertyValue = components::editBlockProperty(params.controlWindow.label.c_str(), propertyName, currentValue, meta);
+    if (newPropertyValue) {
+        block.setSetting(propertyName, std::move(newPropertyValue));
+    }
+}
+
+DashboardPage::ExportedPropertyPairsByWindowID DashboardPage::getExportedPropertyPairsByWindowID() const noexcept {
+    ExportedPropertyPairsByWindowID propertyPairsByWindowID;
+    for (auto [blockName, exportedPropertiesPtr] : _dashboard->graphModel.recursiveGatherExportedProperties()) {
+        for (auto& [propertyName, exportedPropertyInfo] : *exportedPropertiesPtr) {
+            if (exportedPropertyInfo.windowId) {
+                if (!_dashboard->propertyControlWindows.contains(*exportedPropertyInfo.windowId)) {
+                    // window no longer exists
+                    exportedPropertyInfo.windowId.reset();
+                } else {
+                    propertyPairsByWindowID.values[*exportedPropertyInfo.windowId].emplace_back(std::string{blockName}, propertyName);
+                }
+            }
+        }
+    }
+    return propertyPairsByWindowID;
+}
+
+auto DashboardPage::ExportedPropertyPairsByWindowID::getForWindow(std::size_t id) const noexcept -> PropertyPairSpan {
+    const auto propertyPairsIter = values.find(id);
+    return propertyPairsIter == std::end(values) ? PropertyPairSpan{} : propertyPairsIter->second;
+}
+
+void DashboardPage::addPropertyControlWindows(const AddPropertyControlWindowsParams& params) {
+    for (auto& [id, controlWindow] : _dashboard->propertyControlWindows) {
+        params.output.emplace_back(controlWindow.window);
+
+        auto propertyPairsForThisWindow = params.pairs.getForWindow(id);
+
+        const IMW::WidgetSize editorWidgetSize     = getEditorWidgetSize(_dashboard->graphModel, controlWindow, propertyPairsForThisWindow);
+        const auto            windowTitleBarHeight = ImGui::GetFrameHeight();
+        const auto&           style                = ImGui::GetStyle();
+        const ImVec2          fittedSize{
+            editorWidgetSize.preferred.x + style.WindowPadding.x * 2.0f,
+            editorWidgetSize.preferred.y + style.WindowPadding.y * 2.0f + windowTitleBarHeight,
+        };
+
+        if (!propertyPairsForThisWindow.empty()) {
+            controlWindow.window->windowMinSizeOverride = fittedSize;
+            controlWindow.window->windowMaxSize         = fittedSize;
+        } else {
+            controlWindow.window->windowMinSizeOverride.reset();
+            controlWindow.window->windowMaxSize.reset();
+        }
+
+        auto*      existingWindow                      = ImGui::FindWindowByName(controlWindow.window->name.c_str());
+        const bool docked                              = existingWindow ? existingWindow->DockIsActive : false;
+        controlWindow.window->wantsHorizontalScrollbar = docked;
+
+        auto  onContextMenuAction        = params.onContextMenuAction;
+        auto& removeList                 = params.removeList;
+        controlWindow.window->renderFunc = [this, id, &controlWindow, onContextMenuAction, &removeList, editorWidgetSize, propertyPairsForThisWindow] {
+            auto action = this->drawPropertyControlWindow({
+                .windowId       = id,
+                .controlWindow  = controlWindow,
+                .properties     = propertyPairsForThisWindow,
+                .editWidgetSize = editorWidgetSize,
+                .removeList     = removeList,
+            });
+            if (action != PropertyControlWindowContextMenuAction::None) {
+                onContextMenuAction(action);
+            }
+        };
+    }
+}
+
+void DashboardPage::drawCurrentPropertiesPopup(const ExportedPropertyPairsByWindowID& pairs) {
+    bool          isOpen = true;
+    IMW::StyleVar minSize(ImGuiStyleVar_WindowMinSize, ImVec2{300.f, 200.f});
+    auto          popup = IMW::ModalPopup(currentPropertiesPopupID, &isOpen, 0);
+    if (!popup) {
+        return;
+    }
+
+    {
+        IMW::Font             font(LookAndFeel::instance().fontBigger[LookAndFeel::instance().prototypeMode]);
+        constexpr const char* title = "Disconnect Properties";
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + std::max(0.f, ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(title).x) / 2.f);
+        ImGui::TextUnformatted(title);
+    }
+
+    IMW::Child child("childProperties", ImVec2{}, 0, 0);
+
+    const std::size_t numColumns = 3;
+    if (auto table = IMW::Table("propertiesTable", numColumns, ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_RowBg, ImVec2(0, 0), 0.0f)) {
+        ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthStretch);
+
+        std::size_t id = 0;
+        for (const auto& [blockName, propertyName] : pairs.getForWindow(_propertyControlWindowID)) {
+            IMW::ChangeId rowId{++id};
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+
+            const auto propertyInfo = getPropertyInfo(_dashboard->graphModel, blockName, propertyName);
+            if (!propertyInfo) {
+                assert(false && "Attempt to edit nonexistent property or block");
+                continue;
+            }
+            const auto& [currentValue, meta, block] = *propertyInfo;
+
+            ImGui::TableSetColumnIndex(0);
+
+            constexpr ImGuiSelectableFlags flags = ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowOverlap;
+            const ImVec2                   selectableDimensions{0, ImGui::GetFrameHeight()};
+            const bool                     clicked = ImGui::Selectable(std::format("##selectable{}{}", blockName, propertyName).c_str(), false, flags, selectableDimensions);
+
+            ImGui::SameLine();
+            const auto controlType = meta.controlType(propertyName, currentValue);
+            components::ExportedPropertyList::drawPropertyUninteractiveNoLabel(propertyName.c_str(), controlType, currentValue);
+
+            ImGui::TableSetColumnIndex(1);
+
+            ImGui::TextUnformatted(block.blockName.c_str());
+
+            ImGui::TableSetColumnIndex(2);
+
+            ImGui::TextUnformatted(propertyName.c_str());
+
+            if (clicked) {
+                block.exportedProperties.at(propertyName).windowId.reset();
+            }
+        }
+    }
+}
+
+void DashboardPage::drawChangeLabelPopup() {
+    auto selectedWindowIter = _dashboard->propertyControlWindows.find(_propertyControlWindowID);
+    if (selectedWindowIter == std::end(_dashboard->propertyControlWindows)) {
+        return;
+    }
+
+    bool          isOpen = true;
+    IMW::StyleVar minSize(ImGuiStyleVar_WindowMinSize, ImVec2{200.f, ImGui::GetFrameHeight()});
+    if (auto popup = IMW::ModalPopup(changeLabelPopupID, &isOpen, ImGuiPopupFlags_None)) {
+        constexpr int numColumns = 2;
+        if (auto table = IMW::Table("labelTable", numColumns, ImGuiTableFlags_SizingFixedFit, ImVec2(0, 0), 0.0f)) {
+            ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
+            ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::TextUnformatted("label:");
+            ImGui::TableSetColumnIndex(1);
+            ImGui::InputText("##Change label", &selectedWindowIter->second.label);
+        }
+    }
+}
+
+ImVec2 DashboardPage::drawCharts(Mode mode, const ExportedPropertyPairsByWindowID& propertyPairsByWindowID, std::vector<std::size_t>& windowRemoveList) {
     IMW::Group group;
 
     ImVec2 paneSize = ImGui::GetContentRegionAvail();
@@ -146,7 +427,31 @@ ImVec2 DashboardPage::drawCharts(Mode mode) noexcept {
         };
     }
 
+    // out vars, not set until after .render() and window callbacks below
+    auto contextMenuAction = PropertyControlWindowContextMenuAction::None;
+
+    this->addPropertyControlWindows({
+        .output              = windows,
+        .pairs               = propertyPairsByWindowID,
+        .onContextMenuAction = [&contextMenuAction](PropertyControlWindowContextMenuAction action) { contextMenuAction = action; },
+        .removeList          = windowRemoveList,
+    });
+
     _dockSpace.render(windows, paneSize, mode == Mode::Layout);
+
+    // now that render() has called, contextMenuAction has been populated by callback
+    {
+        using enum PropertyControlWindowContextMenuAction;
+        switch (contextMenuAction) {
+        case None: break;
+        case OpenChangeLabelPopup: ImGui::OpenPopup(changeLabelPopupID); break;
+        case OpenDisconnectCurrentPropertiesPopup: ImGui::OpenPopup(currentPropertiesPopupID); break;
+        }
+    }
+
+    this->drawCurrentPropertiesPopup(propertyPairsByWindowID);
+    this->drawChangeLabelPopup();
+
     return paneSize;
 }
 
@@ -359,58 +664,119 @@ DashboardPage::LegendItemClickResult DashboardPage::drawLegend(Mode mode, ImVec2
     return clickResult;
 }
 
-void DashboardPage::draw(Mode mode) noexcept {
-    processPendingTransmutation();
-    processPendingRemovals();
+void DashboardPage::applyControlPanelWindowAction(const components::BlockControlsPanelResult& controlPanelAction, const ExportedPropertyPairsByWindowID& pairs, std::vector<std::size_t>& windowRemoveList) {
+    if (controlPanelAction.allExportedPropertiesPageResult) {
+        using Action         = components::ExportedPropertyList::Action;
+        const auto& property = controlPanelAction.allExportedPropertiesPageResult.targetProperty;
+        switch (controlPanelAction.allExportedPropertiesPageResult.action) {
+        case Action::Unexport: {
+            if (const auto propertyInfo = getPropertyInfo(_dashboard->graphModel, property.blockName, property.propertyName)) {
+                propertyInfo->block.exportedProperties.erase(property.propertyName);
+            }
+            break;
+        }
+        case Action::AddWindow: {
+            if (const auto propertyInfo = getPropertyInfo(_dashboard->graphModel, property.blockName, property.propertyName)) {
+                const auto [currentValue, meta, block] = *propertyInfo;
+                // if we got here, the property and block must actually exist, so it's okay to make a window now
+                const auto& [windowId, _] = _dashboard->newPropertyControlWindow(std::addressof(block), property.propertyName, property.propertyName);
+
+                propertyInfo->block.exportedProperties.find(property.propertyName)->second.windowId = windowId;
+            }
+            break;
+        }
+        case Action::Selected: break;
+        }
+    }
+    if (controlPanelAction.blockEditPaneResult) {
+        const auto& [type, block, propertyName] = controlPanelAction.blockEditPaneResult;
+        using enum components::BlockPropertyEditResult::Type;
+        switch (type) {
+        case AddNewWindow: {
+            const auto& [id, window]                         = this->_dashboard->newPropertyControlWindow(block, propertyName, propertyName);
+            block->exportedProperties[propertyName].windowId = id;
+            window.window->wantsDockAtBottom                 = true; // dockspace relayout() is about to be triggered due to a new window, it will see this
+            ImGui::FocusWindow(ImGui::FindWindowByName(window.window->name.c_str()));
+        } break;
+        case RemoveFromExistingWindow: {
+            auto exportedIter = block->exportedProperties.find(propertyName);
+            if (exportedIter != std::end(block->exportedProperties) && exportedIter->second.windowId.has_value()) {
+                // erase window if this property being removed was the last one
+                auto pairsForExistingWindow = pairs.getForWindow(*exportedIter->second.windowId);
+                if (pairsForExistingWindow.size() == 1) {
+                    assert(pairsForExistingWindow.front().blockName == block->blockName);
+                    assert(pairsForExistingWindow.front().propertyName == propertyName);
+                    windowRemoveList.push_back(*exportedIter->second.windowId);
+                }
+                exportedIter->second.windowId.reset();
+            }
+        } break;
+        }
+    }
+}
+
+DashboardPage::LegendItemClickResult DashboardPage::drawChartsLegendAndEditPane(Mode mode, const ExportedPropertyPairsByWindowID& propertyPairsByWindowID, std::vector<std::size_t>& windowRemoveList) {
+    constexpr float splitterWidth     = 6;
+    constexpr float halfSplitterWidth = splitterWidth / 2.f;
 
     const float  left = ImGui::GetCursorPosX();
     const float  top  = ImGui::GetCursorPosY();
     const ImVec2 size = ImGui::GetContentRegionAvail();
 
-    const bool      horizontalSplit   = size.x > size.y;
-    constexpr float splitterWidth     = 6;
-    constexpr float halfSplitterWidth = splitterWidth / 2.f;
-    const float     ratio             = mode == Mode::Interaction ? components::Splitter(size, horizontalSplit, splitterWidth, 0.2f, !_editPane.selectedBlock()) : 0.f;
+    const bool  horizontalSplit = size.x > size.y;
+    const float ratio           = mode == Mode::Interaction ? components::Splitter(size, horizontalSplit, splitterWidth, 0.2f, !_editPane.selectedBlock()) : 0.f;
 
     ImGui::SetCursorPosX(left);
     ImGui::SetCursorPosY(top);
 
     LegendItemClickResult legendClickResult;
-    {
-        IMW::Child plotsChild("##plots", horizontalSplit ? ImVec2(size.x * (1.f - ratio) - halfSplitterWidth, size.y) : ImVec2(size.x, size.y * (1.f - ratio) - halfSplitterWidth), false, ImGuiWindowFlags_NoScrollbar);
+    IMW::Child            plotsChild("##plots", horizontalSplit ? ImVec2(size.x * (1.f - ratio) - halfSplitterWidth, size.y) : ImVec2(size.x, size.y * (1.f - ratio) - halfSplitterWidth), false, ImGuiWindowFlags_NoScrollbar);
 
-        if (ImGui::IsWindowHovered() && ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
-            _editPane.setSelectedBlock(nullptr, nullptr);
-        }
-
-        // Render ChartPane blocks
-        const auto paneSize = this->drawCharts(mode);
-        ImGui::SetCursorPos(ImVec2(0, ImGui::GetWindowHeight() - _legendBox.y));
-
-        // quickfix for an imgui bug?: the SetCursorPos above does not seem to
-        // be sufficient for getting our cursor to return there after
-        // SameLine(). The issue is visible iff we do manual cursor
-        // manipulation (as the global signal legend does for the first color
-        // rect). So to make sure the first item draws at the same position as
-        // the succeeding ones after SameLine(), just insert a dummy size and
-        // do SameLine here, so the imgui context is in the same state as later
-        ImGui::ItemSize(ImVec2{}, 0.f);
-        ImGui::SameLine();
-
-        legendClickResult = this->drawLegend(mode, paneSize);
-
-        if (!legendClickResult.sinkForNewPlot.empty()) {
-            _sinkForNewPlot = legendClickResult.sinkForNewPlot;
-        }
+    if (ImGui::IsWindowHovered() && ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
+        _editPane.setSelectedBlock(nullptr, nullptr);
     }
 
+    // chart
+    const auto paneSize = this->drawCharts(mode, propertyPairsByWindowID, windowRemoveList);
+    ImGui::SetCursorPos(ImVec2(0, ImGui::GetWindowHeight() - _legendBox.y));
+
+    // quickfix for an imgui bug?: the SetCursorPos above does not seem to
+    // be sufficient for getting our cursor to return there after
+    // SameLine(). The issue is visible iff we do manual cursor
+    // manipulation (as the global signal legend does for the first color
+    // rect). So to make sure the first item draws at the same position as
+    // the succeeding ones after SameLine(), just insert a dummy size and
+    // do SameLine here, so the imgui context is in the same state as later
+    ImGui::ItemSize(ImVec2{}, 0.f);
+    ImGui::SameLine();
+
+    // legend
+    legendClickResult = this->drawLegend(mode, paneSize);
+
+    if (!legendClickResult.sinkForNewPlot.empty()) {
+        _sinkForNewPlot = legendClickResult.sinkForNewPlot;
+    }
+
+    // edit pane
     if (horizontalSplit) {
         const float w = size.x * ratio;
-        components::BlockControlsPanel(_editPane, {left + size.x - w + halfSplitterWidth, top}, {w - halfSplitterWidth, size.y}, true);
+        applyControlPanelWindowAction(components::BlockControlsPanel(_editPane, {left + size.x - w + halfSplitterWidth, top}, {w - halfSplitterWidth, size.y}, true), propertyPairsByWindowID, windowRemoveList);
     } else {
         const float h = size.y * ratio;
-        components::BlockControlsPanel(_editPane, {left, top + size.y - h + halfSplitterWidth}, {size.x, h - halfSplitterWidth}, false);
+        applyControlPanelWindowAction(components::BlockControlsPanel(_editPane, {left, top + size.y - h + halfSplitterWidth}, {size.x, h - halfSplitterWidth}, false), propertyPairsByWindowID, windowRemoveList);
     }
+
+    return legendClickResult;
+}
+
+void DashboardPage::draw(Mode mode) noexcept {
+    processPendingTransmutation();
+    processPendingRemovals();
+
+    const auto               propertyPairsByWindowID = this->getExportedPropertyPairsByWindowID();
+    std::vector<std::size_t> windowRemoveList; // queue removal of windows here, submitted at end of draw()
+
+    const auto legendClickResult = this->drawChartsLegendAndEditPane(mode, propertyPairsByWindowID, windowRemoveList);
 
     // Modal dialogs
     if (legendClickResult.shouldOpenNewPlotModal) {
@@ -427,6 +793,23 @@ void DashboardPage::draw(Mode mode) noexcept {
             this->_requestViewOnlyMode();
         }
         ImGui::EndPopup();
+    }
+
+    // submit window remove list
+    if (!windowRemoveList.empty()) {
+        auto allExportedProperties = _dashboard->graphModel.recursiveGatherExportedProperties();
+        for (std::size_t id : windowRemoveList) {
+            // unbind properties
+            for (auto& [_, exportedPropertiesPtr] : allExportedProperties) {
+                for (auto& [propertyName, exportedPropertyInfo] : *exportedPropertiesPtr) {
+                    if (exportedPropertyInfo.windowId == id) {
+                        exportedPropertyInfo.windowId.reset();
+                    }
+                }
+            }
+            // remove ui windows
+            _dashboard->propertyControlWindows.erase(id);
+        }
     }
 }
 

--- a/src/ui/DashboardPage.hpp
+++ b/src/ui/DashboardPage.hpp
@@ -24,8 +24,12 @@ public:
     enum class Mode { View, Interaction, Layout };
 
 private:
-    static constexpr const char* addChartPopupID          = "New Chart";
-    static constexpr const char* enterViewOnlyModePopupID = "Lock the dashboard?##lockMode";
+    static constexpr const char* addChartPopupID                      = "New Chart";
+    static constexpr const char* enterViewOnlyModePopupID             = "Lock the dashboard?##lockMode";
+    static constexpr const char* currentPropertiesPopupID             = "##Current properties";
+    static constexpr const char* changeLabelPopupID                   = "##Change property control window label";
+    static constexpr const char* addExportedPropertyPopupID           = "Add another exported property";
+    static constexpr const char* propertyControLWindowContextWindowID = "propertyControlWindowContextMenu";
 
     ImVec2 _legendBox{500, 40}; // updated by drawLegend(...)
 
@@ -52,6 +56,9 @@ private:
     // modal dialog state for new plot creation
     std::string _sinkForNewPlot;
 
+    // dialog state for the currently exported properties popup
+    std::size_t _propertyControlWindowID;
+
     // deferred chart transmutation request (processed at start of next frame)
     struct PendingTransmutation {
         std::string chartId;
@@ -69,12 +76,61 @@ private:
     };
 
     void                                drawNewPlotModal();                                         // modifies _showNewPlotModal if close is requested
-    [[nodiscard]] ImVec2                drawCharts(Mode mode) noexcept;                             // returns the size of area used for charts
     [[nodiscard]] LegendItemClickResult drawLegend(Mode mode, ImVec2 chartPaneSize) noexcept;       // sets _legendBox
     [[nodiscard]] ImVec2                drawLegendCenter(Mode mode, ImVec2 chartPaneSize) noexcept; // returns total size of centered legend part
     void                                drawToolbarLayoutButtons(float plotButtonSize) noexcept;
     void                                addSelectedRemoteSignal(const SignalData& selectedRemoteSignal) noexcept;
     void                                doViewModeOverlayArea() noexcept;
+
+    struct ExportedPropertyPairsByWindowID;
+
+    // returns the size of area used for charts
+    [[nodiscard]] ImVec2                drawCharts(Mode mode, const ExportedPropertyPairsByWindowID& propertyPairsByWindowID, std::vector<std::size_t>& windowRemoveList);
+    [[nodiscard]] LegendItemClickResult drawChartsLegendAndEditPane(Mode mode, const ExportedPropertyPairsByWindowID& propertyPairsByWindowID, std::vector<std::size_t>& windowRemoveList);
+    void                                applyControlPanelWindowAction(const components::BlockControlsPanelResult& controlPanelAction, const ExportedPropertyPairsByWindowID& pairs, std::vector<std::size_t>& windowRemoveList);
+
+    using PropertyPairSpan = std::span<const components::ExportedPropertyPair>;
+
+    [[nodiscard]] ExportedPropertyPairsByWindowID getExportedPropertyPairsByWindowID() const noexcept;
+
+    struct ExportedPropertyPairsByWindowID {
+    private:
+        std::unordered_map<std::size_t, std::vector<components::ExportedPropertyPair>> values;
+
+    public:
+        PropertyPairSpan getForWindow(std::size_t id) const noexcept;
+
+        friend ExportedPropertyPairsByWindowID DashboardPage::getExportedPropertyPairsByWindowID() const noexcept;
+    };
+
+    enum class PropertyControlWindowContextMenuAction {
+        None,
+        OpenDisconnectCurrentPropertiesPopup,
+        OpenChangeLabelPopup,
+    };
+
+    struct PropertyControlWindowsDrawParams {
+        std::size_t                       windowId;
+        Dashboard::PropertyControlWindow& controlWindow;
+        PropertyPairSpan                  properties;
+        IMW::WidgetSize                   editWidgetSize;
+        std::vector<std::size_t>&         removeList;
+    };
+
+    struct AddPropertyControlWindowsParams {
+        DockSpace::Windows&                                         output;
+        const ExportedPropertyPairsByWindowID&                      pairs;
+        std::function<void(PropertyControlWindowContextMenuAction)> onContextMenuAction;
+        std::vector<std::size_t>&                                   removeList;
+    };
+
+    void propertyControlWindowEditProperties(const PropertyControlWindowsDrawParams& params) const;
+    void addPropertyControlWindows(const AddPropertyControlWindowsParams& params);
+    void drawCurrentPropertiesPopup(const ExportedPropertyPairsByWindowID& pairs);
+    void drawChangeLabelPopup();
+
+    [[nodiscard]] PropertyControlWindowContextMenuAction drawPropertyControlWindow(const PropertyControlWindowsDrawParams& params);
+    [[nodiscard]] PropertyControlWindowContextMenuAction drawPropertyControlWindowContextMenu(const PropertyControlWindowsDrawParams& params);
 
 public:
     DashboardPage();

--- a/src/ui/DashboardPage.hpp
+++ b/src/ui/DashboardPage.hpp
@@ -13,6 +13,7 @@
 #include "common/ImguiWrap.hpp"
 #include "components/Block.hpp"
 #include "components/Docking.hpp"
+#include "components/GlobalSignalLegend.hpp"
 #include "components/SignalSelector.hpp"
 
 #include <memory>
@@ -50,6 +51,7 @@ private:
     DockSpace                             _dockSpace;
     components::BlockControlsPanelContext _editPane;
     std::unique_ptr<SignalSelector>       _remoteSignalSelector;
+    GlobalSignalLegend                    _signalLegend;
 
     Dashboard* _dashboard = nullptr;
 

--- a/src/ui/GraphModel.cpp
+++ b/src/ui/GraphModel.cpp
@@ -386,10 +386,10 @@ void UiGraphBlock::setBasicBlockData(const gr::property_map& blockData) {
                 port.portDirection = direction;
             }
         } else {
-            auto& exportedPorts = direction == gr::PortDirection::INPUT ? exportedInputPorts : exportedOutputPorts;
             assert(childBlocks.size() <= 1);
             if (childBlocks.size() != 0) {
-                auto* graph = childBlocks[0].get();
+                auto* graph         = childBlocks[0].get();
+                auto& exportedPorts = direction == gr::PortDirection::INPUT ? exportedInputPorts : exportedOutputPorts;
                 for (const auto& [childBlockName, portDefinitions] : exportedPorts) {
                     auto* child = graph->findBlockByUniqueName(childBlockName);
                     if (child == nullptr) {
@@ -586,7 +586,7 @@ void UiGraphBlock::requestBlockUpdate() {
                 gr::Message message;
                 message.cmd         = gr::message::Command::Get;
                 message.endpoint    = gr::scheduler::property::kSchedulerInspect;
-                message.serviceName = parentBlock ? parentBlock->blockUniqueName : blockUniqueName;
+                message.serviceName = parentBlock->blockUniqueName;
                 ownerGraph->sendMessage(std::move(message));
             }
             {

--- a/src/ui/GraphModel.cpp
+++ b/src/ui/GraphModel.cpp
@@ -1,17 +1,15 @@
 #include "GraphModel.hpp"
 
-#include <filesystem>
-#include <memory>
-
-#include "common/ImguiWrap.hpp"
-
-#include <misc/cpp/imgui_stdlib.h>
+#include <scope_exit.hpp>
 
 #include "components/ImGuiNotify.hpp"
 
-#include <scope_exit.hpp>
+#include <gnuradio-4.0/Scheduler.hpp>
 
-#include "App.hpp"
+#include <imgui.h>
+#include <misc/cpp/imgui_stdlib.h>
+
+#include <memory>
 
 using namespace std::string_literals;
 
@@ -259,6 +257,34 @@ void UiGraphBlock::setGraphChildren(const gr::property_map& data) {
     }
 
     shouldRearrangeBlocks = true;
+}
+
+void UiGraphBlock::setSetting(std::string_view keyToUpdate, gr::pmt::Value&& updatedValue) {
+    if (!ownerGraph) {
+        return;
+    }
+
+    const auto setSettingImpl = [](UiGraphBlock& block, std::string_view keyToUpdateImpl, gr::pmt::Value&& updatedValueImpl) {
+        gr::Message message;
+        message.serviceName = block.blockUniqueName;
+        message.endpoint    = gr::block::property::kSetting;
+        message.cmd         = gr::message::Command::Set;
+        message.data        = gr::property_map{{std::pmr::string(keyToUpdateImpl), std::move(updatedValueImpl)}};
+        block.ownerGraph->sendMessage(std::move(message));
+    };
+
+    // set matching exported properties
+    auto exportedPropertyIter = exportedProperties.find(keyToUpdate);
+    if (exportedPropertyIter != std::end(exportedProperties) && exportedPropertyIter->second.windowId.has_value()) {
+        for (const auto& result : ownerGraph->recursiveGatherMatchingExportedProperties(*exportedPropertyIter->second.windowId, this)) {
+            if (result.block == this) {
+                break;
+            }
+            setSettingImpl(*result.block, result.propertyName, gr::pmt::Value{updatedValue});
+        }
+    }
+
+    setSettingImpl(*this, keyToUpdate, std::move(updatedValue));
 }
 
 void UiGraphBlock::setBlockData(const gr::property_map& data) {
@@ -545,22 +571,7 @@ void UiGraphBlock::storeXY() {
         .y = view->y,
     };
 
-    ownerGraph->sendMessage(gr::Message{
-        .cmd             = gr::Message::Set,
-        .serviceName     = blockUniqueName,
-        .clientRequestID = "ui_constraints",
-        .endpoint        = gr::block::property::kSetting,
-        .data =
-            gr::property_map{
-                {
-                    "ui_constraints",
-                    gr::property_map{
-                        {"x", storedXY->x},
-                        {"y", storedXY->y},
-                    },
-                },
-            },
-    });
+    setSetting("ui_constraints", gr::property_map{{"x", storedXY->x}, {"y", storedXY->y}});
 }
 
 void UiGraphBlock::requestBlockUpdate() {
@@ -652,48 +663,93 @@ void UiGraphBlock::updateBlockSettingsMetaInformation() {
 
         blockSettingsMetaInformation.insert_or_assign(std::string(settingKey), SettingsMetaInformation{.unit = std::move(unit), .description = std::move(description), .isVisible = isVisible, .minValue = minVal, .maxValue = maxVal, .enumValues = std::move(enumValues)});
     }
+
+    std::erase_if(exportedProperties, [this](const auto& item) { return !blockSettings.contains(item.first); });
 }
 
-UiGraphModel::FindBlockResult UiGraphModel::recursiveFindBlockByUniqueName(const std::string& uniqueName) {
-    if (rootBlock.blockUniqueName == uniqueName) {
-        return FindBlockResult{
-            .parentGraph        = nullptr,                   //
-            .block              = std::addressof(rootBlock), //
-            .owningCollection   = nullptr,                   //
-            .owningCollectionIt = {}                         //
-        };
+UiGraphModel::FindBlockResult UiGraphModel::recursiveFindBlockByUniqueName(std::string_view uniqueName) {
+    FindBlockResult out{};
+    recursiveForEachBlock([&out, uniqueName](const FindBlockResult& element) {
+        assert(element.block);
+        if (element.block->blockUniqueName == uniqueName) {
+            out = element;
+            return VisitorResult::Break;
+        }
+        return VisitorResult::Recurse;
+    });
+    return out;
+}
+
+UiGraphModel::FindBlockResult UiGraphModel::recursiveFindBlockByName(std::string_view name) {
+    FindBlockResult out{};
+    recursiveForEachBlock([&out, name](const FindBlockResult& element) {
+        assert(element.block);
+        if (element.block->blockName == name) {
+            out = element;
+            return VisitorResult::Break;
+        }
+        return VisitorResult::Recurse;
+    });
+    return out;
+}
+
+UiGraphModel::ExportedPropertiesView UiGraphModel::recursiveGatherExportedProperties() {
+    ExportedPropertiesView output;
+    recursiveForEachBlock([&output](const FindBlockResult& element) {
+        if (!element.block->exportedProperties.empty()) {
+            output.try_emplace(element.block->blockName, std::addressof(element.block->exportedProperties));
+        }
+        return VisitorResult::Recurse;
+    });
+    return output;
+}
+
+std::vector<UiGraphModel::ExportedPropertyMatchResult> UiGraphModel::recursiveGatherMatchingExportedProperties(std::size_t id, UiGraphBlock* exclude) {
+    std::vector<ExportedPropertyMatchResult> output;
+    recursiveForEachBlock([&output, id, exclude](const FindBlockResult& element) {
+        if (element.block != exclude) {
+            for (const auto& [propertyName, exportedInfo] : element.block->exportedProperties) {
+                if (exportedInfo.windowId == id) {
+                    output.emplace_back(element.block, propertyName);
+                    break;
+                }
+            }
+        }
+        return VisitorResult::Recurse;
+    });
+    return output;
+}
+
+void UiGraphModel::recursiveForEachBlock(const std::function<VisitorResult(const FindBlockResult&)>& callback) {
+    if (callback({.block = std::addressof(rootBlock)}) != VisitorResult::Recurse) {
+        return;
     }
 
     std::deque<UiGraphBlock*> toProcess{std::addressof(rootBlock)};
-
     while (!toProcess.empty()) {
         auto* currentGraph = toProcess.front();
         toProcess.pop_front();
 
         auto& childBlocks = currentGraph->childBlocks;
         for (auto blockIt = childBlocks.begin(); blockIt != childBlocks.end(); ++blockIt) {
-            auto& block = *blockIt;
-            if (block->blockUniqueName == uniqueName) {
-                return FindBlockResult{
-                    .parentGraph        = currentGraph,                //
-                    .block              = block.get(),                 //
-                    .owningCollection   = std::addressof(childBlocks), //
-                    .owningCollectionIt = blockIt                      //
-                };
+            auto&               block  = *blockIt;
+            const VisitorResult result = callback(FindBlockResult{
+                .parentGraph        = currentGraph,
+                .block              = block.get(),
+                .owningCollection   = std::addressof(childBlocks),
+                .owningCollectionIt = blockIt,
+            });
+            using enum VisitorResult;
+            switch (result) {
+            case Break: return;
+            case Continue: continue;
+            case Recurse: break;
             }
-
             if (!block->childBlocks.empty()) {
                 toProcess.push_back(block.get());
             }
         }
     }
-
-    return FindBlockResult{
-        .parentGraph        = nullptr, //
-        .block              = nullptr, //
-        .owningCollection   = nullptr, //
-        .owningCollectionIt = {}       //
-    };
 }
 
 void updateKnownTypeMap(auto& map, const auto& data) {
@@ -1066,4 +1122,35 @@ bool UiGraphModel::blockInTree(const UiGraphBlock& block, const UiGraphBlock& tr
     }
 
     return false;
+}
+
+constexpr bool isColourField(const UiGraphBlock::SettingsMetaInformation& meta, std::string_view pattern) {
+    auto containsColo = [](std::string_view s) {
+        constexpr std::string_view target = "colo";
+        return !std::ranges::search(s, target, [](unsigned char a, unsigned char b) { return std::tolower(a) == std::tolower(b); }).empty();
+    };
+    return containsColo(meta.description) || containsColo(pattern);
+};
+
+UiGraphBlock::SettingsControlType UiGraphBlock::SettingsMetaInformation::controlType(std::string_view propertyName, const gr::pmt::Value& value) const {
+    SettingsControlType out{};
+    gr::pmt::ValueVisitor([&](auto& currentValue) {
+        using T = std::remove_cvref_t<decltype(currentValue)>;
+        if constexpr (std::is_same_v<T, bool>) {
+            out = SettingsControlType::Checkbox;
+        } else if constexpr (std::integral<T>) {
+            if constexpr (std::unsigned_integral<T> && sizeof(T) >= 4) {
+                if (isColourField(*this, propertyName)) {
+                    out = SettingsControlType::Color;
+                    return;
+                }
+            }
+            out = (minValue && maxValue) ? SettingsControlType::Slider : SettingsControlType::Keypad;
+        } else if constexpr (std::floating_point<T>) {
+            out = (minValue && maxValue) ? SettingsControlType::Slider : SettingsControlType::Keypad;
+        } else if constexpr (std::same_as<T, std::string> || std::same_as<T, std::string_view> || std::same_as<T, std::pmr::string>) {
+            out = !enumValues.empty() ? SettingsControlType::Combo : SettingsControlType::TextInput;
+        }
+    }).visit(value);
+    return out;
 }

--- a/src/ui/GraphModel.cpp
+++ b/src/ui/GraphModel.cpp
@@ -720,6 +720,17 @@ std::vector<UiGraphModel::ExportedPropertyMatchResult> UiGraphModel::recursiveGa
     return output;
 }
 
+std::vector<UiGraphBlock*> UiGraphModel::recursiveGatherPlotSinks() {
+    std::vector<UiGraphBlock*> output;
+    recursiveForEachBlock([&output](const FindBlockResult& element) {
+        if (element.block->isPlotSink()) {
+            output.push_back(element.block);
+        }
+        return VisitorResult::Recurse;
+    });
+    return output;
+}
+
 void UiGraphModel::recursiveForEachBlock(const std::function<VisitorResult(const FindBlockResult&)>& callback) {
     if (callback({.block = std::addressof(rootBlock)}) != VisitorResult::Recurse) {
         return;

--- a/src/ui/GraphModel.hpp
+++ b/src/ui/GraphModel.hpp
@@ -99,6 +99,7 @@ struct UiGraphBlock {
     const std::vector<UiGraphPort>& inputPorts() { return _inputPorts; }
     const std::vector<UiGraphPort>& outputPorts() { return _outputPorts; }
 
+    void                       setSetting(std::string_view keyToUpdate, gr::pmt::Value&& updatedValue);
     void                       setBlockData(const gr::property_map& data);
     void                       setBasicBlockData(const gr::property_map& blockData);
     void                       setGraphChildren(const gr::property_map& data);
@@ -141,6 +142,15 @@ public:
     gr::property_map blockSettings;
     gr::property_map blockMetaInformation;
 
+    enum class SettingsControlType {
+        Color,
+        Checkbox,
+        Slider,
+        Keypad,
+        Combo,
+        TextInput,
+    };
+
     struct SettingsMetaInformation {
         std::string              unit;
         std::string              description;
@@ -148,8 +158,19 @@ public:
         std::optional<double>    minValue;
         std::optional<double>    maxValue;
         std::vector<std::string> enumValues;
+
+        SettingsControlType controlType(std::string_view propertyName, const gr::pmt::Value& value) const;
     };
 
+    struct ExportedProperty {
+        // if null, this is not visible on any control
+        std::optional<std::size_t> windowId;
+    };
+
+    template<typename Key, typename Value>
+    using UnorderedMap = std::unordered_map<Key, Value, gr::pmt::Value::MapHash, gr::pmt::Value::MapEqual>;
+
+    UnorderedMap<std::string, ExportedProperty>    exportedProperties;
     std::map<std::string, SettingsMetaInformation> blockSettingsMetaInformation;
     void                                           updateBlockSettingsMetaInformation();
 
@@ -248,7 +269,18 @@ public:
         decltype(UiGraphBlock::childBlocks)*          owningCollection;
         decltype(UiGraphBlock::childBlocks)::iterator owningCollectionIt;
     };
-    FindBlockResult recursiveFindBlockByUniqueName(const std::string& uniqueName);
+    FindBlockResult recursiveFindBlockByUniqueName(std::string_view uniqueName);
+    FindBlockResult recursiveFindBlockByName(std::string_view name);
+
+    struct ExportedPropertyMatchResult {
+        UiGraphBlock* block;
+        std::string   propertyName;
+    };
+
+    using ExportedPropertiesView = std::unordered_map<std::string_view, UiGraphBlock::UnorderedMap<std::string, UiGraphBlock::ExportedProperty>*>;
+    /// Returns a map of block names to their exported properties, if the exported properties are not empty
+    ExportedPropertiesView                   recursiveGatherExportedProperties();
+    std::vector<ExportedPropertyMatchResult> recursiveGatherMatchingExportedProperties(std::size_t id, UiGraphBlock* exclude);
 
     std::unique_ptr<UiGraphBlock> makeGraphBlock(UiGraphBlock* parent, const gr::property_map& blockData, const std::string& ownerSchedulerUniqueName, const std::string& ownerGraphUniqueName);
 
@@ -263,6 +295,13 @@ private:
     void handleAvailableGraphSchedulerTypes(const gr::property_map& data);
 
     bool blockInTree(const UiGraphBlock& block, const UiGraphBlock& tree, UiGraphPort::Role direction) const;
+
+    enum class VisitorResult {
+        Recurse,  // recurse into children
+        Continue, // continue to sibling and ignore children of this block
+        Break,
+    };
+    void recursiveForEachBlock(const std::function<VisitorResult(const FindBlockResult& element)>& callback);
 };
 
 } // namespace DigitizerUi

--- a/src/ui/GraphModel.hpp
+++ b/src/ui/GraphModel.hpp
@@ -106,6 +106,8 @@ struct UiGraphBlock {
     void                       setSchedulerGraph(const gr::property_map& data);
     std::optional<UiGraphEdge> parseEdgeData(const gr::property_map& edgeData);
 
+    [[nodiscard]] constexpr bool isPlotSink() { return this->blockTypeName.starts_with("opendigitizer::ImPlotSink"); }
+
     // We often search by name, but as we don't expect graphs with
     // a large $n$ of blocks, linear search will be fine
     std::vector<std::unique_ptr<UiGraphBlock>> childBlocks;
@@ -281,6 +283,7 @@ public:
     /// Returns a map of block names to their exported properties, if the exported properties are not empty
     ExportedPropertiesView                   recursiveGatherExportedProperties();
     std::vector<ExportedPropertyMatchResult> recursiveGatherMatchingExportedProperties(std::size_t id, UiGraphBlock* exclude);
+    std::vector<UiGraphBlock*>               recursiveGatherPlotSinks();
 
     std::unique_ptr<UiGraphBlock> makeGraphBlock(UiGraphBlock* parent, const gr::property_map& blockData, const std::string& ownerSchedulerUniqueName, const std::string& ownerGraphUniqueName);
 

--- a/src/ui/assets/sampleDashboards/PropertyControlDashboard.grc
+++ b/src/ui/assets/sampleDashboards/PropertyControlDashboard.grc
@@ -1,0 +1,358 @@
+blocks:
+  - id: opendigitizer::Arithmetic<float32>
+    parameters:
+      name: sum sigs
+      ui_constraints:
+        x: 30
+        y: 40
+  - id: gr::blocks::fft::FFT<float32, gr::DataSet<float32>, gr::algorithm::FFT>
+    parameters:
+      name: FFT
+      outputInDb: true
+      outputInDeg: true
+      unwrapPhase: true
+  - id: opendigitizer::SineSource<float32>
+    parameters:
+      name: sine source 1
+      frequency: 2
+  - id: opendigitizer::SineSource<float32>
+    parameters:
+      name: sine source 3
+      frequency: 5
+      ui_constraints:
+        x: 30
+        y: 40
+  - id: opendigitizer::ImPlotSink<float32>
+    parameters:
+      name: sinesSink
+      signal_name: value
+      signal_quantity: sum voltage
+      signal_unit: V
+      color: !!uint32 23496
+  - id: opendigitizer::ImPlotSink<gr::DataSet<float32>>
+    parameters:
+      name: fftSink
+      dataset_index: 0
+      signal_name: fft
+      abscissa_quantity: frequency
+      abscissa_unit: Hz
+      signal_quantity: magnitude
+      signal_unit: dB
+      color: !!uint32 23496
+  - id: gr::basic::ClockSource
+    parameters:
+      name: ClockSource
+      chunk_size: 40
+      do_zero_order_hold: true
+      n_samples_max: 0
+      repeat_period: 4000000000
+      sample_rate: 1000
+      verbose_console: false
+      tag_times: !!uint64
+        - 10000000
+        - 100000000 # start pre-ramp
+        - 200000000 # lower-plateau
+        - 500000000 # start main-ramp
+        - 1000000000 # upper-plateau
+        - 2000000000 # CMD_DIAG_TRIGGER1
+        - 3000000000 # start ramp-down
+        - 3900000000
+      tag_values: !!str
+        - "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1"
+        - "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2" # start pre-ramp
+        - "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=3" # lower-plateau
+        - "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
+        - "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=5" # upper-plateau
+        - "CMD_DIAG_TRIGGER1"
+        - "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=6" # start ramp-down
+        - "CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=7"
+  - id: gr::basic::FunctionGenerator<float32>
+    parameters:
+      name: DipoleCurrentGenerator
+      sample_rate: 1000
+      signal_type: Const
+      start_value: 0
+      signal_trigger: "CMD_BP_START"
+    ctx_parameters:
+      - context: "FAIR.SELECTOR.C=1:S=1:P=1"
+        time: !!uint64 0
+        parameters:
+          start_value: 100
+          sample_rate: 1000
+          signal_type: Const
+      - context: "FAIR.SELECTOR.C=1:S=1:P=2"  # start pre-ramp
+        time: !!uint64 0
+        parameters:
+          duration: 0.1
+          start_value: 100
+          final_value: 500
+          round_off_time: 0.02
+          sample_rate: 1000
+          signal_type: ParabolicRamp
+      - context: "FAIR.SELECTOR.C=1:S=1:P=3"  # lower-plateau
+        time: !!uint64 0
+        parameters:
+          start_value: 500
+          sample_rate: 1000
+          signal_type: Const
+      - context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
+        time: !!uint64 0
+        parameters:
+          duration: 0.5
+          start_value: 500
+          final_value: 3000
+          round_off_time: 0.2
+          sample_rate: 1000
+          signal_type: ParabolicRamp
+      - context: "FAIR.SELECTOR.C=1:S=1:P=5" # upper-plateau
+        time: !!uint64 0
+        parameters:
+          start_value: 3000
+          sample_rate: 1000
+          signal_type: Const
+      - context: "FAIR.SELECTOR.C=1:S=1:P=6" # start ramp-down
+        time: !!uint64 0
+        parameters:
+          duration: 0.3
+          start_value: 3000
+          final_value: 100
+          sample_rate: 1000
+          signal_type: CubicSpline
+      - context: "FAIR.SELECTOR.C=1:S=1:P=7" # upper-plateau
+        time: !!uint64 0
+        parameters:
+          start_value: 100
+          sample_rate: 1000
+          signal_type: Const
+  - id: gr::basic::FunctionGenerator<float32>
+    parameters:
+      name: IntensityGenerator
+      sample_rate: 1000
+      signal_type: Const
+      start_value: 0
+      signal_trigger: "CMD_BP_START"
+    ctx_parameters:
+      - context: "FAIR.SELECTOR.C=1:S=1:P=3" # lower-plateau
+        time: !!uint64 0
+        parameters:
+          start_value: 40e9f
+          sample_rate: 1000
+          signal_type: Const
+      - context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
+        time: !!uint64 0
+        parameters:
+          duration: 0.500000
+          start_value: 40e9f
+          final_value: 38e9f
+          sample_rate: 1000
+          signal_type: CubicSpline
+      - context: "FAIR.SELECTOR.C=1:S=1:P=5"
+        time: !!uint64 0
+        parameters:
+          duration: 2
+          start_value: 38e9f
+          final_value: 00e9f
+          round_off_time: 0.3
+          sample_rate: 1000
+          signal_type: ParabolicRamp
+      - context: "FAIR.SELECTOR.C=1:S=1:P=6"
+        time: !!uint64 0
+        parameters:
+          start_value: 0
+          sample_rate: 1000
+          signal_type: Const
+  - id: opendigitizer::ImPlotSink<float32>
+    parameters:
+      name: DipoleCurrentSink
+      color: 0xC80000
+      required_size: 16384
+      signal_name: dipole current
+      signal_quantity: DipoleCurrent
+      signal_unit: A
+  - id: opendigitizer::ImPlotSink<float32>
+    parameters:
+      name: IntensitySink
+      color: 0x0000C8
+      required_size: 16384
+      signal_name: beam intensity
+      signal_quantity: BeamIntensity
+      signal_unit: ppp
+  - id: opendigitizer::ImPlotSink<float32>
+    parameters:
+      name: sineSink1
+      color: 0x00C800
+      signal_name: sine 2Hz
+      signal_quantity: voltage
+      signal_unit: V
+  - id: opendigitizer::ImPlotSink<float32>
+    parameters:
+      name: sineSink3
+      color: 0xC800C8
+      signal_name: sine 5Hz
+      signal_quantity: voltage
+      signal_unit: V
+  - id: gr::basic::ClockSource
+    parameters:
+      name: SpectrumClock
+      sample_rate: 25
+      chunk_size: 1
+      n_samples_max: 0
+  - id: opendigitizer::TestSpectrumGenerator<float32>
+    parameters:
+      name: SpectrumGenerator
+      spectrum_size: 4
+      center_freq: 100e6
+      signal_bandwidth: 1e6
+      clock_rate: 25
+      seed: 42
+      show_schottky: true
+      show_interference_lines: true
+      show_sweep_line: true
+      log_interval: 0
+  - id: opendigitizer::ImPlotSink<gr::DataSet<float32>>
+    parameters:
+      name: spectrumSink
+      dataset_index: 0
+      signal_name: spectrum
+      abscissa_quantity: frequency
+      abscissa_unit: Hz
+      signal_quantity: magnitude
+      signal_unit: dB
+connections:
+  - [sine source 1, 0, sum sigs, 0]
+  - [sine source 3, 0, sum sigs, 1]
+  - [ sine source 1, 0, sineSink1, 0 ]
+  - [ sine source 3, 0, sineSink3, 0 ]
+  - [sum sigs, 0, FFT, 0]
+  - [sum sigs, 0, sinesSink, 0]
+  - [FFT, 0, fftSink, 0]
+  - [ClockSource, 0, DipoleCurrentGenerator, 0]
+  - [DipoleCurrentGenerator, 0, DipoleCurrentSink, 0]
+  - [ClockSource, 0, IntensityGenerator, 0]
+  - [IntensityGenerator, 0, IntensitySink, 0]
+  - [SpectrumClock, 0, SpectrumGenerator, 0]
+  - [SpectrumGenerator, 0, spectrumSink, 0]
+dashboard:
+  layout: Free
+  propertyControlWindows:
+    "Control color for fftSink and sinesSink":
+      label:  "sine wave and fft color"
+      id: !!uint32 1
+    "Property control for spectrum_size of SpectrumGenerator":
+      label:  "spectrum_size"
+      id: !!uint32 2
+  windowLayout:
+    floatingWindows:  {}
+    dockSpace:
+      hsplit:
+        second:
+          vsplit:
+            second:  "Property control for spectrum_size of SpectrumGenerator"
+            first:  "Spectrum View"
+            ratio: !!float32 0.0747968
+        first:
+          vsplit:
+            second:  "Function Generators"
+            first:
+              vsplit:
+                second:  "Control color for fftSink and sinesSink"
+                first:
+                  hsplit:
+                    second:  "FFT Spectrum"
+                    first:  "Raw Signal"
+                    ratio: !!float32 0.497613
+                ratio: !!float32 0.149837
+            ratio: !!float32 0.497561
+        ratio: !!float32 0.660362
+  exportedProperties:
+    "sinesSink":
+      color: !!uint32 1
+    "fftSink":
+      color: !!uint32 1
+    "SpectrumGenerator":
+      spectrum_size: !!uint32 2
+  sources:
+    - name: sinesSink
+      block: sinesSink
+    - name: fftSink
+      block: fftSink
+    - name: DipoleCurrentSink
+      block: DipoleCurrentSink
+      port: 0
+    - name: IntensitySink
+      block: IntensitySink
+      port: 0
+    - name: sineSink1
+      block: sineSink1
+    - name: sineSink3
+      block: sineSink3
+    - name: spectrumSink
+      block: spectrumSink
+  plots:
+    - name: Raw Signal
+      parameters:
+        show_legend: true
+      axes:
+        - axis: X
+          min: NaN # enables auto-range
+          max: NaN # enables auto-range
+          scale: LinearReverse
+        - axis: Y
+          min: NaN # enables auto-range for first axis
+          max: NaN # enables auto-range for first axis
+          format: Default # options: Auto, Metric, MetricInline, Scientific, None, Default
+      sources:
+        - sinesSink
+    - name: FFT Spectrum
+      axes:
+        - axis: X
+          min: 0.0001
+          max: 0.5
+          scale: Log10
+          format: MetricInline # options: Auto, Metric, MetricInline, Scientific, None, Default
+        - axis: Y
+          min: NaN
+          max: NaN
+      sources:
+        - fftSink
+    - name: Function Generators
+      parameters:
+        n_history: 10000 # number of samples to plot
+      axes:
+        - axis: X
+          min: NaN # auto-range min
+          max: NaN # auto-range max
+          scale: Time # UTC time axis, other options: Linear, LinearReverse, Time, Log10, SymLog
+        - axis: Y
+          min: NaN # enables auto-range for first axis
+          max: NaN # enables auto-range for first axis
+        - axis: Y
+          min: -100. # second axis min
+          max: NaN # second axis max
+          format: Metric # options: Auto, Metric, MetricInline, Scientific, None, Default
+      sources:
+        - IntensitySink
+        - DipoleCurrentSink
+    - name: Spectrum View
+      type: opendigitizer::charts::SpectrumView
+      parameters:
+        show_max_hold: true
+        show_min_hold: true
+        show_average: true
+        decay_tau_frames: 120
+        n_history: 256
+        colormap: ImPlotColormap_Viridis
+        top_pane_ratio: 0.4
+      axes:
+        - axis: X
+          min: NaN
+          max: NaN
+          format: MetricInline
+        - axis: Y
+          min: NaN
+          max: NaN
+        - axis: Z
+          min: -85
+          max: -55
+      sources:
+        - spectrumSink

--- a/src/ui/charts/Chart.hpp
+++ b/src/ui/charts/Chart.hpp
@@ -812,6 +812,7 @@ inline constexpr const char* kCheckOff   = "\uf0c8"; // square
 inline constexpr const char* kHistory    = "\uf1da"; // clock-rotate-left
 inline constexpr const char* kArrow      = "\uf061"; // arrow-right
 inline constexpr const char* kFormat     = "\uf031"; // font
+inline constexpr const char* kDisconnect = "\ue55e"; // plug with minus sign
 
 /// Renders icon followed by text, using fontIconsSolid for the icon portion.
 inline void iconText(const char* icon, const char* text) {

--- a/src/ui/common/ImguiWrap.cpp
+++ b/src/ui/common/ImguiWrap.cpp
@@ -1,0 +1,127 @@
+#include "ImguiWrap.hpp"
+
+#include <array>
+#include <string>
+
+namespace DigitizerUi::IMW {
+static ImVec2 framePad() { return ImGui::GetStyle().FramePadding * 2.f; }
+static ImVec2 framePadHeight() { return {0.f, ImGui::GetStyle().FramePadding.y * 2.f}; }
+
+// imgui will insert ItemInnerSpacing.x to the total width if a label is present in a frame
+static ImVec2 labelPlusSpacing(const ImVec2& labelSize) { //
+    return labelSize.x > 0.f ? ImVec2{ImGui::GetStyle().ItemInnerSpacing.x + labelSize.x, labelSize.y} : labelSize;
+}
+
+static WidgetSize calculateLabelMinAndPreferredSize(const std::string& label) {
+    std::string         visible{label.c_str(), ImGui::FindRenderedTextEnd(label.c_str())};
+    const ImVec2        labelSize = ImGui::CalcTextSize(visible.c_str(), nullptr, true);
+    std::array<char, 5> slice     = {};
+    using diff_t                  = decltype(slice.end() - slice.begin());
+    const size_t copyLength       = std::min(slice.size() - 1, visible.size());
+    std::ranges::copy_n(visible.begin(), static_cast<diff_t>(copyLength), slice.begin());
+    assert(slice.back() == '\0');
+    const auto minlabelWidth = ImGui::CalcTextSize(slice.data()).x;
+    return WidgetSize{.min = ImVec2{minlabelWidth, labelSize.y}, .preferred = labelSize}.normalized();
+}
+
+static WidgetSize CalcFramedLabelSize(const std::string& label) {
+    const auto [labelMinSize, labelSize, _] = calculateLabelMinAndPreferredSize(label);
+    return WidgetSize{
+        .min       = labelPlusSpacing(labelMinSize) + framePad(),
+        .preferred = labelPlusSpacing(labelSize) + framePad(),
+    }
+        .normalized();
+}
+
+ImVec2 CalcButtonSize(const char* label) { return ImGui::CalcTextSize(label) + framePad(); }
+
+WidgetSize CalcCheckboxSize(const char* label) {
+    const auto [labelMinSize, labelSize, _] = calculateLabelMinAndPreferredSize(label);
+    const float boxSize                     = ImGui::GetFrameHeight();
+    const auto  addSizeToConstantSize       = [boxSize](ImVec2 size) { //
+        return ImVec2{boxSize + labelPlusSpacing(size).x, size.y + framePad().y};
+    };
+    return WidgetSize{
+        .min                 = addSizeToConstantSize(labelMinSize),
+        .preferred           = addSizeToConstantSize(labelSize),
+        .labelPreferredWidth = labelSize.x,
+    }
+        .normalized();
+}
+
+WidgetSize CalcColorEditorSize(const char* label, ImGuiColorEditFlags flags) {
+    const ImGuiStyle& style                 = ImGui::GetStyle();
+    const auto [labelMinSize, labelSize, _] = calculateLabelMinAndPreferredSize(label);
+    const float frameHeight                 = ImGui::GetFrameHeight();
+
+    const bool hasColorBox = (flags & ImGuiColorEditFlags_NoSmallPreview) == 0;
+    const bool hasInputs   = (flags & ImGuiColorEditFlags_NoInputs) == 0;
+    // treat controls as a fixed size thing, min == preferred, despite having text,
+    // to avoid having to calculate text and text width for each input and mimic a
+    // lot more of imgui internals here
+    float controlsWidth = 0.f;
+    if (hasInputs) {
+        const bool hex      = (flags & ImGuiColorEditFlags_DisplayHex) != 0;
+        const bool hasAlpha = (flags & ImGuiColorEditFlags_NoAlpha) == 0;
+        const int  nFrames  = hex ? 1 : (hasAlpha ? 4 : 3);
+
+        const auto singleInputWidth = ImGui::CalcTextSize("R:77.7").x + framePad().x;
+        controlsWidth               = (float(nFrames) * singleInputWidth) + float(nFrames - 1) * style.ItemInnerSpacing.x;
+    }
+
+    const float colorBoxWidth          = hasColorBox ? frameHeight : 0.f;
+    const float boxAndControlsSpacing  = (hasColorBox && hasInputs) ? style.ItemInnerSpacing.x : 0.f;
+    const auto  addLabelToConstantSize = [colorBoxWidth, boxAndControlsSpacing, controlsWidth, frameHeight](ImVec2 size) { //
+        return ImVec2{(colorBoxWidth + boxAndControlsSpacing + controlsWidth) + labelPlusSpacing(size).x, frameHeight};
+    };
+
+    return WidgetSize{
+        .min                 = addLabelToConstantSize(labelMinSize),
+        .preferred           = addLabelToConstantSize(labelSize),
+        .labelPreferredWidth = labelSize.x,
+    }
+        .normalized();
+}
+
+static WidgetSize CalcSliderOrDragSize(const char* label, std::size_t charsNeeded) {
+    auto size                      = CalcFramedLabelSize(label);
+    auto dragLabelWidth            = ImGui::CalcTextSize("W").x * static_cast<float>(std::max(charsNeeded, std::size_t{1}));
+    size.labelPreferredWidth       = size.preferred.x;
+    const auto dragAdditionalWidth = dragLabelWidth + ImGui::GetStyle().ItemInnerSpacing.x + ImGui::GetStyle().FramePadding.x * 2.f;
+    size.min.x += dragAdditionalWidth;
+    size.preferred.x += dragAdditionalWidth;
+    return size.normalized();
+}
+
+WidgetSize CalcSliderSize(const char* label, std::size_t charsNeeded) { return CalcSliderOrDragSize(label, charsNeeded); }
+WidgetSize CalcDragSize(const char* label, std::size_t charsNeeded) { return CalcSliderOrDragSize(label, charsNeeded); }
+
+WidgetSize CalcTextInputSize(const char* label, const char* contents) {
+    auto labelSize = CalcFramedLabelSize(label);
+    auto inputSize = CalcFramedLabelSize(contents);
+    return WidgetSize{
+        .min                 = ImVec2{labelSize.min.x + inputSize.min.x + ImGui::GetStyle().ItemInnerSpacing.x, std::max(labelSize.min.y, inputSize.min.y)},
+        .preferred           = ImVec2{labelSize.preferred.x + inputSize.preferred.x + ImGui::GetStyle().ItemInnerSpacing.x, std::max(labelSize.preferred.y, inputSize.preferred.y)},
+        .labelPreferredWidth = labelSize.preferred.x,
+    };
+}
+
+WidgetSize CalcComboSize(const char* label, const char* previewValue, ImGuiComboFlags flags) {
+    WidgetSize previewSize{};
+    if (!(flags & ImGuiComboFlags_NoPreview) && previewValue) {
+        // preview is just a framed label
+        previewSize = CalcFramedLabelSize(previewValue);
+    }
+
+    // combo size is arrow plus preview box plus label
+    const float arrowSize                   = (flags & ImGuiComboFlags_NoArrowButton) ? 0.f : ImGui::GetFrameHeight();
+    const auto [labelMinSize, labelSize, _] = calculateLabelMinAndPreferredSize(label);
+    return WidgetSize{
+        .min                 = ImVec2{arrowSize + previewSize.min.x, 0.f} + labelPlusSpacing(labelMinSize) + framePadHeight(),
+        .preferred           = ImVec2{arrowSize + previewSize.preferred.x, 0.f} + labelPlusSpacing(labelSize) + framePadHeight(),
+        .labelPreferredWidth = labelSize.x,
+    }
+        .normalized();
+}
+
+} // namespace DigitizerUi::IMW

--- a/src/ui/common/ImguiWrap.hpp
+++ b/src/ui/common/ImguiWrap.hpp
@@ -7,6 +7,8 @@
 
 #include <c_resource.hpp>
 
+#include <algorithm>
+
 namespace DigitizerUi::IMW {
 
 namespace detail {
@@ -82,6 +84,47 @@ struct PushCursorPosition {
     PushCursorPosition() { saved = ImGui::GetCursorScreenPos(); }
     ~PushCursorPosition() { ImGui::SetCursorScreenPos(saved); }
 };
+
+/// In places such as the edit pane, we want to wrap widgets to a newline when
+/// there is not enough space. But ImGui generally has no concept of min size.
+/// Checkboxes, for example, are a constant size. Meanwhile TextInputs will
+/// take up 65% of the window by default but can shrink to 1px regardless of
+/// their text contents. So, to have a rule when to wrap, we make these min
+/// and preferred sizes ourselves.
+/// Generally, min(strlen(label), 4) characters is considered the min width for
+/// widgets with a label.
+struct WidgetSize {
+    ImVec2 min;
+    ImVec2 preferred;
+    // SetNextItemWidth does not account for/affect the label, so subtract this
+    float labelPreferredWidth{};
+
+    [[nodiscard]] constexpr WidgetSize normalized() const {
+        return {
+            .min                 = min,
+            .preferred           = ImVec2{std::max(preferred.x, min.x), std::max(preferred.y, min.y)},
+            .labelPreferredWidth = labelPreferredWidth,
+        };
+    }
+};
+
+/// Calculate the width and height a button will take up with the current style
+/// and a given label. Buttons have a fixed size.
+ImVec2 CalcButtonSize(const char* label);
+
+WidgetSize CalcCheckboxSize(const char* label);
+/// Minimum size of a labelled color editor, not the color picker popup
+WidgetSize CalcColorEditorSize(const char* label, ImGuiColorEditFlags flags);
+/// charsNeeded should be something like floating point precision, plus unit/suffix strlen
+WidgetSize CalcSliderSize(const char* label, std::size_t charsNeeded);
+/// charsNeeded should be something like floating point precision, plus unit/suffix strlen
+WidgetSize CalcDragSize(const char* label, std::size_t charsNeeded);
+/// Minimum size of a folded ImGui::BeginCombo() (label + arrow + small preview
+/// area). previewValue is only used if ImGuiComboFlags_WidthFitPreview is set
+WidgetSize CalcComboSize(const char* label, const char* previewValue, ImGuiComboFlags flags);
+/// Preferred minimum size of a single-line text input (room for ~4 characters
+/// + label).
+WidgetSize CalcTextInputSize(const char* label, const char* contents);
 
 } // namespace DigitizerUi::IMW
 #endif

--- a/src/ui/common/LookAndFeel.cpp
+++ b/src/ui/common/LookAndFeel.cpp
@@ -48,6 +48,8 @@ const Palette& LookAndFeel::palette() const noexcept {
         .flowgraphBg          = {0.1f, 0.1f, 0.1f, 1.f},
         .flowgraphNodeBg      = {0.2f, 0.2f, 0.2f, 1.f},
         .flowgraphNodeBorder  = {0.7f, 0.7f, 0.7f, 1.f},
+
+        .rowBgAlt = ImVec4{0.2f, 0.2f, 0.2f, 1.0f},
     };
     static const Palette lightModePalette{
         .gridLines = quarterTransparentBlack,
@@ -62,6 +64,8 @@ const Palette& LookAndFeel::palette() const noexcept {
         .flowgraphBg          = {1.f, 1.f, 1.f, 1.f},
         .flowgraphNodeBg      = {0.94f, 0.92f, 1.f, 1.f},
         .flowgraphNodeBorder  = {0.38f, 0.38f, 0.38f, 1.f},
+
+        .rowBgAlt = {0.8f, 0.8f, 0.8f, 1.0f},
     };
 
     return style == Style::Light ? lightModePalette : darkModePalette;

--- a/src/ui/common/LookAndFeel.hpp
+++ b/src/ui/common/LookAndFeel.hpp
@@ -46,6 +46,8 @@ struct Palette {
     ImVec4 flowgraphBg;
     ImVec4 flowgraphNodeBg;
     ImVec4 flowgraphNodeBorder;
+
+    ImVec4 rowBgAlt;
 };
 
 struct LookAndFeel {

--- a/src/ui/components/Block.cpp
+++ b/src/ui/components/Block.cpp
@@ -1,6 +1,5 @@
 #include "Block.hpp"
 #include "BlockNeighboursPreview.hpp"
-#include "Keypad.hpp"
 
 #include <algorithm>
 #include <format>
@@ -9,10 +8,10 @@
 #include <gnuradio-4.0/Scheduler.hpp>
 #include <misc/cpp/imgui_stdlib.h>
 
+#include "../GraphModel.hpp"
 #include "../common/LookAndFeel.hpp"
 #include "../components/Dialog.hpp"
-
-#include "../App.hpp"
+#include "Keypad.hpp"
 
 using namespace std::string_literals;
 
@@ -54,29 +53,128 @@ bool drawRemoveContextPopup(const std::string& context) {
     return false;
 }
 
-void BlockControlsPanel(BlockControlsPanelContext& panelContext, const ImVec2& pos, const ImVec2& frameSize, bool verticalLayout) {
+static void blockContextComboBox(UiGraphBlock* block) {
+    const auto& activeContext = block->activeContext;
+
+    const std::string activeContextLabel = activeContext.context.empty() ? "Default" : activeContext.context;
+    if (auto combo = IMW::Combo("##contextNameCombo", activeContextLabel.c_str(), 0)) {
+        for (const auto& contextNameAndTime : block->contexts) {
+            const bool        selected = activeContext.context == contextNameAndTime.context;
+            const std::string label    = contextNameAndTime.context.empty() ? "Default" : contextNameAndTime.context;
+            if (ImGui::Selectable(label.c_str(), selected)) {
+                block->setActiveContext(contextNameAndTime);
+            }
+            if (selected) {
+                ImGui::SetItemDefaultFocus();
+            }
+        }
+    }
+
+    {
+        ImGui::SameLine();
+        IMW::Disabled disableDueDefaultAction(activeContext.context.empty());
+        IMW::Font     _(LookAndFeel::instance().fontIconsSolid);
+        if (ImGui::Button("\uf146")) {
+            ImGui::OpenPopup(removeContextPopupId);
+        }
+    }
+    IMW::detail::setItemTooltip("Remove context");
+
+    {
+        ImGui::SameLine();
+        IMW::Font _(LookAndFeel::instance().fontIconsSolid);
+        if (ImGui::Button("\uf0fe")) {
+            ImGui::OpenPopup(addContextPopupId);
+        }
+    }
+    IMW::detail::setItemTooltip("Add new context");
+
+    drawAddContextPopup(block);
+    if (drawRemoveContextPopup(activeContext.context)) {
+        block->removeContext(activeContext);
+    }
+}
+
+static BlockPropertyEditResult BlockControlsPanelImpl(BlockControlsPanelContext& panelContext, bool verticalLayout) {
+    // guaranteed to be non-null by check in BlockControlsPanel()
     UiGraphBlock* block = panelContext.selectedBlock();
-    if (!block) {
-        return;
-    }
+
     using namespace DigitizerUi;
-
-    auto size = frameSize;
-    if (panelContext.closeTime < std::chrono::system_clock::now()) {
-        panelContext = {};
-        return;
-    }
-
-    ImGui::SetNextWindowPos(pos, ImGuiCond_Always);
-    ImGui::SetNextWindowSize(frameSize);
-    IMW::Window blockControlsPanel("BlockControlsPanel", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoDocking);
-
     const float lineHeight = [&] {
         IMW::Font font(LookAndFeel::instance().fontIconsSolid);
         return ImGui::GetTextLineHeightWithSpacing() * 1.5f;
     }();
 
+    if (!verticalLayout) {
+        BlockNeighboursPreview(panelContext, ImGui::GetContentRegionAvail());
+        ImGui::SameLine();
+    }
+
     const auto itemSpacing = ImGui::GetStyle().ItemSpacing;
+
+    auto minpos = ImGui::GetCursorPos();
+    auto size   = ImGui::GetContentRegionAvail();
+
+    BlockPropertyEditResult propertyEditResult;
+    {
+        IMW::Child settings("Settings", verticalLayout ? ImVec2(size.x, ImGui::GetContentRegionAvail().y - lineHeight - itemSpacing.y) : ImVec2(ImGui::GetContentRegionAvail().x, size.y), true, ImGuiWindowFlags_HorizontalScrollbar);
+        ImGui::TextUnformatted(block->blockName.c_str());
+        // std::string_view typeName = block->blockTypeName;
+
+        blockContextComboBox(block);
+
+        auto typeParams = block->ownerGraph ? block->ownerGraph->availableParametrizationsFor(block->blockTypeName) : UiGraphModel::AvailableParametrizationsResult{};
+
+        if (typeParams.availableParametrizations && typeParams.availableParametrizations->size() > 1) {
+            if (auto combo = IMW::Combo("##baseTypeCombo", typeParams.parametrization.c_str(), 0)) {
+                for (const auto& availableParametrization : *typeParams.availableParametrizations) {
+                    if (ImGui::Selectable(availableParametrization.c_str(), availableParametrization == typeParams.parametrization)) {
+                        gr::Message message;
+                        assert(!panelContext.targetGraph.empty());
+                        message.cmd      = gr::message::Command::Set;
+                        message.endpoint = gr::scheduler::property::kReplaceBlock;
+                        message.data     = gr::property_map{{"uniqueName", block->blockUniqueName},  //
+                                {"type", std::move(typeParams.baseType) + availableParametrization}, //
+                                {"_targetGraph", panelContext.targetGraph}};
+                        block->ownerGraph->sendMessage(std::move(message));
+                    }
+                    if (availableParametrization == typeParams.parametrization) {
+                        ImGui::SetItemDefaultFocus();
+                    }
+                }
+            }
+        }
+
+        if (verticalLayout) {
+            BlockNeighboursPreview(panelContext, ImGui::GetContentRegionAvail());
+        }
+
+        propertyEditResult = BlockSettingsControls(block);
+
+        if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
+            panelContext.resetTime();
+        }
+    }
+
+    ImGui::SetCursorPos(minpos);
+
+    return propertyEditResult;
+}
+
+BlockControlsPanelResult BlockControlsPanel(BlockControlsPanelContext& panelContext, const ImVec2& pos, const ImVec2& frameSize, bool verticalLayout) {
+    if (!panelContext.selectedBlock()) {
+        return {};
+    }
+
+    auto size = frameSize;
+    if (panelContext.closeTime < std::chrono::system_clock::now()) {
+        panelContext = {};
+        return {};
+    }
+
+    ImGui::SetNextWindowPos(pos, ImGuiCond_Always);
+    ImGui::SetNextWindowSize(frameSize);
+    IMW::Window blockControlsPanel("BlockControlsPanel", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoDocking);
 
     size = ImGui::GetContentRegionAvail();
 
@@ -92,247 +190,269 @@ void BlockControlsPanel(BlockControlsPanelContext& panelContext, const ImVec2& p
         ImGui::ProgressBar(1.f - duration, {size.x, 3});
     }
 
-    if (!verticalLayout) {
-        BlockNeighboursPreview(panelContext, ImGui::GetContentRegionAvail());
-        ImGui::SameLine();
+    IMW::TabBar tabBar("blockControlsPanel##", ImGuiTabBarFlags_None);
+
+    const ImGuiTabItemFlags  selectedBlockFlags = std::exchange(panelContext.wantsSelectedBlockTab, false) ? ImGuiTabItemFlags_SetSelected : ImGuiTabItemFlags_None;
+    BlockControlsPanelResult result;
+    if (auto item = IMW::TabItem("Selected Block", nullptr, selectedBlockFlags)) {
+        result = {
+            .allExportedPropertiesPageResult = {},
+            .blockEditPaneResult             = BlockControlsPanelImpl(panelContext, verticalLayout),
+        };
     }
+    if (auto item = IMW::TabItem("All Exported Properties", nullptr, ImGuiTabItemFlags_None)) {
+        using Flags       = ExportedPropertyList::Flags;
+        const auto params = ExportedPropertyList::Params{.flags = Flags::DragDropHandle | Flags::ContextMenuButton};
+        result            = {
+                       .allExportedPropertiesPageResult = panelContext.propertyList.draw(*panelContext.graphModel, params),
+                       .blockEditPaneResult             = {},
+        };
+    }
+    return result;
+}
 
-    auto minpos = ImGui::GetCursorPos();
-    size        = ImGui::GetContentRegionAvail();
+constexpr ImGuiColorEditFlags colorFieldEditorFlags = ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoAlpha; // ColorEdit3 implies NoAlpha
 
-    {
-        IMW::Child settings("Settings", verticalLayout ? ImVec2(size.x, ImGui::GetContentRegionAvail().y - lineHeight - itemSpacing.y) : ImVec2(ImGui::GetContentRegionAvail().x, size.y), true, ImGuiWindowFlags_HorizontalScrollbar);
-        ImGui::TextUnformatted(block->blockName.c_str());
-        // std::string_view typeName = block->blockTypeName;
-
-        const auto& activeContext = block->activeContext;
-
-        const std::string activeContextLabel = activeContext.context.empty() ? "Default" : activeContext.context;
-        if (auto combo = IMW::Combo("##contextNameCombo", activeContextLabel.c_str(), 0)) {
-            for (const auto& contextNameAndTime : block->contexts) {
-                const bool        selected = activeContext.context == contextNameAndTime.context;
-                const std::string label    = contextNameAndTime.context.empty() ? "Default" : contextNameAndTime.context;
-                if (ImGui::Selectable(label.c_str(), selected)) {
-                    block->setActiveContext(contextNameAndTime);
+gr::pmt::Value editBlockProperty(const char* label, const std::string& propertyName, const gr::pmt::Value& currentPropertyValue, const UiGraphBlock::SettingsMetaInformation& meta) {
+    gr::pmt::Value out;
+    using Type = UiGraphBlock::SettingsControlType;
+    switch (meta.controlType(propertyName, currentPropertyValue)) {
+    case Type::Color: {
+        gr::pmt::ValueVisitor([label, &out]<typename T>(const T& value) {
+            if constexpr (std::unsigned_integral<T> && sizeof(T) >= 4) {
+                ImVec4 col = ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(static_cast<std::uint32_t>(value)));
+                float  rgb[3]{col.x, col.y, col.z};
+                if (ImGui::ColorEdit3(label, rgb, colorFieldEditorFlags)) {
+                    out = static_cast<T>((static_cast<std::uint32_t>(rgb[0] * 255.0f) << 16) | (static_cast<std::uint32_t>(rgb[1] * 255.0f) << 8) | static_cast<std::uint32_t>(rgb[2] * 255.0f));
                 }
-                if (selected) {
+            }
+        }).visit(currentPropertyValue);
+        break;
+    }
+    case Type::TextInput: {
+        assert(meta.enumValues.empty());
+        std::string current = currentPropertyValue.value_or(std::string{});
+        if (ImGui::InputText(label, &current)) {
+            out = current;
+        }
+        break;
+    }
+    case Type::Combo: {
+        assert(!meta.enumValues.empty());
+        std::string current = currentPropertyValue.value_or(std::string{});
+        if (ImGui::BeginCombo(label, current.c_str())) {
+            for (const auto& enumName : meta.enumValues) {
+                const bool isCurrent = enumName == current;
+                if (ImGui::Selectable(enumName.c_str(), isCurrent)) {
+                    out = enumName;
+                }
+                if (isCurrent) {
                     ImGui::SetItemDefaultFocus();
                 }
             }
+            ImGui::EndCombo();
         }
-
-        {
-            ImGui::SameLine();
-            IMW::Disabled disableDueDefaultAction(activeContext.context.empty());
-            IMW::Font     _(LookAndFeel::instance().fontIconsSolid);
-            if (ImGui::Button("\uf146")) {
-                ImGui::OpenPopup(removeContextPopupId);
-            }
+        break;
+    }
+    case Type::Checkbox: {
+        bool temp = currentPropertyValue.value_or(false);
+        if (ImGui::Checkbox(label, &temp)) {
+            out = temp;
         }
-        IMW::detail::setItemTooltip("Remove context");
-
-        {
-            ImGui::SameLine();
-            IMW::Font _(LookAndFeel::instance().fontIconsSolid);
-            if (ImGui::Button("\uf0fe")) {
-                ImGui::OpenPopup(addContextPopupId);
-            }
-        }
-        IMW::detail::setItemTooltip("Add new context");
-
-        drawAddContextPopup(block);
-        if (drawRemoveContextPopup(activeContext.context)) {
-            block->removeContext(activeContext);
-        }
-
-        auto typeParams = block->ownerGraph ? block->ownerGraph->availableParametrizationsFor(block->blockTypeName) : UiGraphModel::AvailableParametrizationsResult{};
-
-        if (typeParams.availableParametrizations) {
-            if (typeParams.availableParametrizations->size() > 1) {
-                if (auto combo = IMW::Combo("##baseTypeCombo", typeParams.parametrization.c_str(), 0)) {
-                    for (const auto& availableParametrization : *typeParams.availableParametrizations) {
-                        if (ImGui::Selectable(availableParametrization.c_str(), availableParametrization == typeParams.parametrization)) {
-                            gr::Message message;
-                            assert(!panelContext.targetGraph.empty());
-                            message.cmd      = gr::message::Command::Set;
-                            message.endpoint = gr::scheduler::property::kReplaceBlock;
-                            message.data     = gr::property_map{{"uniqueName", block->blockUniqueName},  //
-                                    {"type", std::move(typeParams.baseType) + availableParametrization}, //
-                                    {"_targetGraph", panelContext.targetGraph}};
-                            block->ownerGraph->sendMessage(std::move(message));
-                        }
-                        if (availableParametrization == typeParams.parametrization) {
-                            ImGui::SetItemDefaultFocus();
-                        }
-                    }
+        break;
+    }
+    case Type::Slider: {
+        assert(meta.minValue && meta.maxValue);
+        assert(currentPropertyValue.is_arithmetic());
+        gr::pmt::ValueVisitor([&out, &meta, label]<typename T>(const T& num) {
+            if constexpr (std::floating_point<T>) {
+                double temp = num;
+                if (ImGui::SliderScalar(label, ImGuiDataType_Double, &temp, &*meta.minValue, &*meta.maxValue, "%d", {})) {
+                    out = static_cast<T>(temp);
+                }
+            } else if constexpr (std::integral<T>) {
+                auto       temp     = static_cast<std::int64_t>(num);
+                const auto minValue = static_cast<std::int64_t>(*meta.minValue);
+                const auto maxValue = static_cast<std::int64_t>(*meta.maxValue);
+                if (ImGui::SliderScalar(label, ImGuiDataType_S64, &temp, &minValue, &maxValue, "%d", {})) {
+                    out = static_cast<T>(temp);
                 }
             }
+        }).visit(currentPropertyValue);
+        break;
+    }
+    case Type::Keypad: {
+        assert(!meta.minValue || !meta.maxValue);
+        assert(currentPropertyValue.is_arithmetic());
+        gr::pmt::ValueVisitor([&propertyName, label, &meta, &out]<typename T>(const T& num) {
+            // sizeof(T) >= 4 is just here to reduce template instantiations of InputKeypad<>::edit
+            if constexpr (std::is_arithmetic_v<T> && sizeof(T) >= 4) {
+                T temp = num;
+                if (InputKeypad<>::edit(propertyName, label, &temp, meta.unit)) {
+                    out = static_cast<T>(temp);
+                }
+            } else {
+                assert(false && "unexpected type for keypad edited property");
+            }
+        }).visit(currentPropertyValue);
+        break;
+    }
+    }
+    return out;
+}
+
+IMW::WidgetSize calcEditorSize(const char* label, const std::string& propertyName, const gr::pmt::Value& value, const UiGraphBlock::SettingsMetaInformation& meta) {
+    using enum UiGraphBlock::SettingsControlType;
+    switch (meta.controlType(propertyName, value)) {
+    case Checkbox: return IMW::CalcCheckboxSize(label);
+    case Color: return IMW::CalcColorEditorSize(label, colorFieldEditorFlags);
+    // could calculate no. of digits needed by slider with logarithms, but it is okay to clip off big numbers
+    case Slider: return IMW::CalcSliderSize(label, 5);
+    case Keypad: {
+        if (value.is_floating_point()) {
+            return InputKeypad<>::calcSize<float>(label, meta.unit);
+        } else if (value.is_integral()) {
+            return InputKeypad<>::calcSize<std::uint32_t>(label, meta.unit);
         }
+        return InputKeypad<>::calcSize<std::string>(label, meta.unit);
+    }
+    case Combo: return IMW::CalcComboSize(label, value.value_or(std::string{}).c_str(), 0);
+    case TextInput: return IMW::CalcTextInputSize(label, value.value_or(std::string{}).c_str());
+    }
+    return {};
+}
 
-        if (verticalLayout) {
-            BlockNeighboursPreview(panelContext, ImGui::GetContentRegionAvail());
+/// Function drawSettingRow() became too complex, so this had to be created to
+/// split it in two. These are UI measurements which are shared between drawing
+/// the edit widget on the left and the export and (+/-) button on the right.
+struct BlockSettingRowExportButtonsParams {
+    bool                                                 shouldWrapButtons{};
+    bool                                                 isExported{};
+    ImVec2                                               cursorStart{};
+    float                                                regionAvailable{};
+    float                                                exportButtonWidth{};
+    float                                                assignButtonWidth{};
+    float                                                spacing{};
+    const std::string&                                   exportButtonLabel;
+    const std::string&                                   assignButtonLabel;
+    const std::string&                                   propertyKey;
+    UiGraphBlock&                                        block;
+    decltype(UiGraphBlock::exportedProperties)::iterator exportedPropertyIter{};
+};
+
+static BlockPropertyEditResult drawExportButtons(const BlockSettingRowExportButtonsParams& params) {
+    if (!params.shouldWrapButtons) {
+        ImGui::SameLine(0.f, 0.f);
+    }
+    ImGui::SetCursorPosX(params.cursorStart.x + params.regionAvailable - params.exportButtonWidth);
+    if (ImGui::Button(params.exportButtonLabel.c_str())) {
+        if (params.isExported) {
+            params.block.exportedProperties.erase(params.exportedPropertyIter);
+        } else {
+            params.block.exportedProperties.try_emplace(params.propertyKey);
         }
+    }
+    ImGui::SameLine(0.f, 0.f);
+    ImGui::SetCursorPosX(params.cursorStart.x + params.regionAvailable - (params.exportButtonWidth + params.assignButtonWidth + params.spacing));
+    if (ImGui::Button(params.assignButtonLabel.c_str())) {
+        // re-search in case user can press un-export and (+) at the same time and invalidated the iterator already
+        const auto newExportedIter = params.block.exportedProperties.find(params.propertyKey);
+        if (newExportedIter != std::end(params.block.exportedProperties) && newExportedIter->second.windowId.has_value()) {
+            return BlockPropertyEditResult{
+                .type     = BlockPropertyEditResult::Type::RemoveFromExistingWindow,
+                .block    = std::addressof(params.block),
+                .property = params.propertyKey,
+            };
+        } else {
+            return BlockPropertyEditResult{
+                .type     = BlockPropertyEditResult::Type::AddNewWindow,
+                .block    = std::addressof(params.block),
+                .property = params.propertyKey,
+            };
+        }
+    }
+    return BlockPropertyEditResult{};
+}
 
-        BlockSettingsControls(block);
+/// Returns a value if the row was successfully drawn
+static std::optional<BlockPropertyEditResult> drawSettingRow(const std::string& key, UiGraphBlock& block, const gr::pmt::Value& value, int rowIndex) {
+    if (!value.is_string() && !value.is_floating_point() && !value.is_integral()) {
+        return {}; // unsupported type
+    }
 
-        if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem)) {
-            panelContext.resetTime();
+    auto          id = ImGui::GetID(key.c_str());
+    IMW::ChangeId rowId{int(id)};
+
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+
+    auto metaInfoIter = block.blockSettingsMetaInformation.find(std::string(key));
+    if (metaInfoIter == std::end(block.blockSettingsMetaInformation)) {
+        assert(false);
+        return {};
+    }
+    auto& metaInfo = metaInfoIter->second;
+    ImGui::TextUnformatted(metaInfo.description.c_str());
+    if (metaInfo.minValue && metaInfo.maxValue) {
+        ImGui::SameLine();
+        ImGui::TextDisabled("(%.4g \x{e2}\x{80}\x{93} %.4g)", *metaInfo.minValue, *metaInfo.maxValue);
+    }
+
+    ImGui::TableSetColumnIndex(1);
+    char label[64];
+    auto labelResult = std::format_to_n(label, sizeof(label) - 1, "##parameter_{}", rowIndex);
+    *labelResult.out = '\0';
+
+    auto        exportedPropertyIter = block.exportedProperties.find(key);
+    const bool  isExported           = exportedPropertyIter != block.exportedProperties.end();
+    const char* visibleExportText    = isExported ? "Un-Export" : "Export";
+    const auto  exportButtonLabel    = std::format("{}##{}", visibleExportText, key);
+
+    const bool  isAssigned              = isExported && exportedPropertyIter->second.windowId.has_value();
+    const char* visibleAssignButtonText = isAssigned ? "-" : "+";
+    const auto  assignButtonLabel       = std::format("{}##assignButton{}", visibleAssignButtonText, key);
+
+    BlockSettingRowExportButtonsParams params{
+        .isExported           = isExported,
+        .cursorStart          = ImGui::GetCursorPos(),
+        .regionAvailable      = ImGui::GetContentRegionAvail().x,
+        .exportButtonWidth    = IMW::CalcButtonSize(visibleExportText).x,
+        .assignButtonWidth    = IMW::CalcButtonSize(visibleAssignButtonText).x,
+        .spacing              = ImGui::GetStyle().ItemSpacing.x,
+        .exportButtonLabel    = exportButtonLabel,
+        .assignButtonLabel    = assignButtonLabel,
+        .propertyKey          = key,
+        .block                = block,
+        .exportedPropertyIter = exportedPropertyIter,
+    };
+
+    const auto  editorMinWidth      = calcEditorSize(label, key, value, metaInfo).min.x;
+    const float regionBeforeButtons = params.regionAvailable - params.exportButtonWidth - params.assignButtonWidth - (params.spacing * 2.f);
+    params.shouldWrapButtons        = regionBeforeButtons < editorMinWidth,
+
+    ImGui::SetNextItemWidth(std::max(1.f, params.shouldWrapButtons ? params.regionAvailable : regionBeforeButtons));
+    if (auto newValue = editBlockProperty(label, key, value, metaInfo); newValue.has_value()) {
+        block.setSetting(key, std::move(newValue));
+    }
+
+    if (ImGui::IsItemHovered()) {
+        if (metaInfo.minValue && metaInfo.maxValue) {
+            ImGui::SetTooltip("%s [%.4g \x{e2}\x{80}\x{93} %.4g]", key.c_str(), *metaInfo.minValue, *metaInfo.maxValue);
+        } else {
+            ImGui::SetTooltip("%s", key.c_str());
         }
     }
 
-    ImGui::SetCursorPos(minpos);
+    return drawExportButtons(params);
 }
 
-void BlockSettingsControls(UiGraphBlock* block, const ImVec2& /*size*/) {
-    constexpr auto editorFieldWidth = 150;
-
-    const auto isColourField = [](const UiGraphBlock::SettingsMetaInformation& meta, std::string_view key) {
-        auto containsColo = [](std::string_view s) {
-            constexpr std::string_view target = "colo";
-            return !std::ranges::search(s, target, [](unsigned char a, unsigned char b) { return std::tolower(a) == std::tolower(b); }).empty();
-        };
-        return containsColo(meta.description) || containsColo(key);
-    };
-
-    const auto sendSetSettingMessage = [block](std::string_view keyToUpdate, auto updatedValue) {
-        if (!block->ownerGraph) {
-            return;
-        }
-        gr::Message message;
-        message.serviceName = block->blockUniqueName;
-        message.endpoint    = gr::block::property::kSetting;
-        message.cmd         = gr::message::Command::Set;
-        message.data        = gr::property_map{{std::pmr::string(keyToUpdate), updatedValue}};
-        block->ownerGraph->sendMessage(std::move(message));
-    };
-
+BlockPropertyEditResult BlockSettingsControls(UiGraphBlock* block, const ImVec2& /*size*/) {
     InputKeypad<>::clearIfNewBlock(block->blockUniqueName);
+    BlockPropertyEditResult result{};
+    const auto              drawSettingsTable = [&](bool visibleOnly) {
+        IMW::StyleColor rowBg(ImGuiCol_TableRowBgAlt, LookAndFeel::instance().palette().rowBgAlt);
 
-    const auto drawSettingRow = [&](const std::string& key, const gr::pmt::Value& value, int& rowIndex) {
-        bool isEditable = false;
-        gr::pmt::ValueVisitor([&](const auto& arg) {
-            using T = std::decay_t<decltype(arg)>;
-            if constexpr (std::same_as<T, std::string> || std::same_as<T, std::string_view> || std::same_as<T, std::pmr::string> || std::floating_point<T> || std::integral<T>) {
-                isEditable = true;
-            }
-        }).visit(value);
-        if (!isEditable) {
-            return;
-        }
-
-        auto          id = ImGui::GetID(key.c_str());
-        IMW::ChangeId rowId{int(id)};
-
-        ImGui::TableNextRow();
-        ImGui::TableSetColumnIndex(0);
-        auto& meta = block->blockSettingsMetaInformation[std::string(key)];
-        ImGui::TextUnformatted(meta.description.c_str());
-        if (meta.minValue && meta.maxValue) {
-            ImGui::SameLine();
-            ImGui::TextDisabled("(%.4g \xe2\x80\x93 %.4g)", *meta.minValue, *meta.maxValue);
-        }
-
-        ImGui::TableSetColumnIndex(1);
-        char label[64];
-        auto labelResult = std::format_to_n(label, sizeof(label) - 1, "##parameter_{}", rowIndex);
-        *labelResult.out = '\0';
-
-        const auto getUnit = [&meta]() -> std::string_view { return meta.unit; };
-
-        const auto showFieldTooltip = [&]() {
-            if (ImGui::IsItemHovered()) {
-                if (meta.minValue && meta.maxValue) {
-                    ImGui::SetTooltip("%s [%.4g \xe2\x80\x93 %.4g]", key.c_str(), *meta.minValue, *meta.maxValue);
-                } else {
-                    ImGui::SetTooltip("%s", key.c_str());
-                }
-            }
-        };
-
-        gr::pmt::ValueVisitor([&]<typename TArg>(const TArg& arg) {
-            using T = std::decay_t<TArg>;
-            if constexpr (std::same_as<T, bool>) {
-                bool temp = arg;
-                if (ImGui::Checkbox(label, &temp)) {
-                    sendSetSettingMessage(key, temp);
-                }
-                showFieldTooltip();
-            } else if constexpr (std::same_as<T, std::string> || std::same_as<T, std::string_view> || std::same_as<T, std::pmr::string>) {
-                if (!meta.enumValues.empty()) {
-                    ImGui::SetNextItemWidth(-FLT_MIN);
-                    std::string current(arg);
-                    if (ImGui::BeginCombo(label, current.c_str())) {
-                        for (const auto& enumName : meta.enumValues) {
-                            if (ImGui::Selectable(enumName.c_str(), enumName == current)) {
-                                sendSetSettingMessage(key, enumName);
-                            }
-                            if (enumName == current) {
-                                ImGui::SetItemDefaultFocus();
-                            }
-                        }
-                        ImGui::EndCombo();
-                    }
-                } else {
-                    ImGui::SetNextItemWidth(-FLT_MIN);
-                    std::string temp(arg);
-                    if (ImGui::InputText(label, &temp)) {
-                        sendSetSettingMessage(key, std::move(temp));
-                    }
-                }
-                showFieldTooltip();
-            } else if constexpr (std::unsigned_integral<T> && sizeof(T) >= 4) {
-                if (isColourField(meta, key)) {
-                    ImVec4 col = ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(static_cast<std::uint32_t>(arg)));
-                    float  rgb[3]{col.x, col.y, col.z};
-                    if (ImGui::ColorEdit3(label, rgb, ImGuiColorEditFlags_NoInputs)) {
-                        auto newColor = static_cast<T>((static_cast<std::uint32_t>(rgb[0] * 255.0f) << 16) | (static_cast<std::uint32_t>(rgb[1] * 255.0f) << 8) | static_cast<std::uint32_t>(rgb[2] * 255.0f));
-                        sendSetSettingMessage(key, newColor);
-                    }
-                    showFieldTooltip();
-                } else {
-                    ImGui::SetNextItemWidth(editorFieldWidth);
-                    int temp = static_cast<int>(arg);
-                    if (meta.minValue && meta.maxValue) {
-                        if (ImGui::SliderInt(label, &temp, static_cast<int>(*meta.minValue), static_cast<int>(*meta.maxValue))) {
-                            sendSetSettingMessage(key, static_cast<T>(temp));
-                        }
-                    } else if (InputKeypad<>::edit(key.c_str(), label, &temp, getUnit())) {
-                        sendSetSettingMessage(key, static_cast<T>(temp));
-                    }
-                    showFieldTooltip();
-                }
-            } else if constexpr (std::floating_point<T>) {
-                ImGui::SetNextItemWidth(editorFieldWidth);
-                float temp = static_cast<float>(arg);
-                if (meta.minValue && meta.maxValue) {
-                    const float minV = static_cast<float>(*meta.minValue);
-                    const float maxV = static_cast<float>(*meta.maxValue);
-                    if (ImGui::SliderFloat(label, &temp, minV, maxV)) {
-                        sendSetSettingMessage(key, static_cast<T>(temp));
-                    }
-                } else if (InputKeypad<>::edit(key.c_str(), label, &temp, getUnit())) {
-                    sendSetSettingMessage(key, static_cast<T>(temp));
-                }
-                showFieldTooltip();
-            } else if constexpr (std::integral<T>) {
-                ImGui::SetNextItemWidth(editorFieldWidth);
-                int temp = static_cast<int>(arg);
-                if (meta.minValue && meta.maxValue) {
-                    if (ImGui::SliderInt(label, &temp, static_cast<int>(*meta.minValue), static_cast<int>(*meta.maxValue))) {
-                        sendSetSettingMessage(key, static_cast<T>(temp));
-                    }
-                } else if (InputKeypad<>::edit(key.c_str(), label, &temp, getUnit())) {
-                    sendSetSettingMessage(key, static_cast<T>(temp));
-                }
-                showFieldTooltip();
-            }
-        }).visit(value);
-
-        ++rowIndex;
-    };
-
-    const auto drawSettingsTable = [&](bool visibleOnly) {
-        if (auto table = IMW::Table(visibleOnly ? "settings_visible" : "settings_more", 2, ImGuiTableFlags_SizingFixedFit, ImVec2(0, 0), 0.0f)) {
+        if (auto table = IMW::Table(visibleOnly ? "settings_visible" : "settings_more", 2, ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_RowBg, ImVec2(0, 0), 0.0f)) {
             ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
             ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthStretch);
 
@@ -344,7 +464,12 @@ void BlockSettingsControls(UiGraphBlock* block, const ImVec2& /*size*/) {
                 if (isMarked != visibleOnly) {
                     continue;
                 }
-                drawSettingRow(keyStr, value, rowIndex);
+                if (auto rowResult = drawSettingRow(keyStr, *block, value, rowIndex)) {
+                    rowIndex += 1;
+                    if (*rowResult) {
+                        result = std::move(*rowResult);
+                    }
+                }
             }
         }
     };
@@ -382,6 +507,7 @@ void BlockSettingsControls(UiGraphBlock* block, const ImVec2& /*size*/) {
     if (ImGui::IsItemHovered()) {
         ImGui::SetTooltip("Reset all settings to defaults");
     }
+    return result;
 }
 
 BlockControlsPanelContext::BlockControlsPanelContext() {
@@ -402,6 +528,7 @@ void BlockControlsPanelContext::setSelectedBlock(UiGraphBlock* block, UiGraphMod
     graphModel = model;
     if (graphModel) {
         graphModel->selectedBlock = block;
+        wantsSelectedBlockTab     = true;
     }
 }
 

--- a/src/ui/components/Block.hpp
+++ b/src/ui/components/Block.hpp
@@ -1,7 +1,13 @@
 #ifndef OPENDIGITIZER_UI_COMPONENTS_BLOCK_HPP_
 #define OPENDIGITIZER_UI_COMPONENTS_BLOCK_HPP_
 
+#include "../GraphModel.hpp"
 #include "../common/ImguiWrap.hpp"
+#include "ExportedPropertiesList.hpp"
+
+#include <gnuradio-4.0/Value.hpp>
+
+#include <imgui.h> // ImVec2
 
 #include <chrono>
 #include <functional>
@@ -24,14 +30,47 @@ struct BlockControlsPanelContext {
 
     Mode mode = Mode::None;
 
+    bool wantsSelectedBlockTab = true;
+
+    ExportedPropertyList propertyList;
+
     std::chrono::time_point<std::chrono::system_clock> closeTime;
     std::function<void(UiGraphBlock* block)>           blockClickedCallback;
 
     void resetTime();
 };
 
-void BlockControlsPanel(BlockControlsPanelContext& context, const ImVec2& pos, const ImVec2& frameSize, bool verticalLayout);
-void BlockSettingsControls(UiGraphBlock* block, const ImVec2& size = {0.f, 0.f});
+struct BlockPropertyEditResult {
+    enum class Type {
+        AddNewWindow,
+        RemoveFromExistingWindow,
+    };
+
+    Type          type{};
+    UiGraphBlock* block = nullptr;
+    std::string   property;
+
+    constexpr explicit operator bool() const { return block; }
+};
+
+struct BlockControlsPanelResult {
+    ExportedPropertyList::Result allExportedPropertiesPageResult;
+    BlockPropertyEditResult      blockEditPaneResult;
+};
+
+/// Returns the action taken on the exported property page, if one occurred
+BlockControlsPanelResult BlockControlsPanel(BlockControlsPanelContext& context, const ImVec2& pos, const ImVec2& frameSize, bool verticalLayout);
+BlockPropertyEditResult  BlockSettingsControls(UiGraphBlock* block, const ImVec2& size = {0.f, 0.f});
+
+/// Make imgui widgets to edit a block property value
+/// Supports types in block properties: string bool integer float enum color
+/// Returns a value containing monostate if no change occurred.
+[[nodiscard]] gr::pmt::Value editBlockProperty(const char* label, const std::string& propertyName, const gr::pmt::Value& currentPropertyValue, const UiGraphBlock::SettingsMetaInformation& meta);
+
+/// Min and preferred size of the edit widget that editBlockProperty would draw
+/// for the given value and meta information. Used to determine how to wrap
+/// these on a line.
+[[nodiscard]] IMW::WidgetSize calcEditorSize(const char* label, const std::string& propertyName, const gr::pmt::Value& currentPropertyValue, const UiGraphBlock::SettingsMetaInformation& meta);
 
 } // namespace DigitizerUi::components
 

--- a/src/ui/components/Docking.cpp
+++ b/src/ui/components/Docking.cpp
@@ -55,6 +55,24 @@ static void dragWindow(ImGuiWindow* windowToDrag, ImRect boundingBox) {
     g.ActiveIdClickOffset.y = std::clamp(g.ActiveIdClickOffset.y, 0.f, std::max(0.f, ImGui::GetFrameHeight() - 1.f));
 };
 
+static void dockAtBottomIfWanted(const DockSpace::Windows& windows, ImGuiID dockspaceID, ImGuiDockNodeFlags nodeFlags) {
+    // if any windows request to be docked at the bottom, respect that
+    for (const auto& window : windows) {
+        if (window->wantsDockAtBottom) {
+            window->wantsDockAtBottom = false;
+            ImGuiID bottomId          = 0;
+            ImGuiID topId             = 0;
+            ImGui::DockBuilderSplitNode(dockspaceID, ImGuiDir_Down, .3f, &bottomId, &topId);
+
+            ImGui::DockBuilderDockWindow(window->name.data(), bottomId);
+            auto bottomNode = ImGui::DockBuilderGetNode(bottomId);
+            bottomNode->SetLocalFlags(nodeFlags);
+            ImGui::DockBuilderSetNodeSize(bottomId, ImVec2{bottomNode->Size.x, ImGui::GetFrameHeight() + ImGui::GetStyle().WindowPadding.y});
+            ImGui::DockBuilderFinish(dockspaceID);
+        }
+    }
+}
+
 void DockSpace::setLayoutType(DockingLayoutType type) {
     if (type != _layoutType) {
         _layoutType = type;
@@ -105,14 +123,18 @@ void DockSpace::render(const Windows& windows, ImVec2 paneSize, bool isEditable)
 void DockSpace::renderWindows(const Windows& windows, bool isEditable) {
     for (const auto& window : windows) {
         constexpr float floatingWindowMinSizeFractionOfMainWindow = 1.f / 4.f;
-        const ImVec2    windowSizeMax                             = ImGui::GetMainViewport()->WorkSize;
-        const ImVec2    windowSizeMin                             = {
+        const ImVec2    windowSizeMax                             = window->windowMaxSize.value_or(ImGui::GetMainViewport()->WorkSize);
+        const ImVec2    windowSizeMin                             = window->windowMinSizeOverride.value_or(ImVec2{
             std::max(1.f, windowSizeMax.x * floatingWindowMinSizeFractionOfMainWindow),
             std::max(1.f, windowSizeMax.y * floatingWindowMinSizeFractionOfMainWindow),
-        };
+        });
         ImGui::SetNextWindowSizeConstraints(windowSizeMin, windowSizeMax);
 
-        IMW::Window dock(window->name.data(), nullptr, ImGuiWindowFlags_NoCollapse);
+        ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+        if (window->wantsHorizontalScrollbar) {
+            flags |= ImGuiWindowFlags_HorizontalScrollbar;
+        }
+        IMW::Window dock(window->name.data(), nullptr, flags);
 
         if (window->renderFunc) {
             window->renderFunc();
@@ -180,6 +202,10 @@ void DockSpace::drawEditableWindowDragArea() {
     }
 
     ImGui::SetCursorScreenPos(oldPos);
+    // there is an assert in imgui that the cursor screen pos does not exceed
+    // both window size and content. Adding a dummy expands the content to the
+    // cursor
+    ImGui::Dummy({});
 }
 
 void DockSpace::layoutInBox(const Windows& windows, ImGuiDir direction, bool isEditable) {
@@ -363,6 +389,8 @@ void DockSpace::relayout(const Windows& windows, bool isEditable, bool exactFree
             }
         } else {
             restoreDockSpaceState(_lastFreeLayout, dockspaceID);
+
+            dockAtBottomIfWanted(windows, dockspaceID, nodeFlags(isEditable));
         }
     } else {
         layoutInGrid(windows, isEditable);

--- a/src/ui/components/Docking.hpp
+++ b/src/ui/components/Docking.hpp
@@ -99,6 +99,15 @@ struct DockSpace::Window {
     /// Min point of the pane is (0, 0).
     /// This is only used at startup, loaded from "rect" field of plots in dashboard yaml
     std::optional<FreeGeometry> freeLayoutPosition;
+
+    std::optional<ImVec2> windowMinSizeOverride;
+    std::optional<ImVec2> windowMaxSize;
+    bool                  wantsHorizontalScrollbar = false;
+
+    /// If a window is floating and this is true, then relayout() will see it
+    /// and consume it, docking the floating window at the bottom of the
+    /// dockspace.
+    bool wantsDockAtBottom = false;
 };
 
 } // namespace DigitizerUi

--- a/src/ui/components/ExportedPropertiesList.cpp
+++ b/src/ui/components/ExportedPropertiesList.cpp
@@ -1,0 +1,260 @@
+#include "ExportedPropertiesList.hpp"
+#include "Block.hpp"
+
+#include "../common/LookAndFeel.hpp"
+
+#include <misc/cpp/imgui_stdlib.h>
+
+namespace DigitizerUi::components {
+void ExportedPropertyDragDropPayload::payloadSource(const std::string& block, const std::string& property) {
+    ExportedPropertyDragDropPayload payload{};
+    if (property.size() > sizeof(payload.propertyName) - 1) {
+        std::println("WARNING: property name {} too large for drag and drop payload", property);
+    }
+    if (block.size() > sizeof(payload.blockName) - 1) {
+        std::println("WARNING: block name {} too large for drag and drop payload", block);
+    }
+    using diff_t = decltype(property.begin() - property.end());
+
+    const auto propertyLen = std::min(property.size(), sizeof(payload.propertyName) - 1);
+    std::ranges::copy_n(property.begin(), static_cast<diff_t>(propertyLen), payload.propertyName.begin());
+
+    const auto blockLen = std::min(block.size(), sizeof(payload.blockName) - 1);
+    std::ranges::copy_n(block.begin(), static_cast<diff_t>(blockLen), payload.blockName.begin());
+
+    ImGui::SetDragDropPayload(kType, &payload, sizeof(payload));
+}
+
+/// The goal of this function is to draw a block property without +/- increment
+/// operators for numbers, dropdown symbols for combo boxes, or text focus for
+/// text inputs, etc.
+void ExportedPropertyList::drawPropertyUninteractive(const char* blockName, const char* propertyName, UiGraphBlock::SettingsControlType type, const gr::pmt::Value& currentPropertyValue) {
+    const auto id = std::format("{}{}##", blockName ? blockName : "unknown", propertyName ? propertyName : "unknown");
+    drawPropertyUninteractiveNoLabel(id.c_str(), type, currentPropertyValue);
+    // still have preview of color before color properties
+    if (blockName) {
+        ImGui::SameLine();
+        ImGui::TextUnformatted(blockName, ImGui::FindRenderedTextEnd(blockName));
+    }
+    if (propertyName) {
+        ImGui::SameLine();
+        ImGui::TextUnformatted(propertyName, ImGui::FindRenderedTextEnd(propertyName));
+    }
+}
+
+void ExportedPropertyList::drawPropertyUninteractiveNoLabel(const char* id, UiGraphBlock::SettingsControlType type, const gr::pmt::Value& currentPropertyValue) {
+    gr::pmt::ValueVisitor([type, id]<typename T>(const T& value) {
+        if constexpr (std::is_same_v<T, bool>) {
+            bool dummy = value;
+            ImGui::Checkbox(id, &dummy);
+            return;
+        } else if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, std::string_view> || std::is_same_v<T, std::pmr::string>) {
+            ImGui::TextUnformatted(std::string{value}.c_str());
+        } else if constexpr (std::is_floating_point_v<T>) {
+            ImGui::Text("%f", static_cast<double>(value));
+        } else if constexpr (std::is_integral_v<T>) {
+            if constexpr (std::unsigned_integral<T> && sizeof(T) >= 4) {
+                if (type == UiGraphBlock::SettingsControlType::Color) {
+                    // draw the color button but ignore interaction with it
+                    std::ignore = ImGui::ColorButton(id, ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(static_cast<std::uint32_t>(value))));
+                    return;
+                }
+            }
+            ImGui::Text("%lld", static_cast<long long>(value));
+        }
+    }).visit(currentPropertyValue);
+}
+
+enum class ValidExportedPropertyResult {
+    DrawnButNoAction,
+    Filtered,
+    OpenContextMenu,
+};
+
+/// Actually draws the exported property, assumes iterators are valid
+static ValidExportedPropertyResult drawValidExportedProperty(                       //
+    UiGraphBlock*                                                  block,           //
+    bool                                                           isDisabled,      //
+    decltype(UiGraphBlock::blockSettings)::iterator                settingIterator, //
+    decltype(UiGraphBlock::blockSettingsMetaInformation)::iterator metaIterator,    //
+    const ExportedPropertyList::Params&                            parameters       //
+) {
+    const gr::pmt::Value& current               = settingIterator->second;
+    const auto&           meta                  = metaIterator->second;
+    const auto            propertyUiControlType = meta.controlType(settingIterator->first, current);
+
+    // filter properties not matching type
+    if (parameters.typeFilter && parameters.typeFilter != propertyUiControlType) {
+        return ValidExportedPropertyResult::Filtered;
+    }
+
+    IMW::Group property;
+
+    IMW::ChangeStrId id(std::format("{}{}", block->blockName, settingIterator->first).c_str());
+
+    // draw drag and drop button
+    if (parameters.flags & ExportedPropertyList::Flags::DragDropHandle) {
+        {
+            IMW::Font font(LookAndFeel::instance().fontIconsSolidLarge);
+            ImGui::Button("\u{f58e}");
+        }
+        ImGui::SetItemTooltip("Drag to control window...");
+
+        if (auto dndSource = IMW::DragDropSource(ImGuiDragDropFlags_AcceptNoDrawDefaultRect)) {
+            ExportedPropertyDragDropPayload::payloadSource(block->blockName, std::string{settingIterator->first});
+            ImGui::Text("Property \"%s\"...", settingIterator->first.c_str());
+        }
+        ImGui::SameLine();
+    }
+
+    constexpr const char* moreOptionsLabel      = "...";
+    const auto            moreOptionsButtonSize = IMW::CalcButtonSize(moreOptionsLabel);
+
+    if (parameters.flags & ExportedPropertyList::Flags::SelectableProperties) {
+        // in this case you can't interact with the controls of the property, so avoid drawing ones that don't add information.
+        // passing in nullptr for blockname since we are in a section which is already labeled with the blockname
+        ExportedPropertyList::drawPropertyUninteractive(nullptr, settingIterator->first.c_str(), propertyUiControlType, current);
+    } else {
+        IMW::Disabled disabled(isDisabled);
+        const auto    labelSize = ImGui::CalcTextSize(settingIterator->first.c_str());
+        ImGui::SetNextItemWidth(-(labelSize + moreOptionsButtonSize + ImGui::GetStyle().ItemSpacing * 2.f).x);
+        if (auto newValue = editBlockProperty(settingIterator->first.c_str(), std::string{settingIterator->first}, current, meta)) {
+            block->setSetting(settingIterator->first, std::move(newValue));
+        }
+    }
+
+    if (parameters.flags & ExportedPropertyList::Flags::ContextMenuButton) {
+        ImGui::SameLine();
+        const auto avail = ImGui::GetContentRegionAvail().x;
+        if (avail > moreOptionsButtonSize.x) {
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (avail - moreOptionsButtonSize.x));
+        }
+        if (ImGui::Button(moreOptionsLabel)) {
+            return ValidExportedPropertyResult::OpenContextMenu;
+        }
+    }
+    return ValidExportedPropertyResult::DrawnButNoAction;
+}
+
+ExportedPropertyList::ExportedPropertyAction ExportedPropertyList::drawExportedProperty(UiGraphBlock* block, const std::string& exportedPropertyName, const ExportedPropertyList::Params& parameters) {
+    auto       action         = ExportedPropertyAction::None;
+    const auto matchPredicate = [block, &exportedPropertyName](const ExportedPropertyPair& pair) { //
+        return pair.blockName == block->blockName && pair.propertyName == exportedPropertyName;
+    };
+    const bool isDisabled = std::ranges::find_if(parameters.disabledList, matchPredicate) != std::end(parameters.disabledList);
+    // filter properties which do not have the filter string, if it is present
+    static constexpr auto stringToLowercase = [](std::string_view string) { //
+        return string | std::views::transform([](unsigned char c) { return std::tolower(c); }) | std::ranges::to<std::string>();
+    };
+    static constexpr auto has = [](const std::string& a, const auto& pattern) { //
+        return stringToLowercase(a).find(stringToLowercase(pattern)) != std::string::npos;
+    };
+    if (!filter.empty() && !has(exportedPropertyName, filter) && !has(block->blockName, filter) && !has(block->blockUniqueName, filter)) {
+        return ExportedPropertyAction::None;
+    }
+
+    auto propertyIter = block->blockSettings.find(exportedPropertyName);
+    auto metaIter     = block->blockSettingsMetaInformation.find(exportedPropertyName);
+    if (propertyIter == std::end(block->blockSettings) || metaIter == std::end(block->blockSettingsMetaInformation)) {
+        return ExportedPropertyAction::None;
+    }
+
+    using enum ValidExportedPropertyResult;
+    switch (drawValidExportedProperty(block, isDisabled, propertyIter, metaIter, parameters)) {
+    case DrawnButNoAction: break;
+    case Filtered: return ExportedPropertyAction::None; break;
+    case OpenContextMenu: action = ExportedPropertyAction::OpenContextMenu; break;
+    }
+
+    if (!isDisabled && (parameters.flags & Flags::SelectableProperties)) {
+        if (ImGui::IsItemHovered()) {
+            ImGui::GetCurrentWindow()->DrawList->AddRectFilled(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), rgbToImGuiABGR(0x63e69f, 0x99));
+        }
+        // create a button over the previous item
+        ImGui::SetCursorScreenPos(ImGui::GetItemRectMin());
+        if (ImGui::InvisibleButton(propertyIter->first.c_str(), ImGui::GetItemRectSize())) {
+            action = ExportedPropertyAction::SelectThis;
+        }
+    } else {
+        if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
+            action = ExportedPropertyAction::OpenContextMenu;
+        }
+    }
+    return action;
+}
+
+ExportedPropertyList::Result ExportedPropertyList::draw(UiGraphModel& graphModel, const Params& parameters) {
+    {
+        IMW::Font       font(LookAndFeel::instance().fontIconsSolidLarge);
+        constexpr auto* searchLabel = "\u{f002}";
+        ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - (ImGui::CalcTextSize(searchLabel).x + ImGui::GetStyle().ItemInnerSpacing.x));
+        ImGui::InputText(searchLabel, std::addressof(this->filter));
+    }
+
+    IMW::Child child("propertiesScrollable", ImVec2{}, 0, 0);
+
+    bool                 openContextMenu = false;
+    ExportedPropertyPair selected{};
+
+    const auto allExportedPropertiesByBlockName = graphModel.recursiveGatherExportedProperties();
+    for (const auto& [blockName, exportedPropertiesPtr] : allExportedPropertiesByBlockName) {
+        auto* block = graphModel.recursiveFindBlockByName(blockName).block;
+        if (!block) {
+            continue;
+        }
+
+        if (ImGui::TreeNode(block->blockUniqueName.c_str(), "%s", block->blockName.c_str())) {
+            for (const auto& [exportedPropertyName, _] : *exportedPropertiesPtr) {
+                using enum ExportedPropertyAction;
+                switch (this->drawExportedProperty(block, exportedPropertyName, parameters)) {
+                case None: break;
+                case SelectThis: {
+                    selected = {.blockName = block->blockName, .propertyName = exportedPropertyName};
+                } break;
+                case OpenContextMenu: {
+                    this->contextMenuTarget = {.blockName = block->blockName, .propertyName = exportedPropertyName};
+                    openContextMenu         = true;
+                } break;
+                }
+            }
+            ImGui::TreePop();
+        }
+    }
+
+    if (allExportedPropertiesByBlockName.empty()) {
+        constexpr auto* emptyLabel = "No properties yet exported...";
+        const auto      desired    = ImGui::CalcTextSize(emptyLabel).x;
+        const auto      available  = ImGui::GetContentRegionAvail().x;
+        if (desired < available) {
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (available - desired) / 2.f);
+        }
+        ImGui::TextUnformatted(emptyLabel);
+    }
+
+    if (openContextMenu) {
+        ImGui::OpenPopup(ExportedPropertyList::kContextMenuPopupID);
+        isContextMenuOpen = true;
+    }
+
+    if (auto popup = IMW::Popup(ExportedPropertyList::kContextMenuPopupID, 0)) {
+        Result     out;
+        const bool addWindow = ImGui::Button("New Window");
+        const bool unexport  = ImGui::Button("Un-export");
+        if (addWindow) {
+            out.action         = Action::AddWindow;
+            out.targetProperty = std::move(this->contextMenuTarget);
+            ImGui::CloseCurrentPopup();
+        } else if (unexport) {
+            out.action         = Action::Unexport;
+            out.targetProperty = std::move(this->contextMenuTarget);
+            ImGui::CloseCurrentPopup();
+        }
+        return out;
+    }
+
+    return {
+        .action         = Action::Selected,
+        .targetProperty = std::move(selected),
+    };
+}
+} // namespace DigitizerUi::components

--- a/src/ui/components/ExportedPropertiesList.hpp
+++ b/src/ui/components/ExportedPropertiesList.hpp
@@ -1,0 +1,112 @@
+#ifndef OPENDIGITIZER_UI_COMPONENTS_EXPORTED_PROPERTIES_LIST_HPP_
+#define OPENDIGITIZER_UI_COMPONENTS_EXPORTED_PROPERTIES_LIST_HPP_
+
+#include "../GraphModel.hpp"
+
+#include <imgui.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace DigitizerUi {
+namespace components {
+struct ExportedPropertyPair {
+    std::string blockName;
+    std::string propertyName;
+
+    constexpr explicit operator bool() const { return !blockName.empty() || !propertyName.empty(); }
+};
+
+class ExportedPropertyList {
+    // keep this across frames
+    std::string          filter;
+    ExportedPropertyPair contextMenuTarget;
+    bool                 isContextMenuOpen = false;
+
+    constexpr static const char* kContextMenuPopupID = "exportedPropertyListContextMenu##";
+
+public:
+    enum class Flags : std::uint8_t {
+        None = 0x0,
+        // properties are just selectable, buttons on the properties are not interactable
+        SelectableProperties = 0x1,
+        // enable drag and drop handle on the left hand side of properties
+        DragDropHandle = 0x2,
+        // add a "..." button on the right hand side, which opens the context menu
+        ContextMenuButton = 0x4,
+    };
+
+    struct Params {
+        Flags flags = {};
+        // filter the displayed exported properties to only ones that match this type
+        std::optional<UiGraphBlock::SettingsControlType> typeFilter;
+        // items in this vector will not be interactable
+        std::span<const ExportedPropertyPair> disabledList;
+    };
+
+    enum class Action {
+        Selected,
+        AddWindow,
+        Unexport,
+    };
+
+    struct Result {
+        Action               action = {};
+        ExportedPropertyPair targetProperty;
+
+        constexpr explicit operator bool() const { return bool(targetProperty); }
+    };
+
+    /// Draw the UI and send the necessary signals to modify properties.
+    [[nodiscard]] Result draw(UiGraphModel& graphModel, const Params& parameters);
+
+    static void drawPropertyUninteractive(const char* blockName, const char* propertyName, UiGraphBlock::SettingsControlType type, const gr::pmt::Value& currentPropertyValue);
+    static void drawPropertyUninteractiveNoLabel(const char* id, UiGraphBlock::SettingsControlType type, const gr::pmt::Value& currentPropertyValue);
+
+private:
+    enum class ExportedPropertyAction {
+        None,
+        OpenContextMenu,
+        SelectThis,
+    };
+
+    /// Draw a single property and return whether the user wants to select the property or open the context menu for this property
+    [[nodiscard]] ExportedPropertyAction drawExportedProperty(UiGraphBlock* block, const std::string& exportedPropertyName, const ExportedPropertyList::Params& parameters);
+};
+
+constexpr ExportedPropertyList::Flags operator|(ExportedPropertyList::Flags a, ExportedPropertyList::Flags b) { //
+    return static_cast<ExportedPropertyList::Flags>(std::to_underlying(a) | std::to_underlying(b));
+}
+constexpr bool operator&(ExportedPropertyList::Flags a, ExportedPropertyList::Flags b) { //
+    return static_cast<bool>(std::to_underlying(a) & std::to_underlying(b));
+}
+
+struct ExportedPropertyDragDropPayload {
+    static constexpr const char kType[] = "OD_EXPORTED_PROPERTY_DND";
+    static_assert(sizeof(kType) < 32); // imgui internal buffer limit
+
+    std::array<char, 256> propertyName = {};
+    std::array<char, 256> blockName    = {};
+
+    constexpr explicit operator ExportedPropertyPair() const {
+        return {
+            .blockName    = std::string{std::string_view(blockName.data(), strnlen(blockName.data(), blockName.size()))},
+            .propertyName = std::string{std::string_view(propertyName.data(), strnlen(propertyName.data(), propertyName.size()))},
+        };
+    }
+
+    /// Should be called within an if(IMW::DragDropSource()) { ... } block
+    static void payloadSource(const std::string& block, const std::string& property);
+
+    [[nodiscard]] static ExportedPropertyPair getCurrentPayload() {
+        if (const auto* payload = ImGui::GetDragDropPayload(); payload && payload->Data) {
+            return ExportedPropertyPair(*static_cast<ExportedPropertyDragDropPayload*>(payload->Data));
+        }
+        return {};
+    }
+};
+
+} // namespace components
+} // namespace DigitizerUi
+#endif

--- a/src/ui/components/GlobalSignalLegend.hpp
+++ b/src/ui/components/GlobalSignalLegend.hpp
@@ -1,54 +1,40 @@
 #ifndef OPENDIGITIZER_GLOBAL_SIGNAL_LEGEND_HPP
 #define OPENDIGITIZER_GLOBAL_SIGNAL_LEGEND_HPP
 
-#include <functional>
+#include "../GraphModel.hpp"
+#include "../charts/Charts.hpp"
+#include "../common/ImguiWrap.hpp"
+#include "../common/LookAndFeel.hpp"
+
+#include <implot.h>
+
 #include <string>
 #include <string_view>
-
-#include <gnuradio-4.0/Block.hpp>
-
-#include "../charts/Chart.hpp"
-#include "../charts/SinkRegistry.hpp"
-#include "../common/ImguiWrap.hpp"
 
 namespace DigitizerUi {
 
 /// Global signal legend displaying all registered sinks from SinkRegistry.
 /// Supports left-click toggle, right-click colour/settings, drag to charts, and drop from charts.
-struct GlobalSignalLegend : gr::Block<GlobalSignalLegend, gr::Drawable<gr::UICategory::Toolbar, "ImGui">> {
-    using RightClickCallback = std::function<void(std::string_view sinkUniqueName)>;
-
+struct GlobalSignalLegend {
     enum class ClickResult { None, Left, RightColor, RightName };
 
-    GR_MAKE_REFLECTABLE(GlobalSignalLegend);
+    ImVec2      _legendSize{0.f, 0.f};
+    std::string _editingSinkUniqueName;
+    bool        _openColorPopup  = false;
+    bool        _dragDropEnabled = true;
 
-    ImVec2             _legendSize{0.f, 0.f};
-    float              _paneWidth{800.f};
-    RightClickCallback _onRightClick;
-    std::string        _editingSinkUniqueName;
-    bool               _openColorPopup  = false;
-    bool               _dragDropEnabled = true;
-
-    void setRightClickCallback(RightClickCallback callback) { _onRightClick = std::move(callback); }
-    void setPaneWidth(float width) { _paneWidth = width; }
     void setDragDropEnabled(bool isNowEnabled) { _dragDropEnabled = isNowEnabled; }
 
-    gr::work::Result work(std::size_t = std::numeric_limits<std::size_t>::max()) noexcept { return {0UZ, 0UZ, gr::work::Status::OK}; }
-
-    gr::work::Status draw(const gr::property_map& config = {}) noexcept {
-        if (auto it = config.find("paneWidth"); it != config.end()) {
-            if (auto* val = it->second.get_if<float>()) {
-                _paneWidth = *val;
-            }
-        }
-        _legendSize = drawLegend(_paneWidth);
-        return gr::work::Status::OK;
+    /// Returns the unique name of a signal which was right-clicked, if any
+    std::string draw(UiGraphModel& graphModel, float paneWidth) noexcept {
+        std::string out;
+        std::tie(_legendSize, out) = drawLegend(graphModel, paneWidth);
+        return out;
     }
 
     [[nodiscard]] ImVec2 legendSize() const noexcept { return _legendSize; }
 
     static ClickResult drawLegendItem(std::uint32_t color, std::string_view text, bool enabled = true) {
-        using namespace opendigitizer::charts;
         ClickResult                result = ClickResult::None;
         constexpr ImGuiMouseButton kRMB   = ImGuiMouseButton_Right;
 
@@ -93,12 +79,23 @@ struct GlobalSignalLegend : gr::Block<GlobalSignalLegend, gr::Drawable<gr::UICat
         return result;
     }
 
-    void drawSink(opendigitizer::SignalSink& sink, float& accumulatedWidth, float paneWidth, int index) {
-        using namespace opendigitizer::charts;
+    /// Returns true if the block was right-clicked
+    bool drawSink(UiGraphBlock& sink, float& accumulatedWidth, float paneWidth, int index) {
         IMW::ChangeId itemId(index);
 
-        const auto        color = sink.color();
-        const std::string label = sink.signalName().empty() ? std::string(sink.name()) : std::string(sink.signalName());
+        auto getOrNull = [&](const gr::property_map& m, std::string_view key) -> gr::pmt::Value {
+            if (auto it = m.find(std::string(key)); it != m.end()) {
+                return it->second;
+            }
+            return {};
+        };
+
+        const auto        color       = getOrNull(sink.blockSettings, "color").value_or(std::uint32_t{0});
+        const auto        visible     = getOrNull(sink.blockSettings, "visible").value_or(true);
+        const auto        signal_name = getOrNull(sink.blockSettings, "signal_name").value_or(std::string{});
+        const auto        name        = getOrNull(sink.blockSettings, "name").value_or(std::string{});
+        const auto&       uniqueName  = sink.blockUniqueName;
+        const std::string label       = signal_name.empty() ? name : signal_name;
 
         // check if we need to wrap to next line
         const auto widthEstimate = ImGui::CalcTextSize(label.c_str()).x + 20.f;
@@ -109,22 +106,17 @@ struct GlobalSignalLegend : gr::Block<GlobalSignalLegend, gr::Drawable<gr::UICat
         }
 
         // draw the legend item
-        auto clickResult = drawLegendItem(color, label, sink.drawEnabled());
+        auto clickResult = drawLegendItem(color, label, visible);
         if (ImGui::IsItemHovered() && !ImGui::GetDragDropPayload()) {
             ImGui::SetTooltip(_dragDropEnabled ? "Drag/Toggle Signal" : "Toggle Signal");
         }
 
         if (clickResult == ClickResult::RightColor) {
-            _editingSinkUniqueName = std::string(sink.uniqueName());
+            _editingSinkUniqueName = std::string(uniqueName);
             _openColorPopup        = true;
         }
-        if (clickResult == ClickResult::RightName) {
-            if (_onRightClick) {
-                _onRightClick(sink.uniqueName());
-            }
-        }
         if (clickResult == ClickResult::Left) {
-            sink.setDrawEnabled(!sink.drawEnabled());
+            sink.setSetting("visible", !visible);
         }
 
         accumulatedWidth += ImGui::GetItemRectSize().x;
@@ -132,26 +124,34 @@ struct GlobalSignalLegend : gr::Block<GlobalSignalLegend, gr::Drawable<gr::UICat
         // drag source - from global legend (empty source_chart_id = no removal needed)
         if (_dragDropEnabled) {
             if (auto dndSource = IMW::DragDropSource(ImGuiDragDropFlags_None)) {
+                using namespace opendigitizer::charts;
                 dnd::Payload payload{};
-                opendigitizer::charts::dnd::copyToBuffer(payload.sink_name, label);
+                dnd::copyToBuffer(payload.sink_name, label);
                 ImGui::SetDragDropPayload(dnd::kPayloadType, &payload, sizeof(payload));
-                drawLegendItem(color, label, sink.drawEnabled());
+                drawLegendItem(color, label, visible);
             }
         }
+        return clickResult == ClickResult::RightName;
     }
 
-    ImVec2 drawLegend(float paneWidth) {
+    std::pair<ImVec2, std::string> drawLegend(UiGraphModel& graphModel, float paneWidth) {
         using namespace opendigitizer::charts;
         ImVec2 legendSize{0.f, 0.f};
         float  accumulatedWidth = paneWidth; // start at full width to force new line
 
         _openColorPopup = false;
 
+        std::string rightClickedBlockName;
         {
             IMW::Group group;
 
             int index = 0;
-            SinkRegistry::instance().forEach([&](opendigitizer::SignalSink& sink) { drawSink(sink, accumulatedWidth, paneWidth, index++); });
+            for (UiGraphBlock* sink : graphModel.recursiveGatherPlotSinks()) {
+                if (drawSink(*sink, accumulatedWidth, paneWidth, index)) {
+                    rightClickedBlockName = sink->blockUniqueName;
+                }
+                ++index;
+            }
         }
 
         legendSize.x = ImGui::GetItemRectSize().x;
@@ -162,14 +162,15 @@ struct GlobalSignalLegend : gr::Block<GlobalSignalLegend, gr::Drawable<gr::UICat
             ImGui::OpenPopup("SinkColorPopup");
         }
         if (ImGui::BeginPopup("SinkColorPopup")) {
-            auto editingSink = SinkRegistry::instance().findSink([this](const auto& s) { return s.uniqueName() == _editingSinkUniqueName; });
+            UiGraphBlock* editingSink = graphModel.recursiveFindBlockByUniqueName(_editingSinkUniqueName).block;
             if (editingSink) {
-                std::uint32_t c   = editingSink->color();
-                ImVec4        col = ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(c));
+                auto          colorIter = editingSink->blockSettings.find("color");
+                std::uint32_t c         = colorIter != std::end(editingSink->blockSettings) ? colorIter->second.value_or(std::uint32_t{}) : std::uint32_t{};
+                ImVec4        col       = ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(c));
                 float         rgb[3]{col.x, col.y, col.z};
                 if (ImGui::ColorPicker3("##color", rgb, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoSidePreview | ImGuiColorEditFlags_PickerHueBar)) {
                     auto newColor = (static_cast<std::uint32_t>(rgb[0] * 255.0f) << 16) | (static_cast<std::uint32_t>(rgb[1] * 255.0f) << 8) | static_cast<std::uint32_t>(rgb[2] * 255.0f);
-                    editingSink->setColor(newColor);
+                    editingSink->setSetting("color", newColor);
                 }
             }
             ImGui::EndPopup();
@@ -178,14 +179,10 @@ struct GlobalSignalLegend : gr::Block<GlobalSignalLegend, gr::Drawable<gr::UICat
         // drop target - accept drops from charts, signal removal via dnd::g_state
         dnd::handleLegendDropTarget();
 
-        return legendSize;
+        return {legendSize, rightClickedBlockName};
     }
 };
 
 } // namespace DigitizerUi
-
-// register GlobalSignalLegend with the GR4 block registry
-GR_REGISTER_BLOCK("DigitizerUi::GlobalSignalLegend", DigitizerUi::GlobalSignalLegend)
-inline auto registerGlobalSignalLegend = gr::registerBlock<DigitizerUi::GlobalSignalLegend>(gr::globalBlockRegistry());
 
 #endif // OPENDIGITIZER_GLOBAL_SIGNAL_LEGEND_HPP

--- a/src/ui/components/Keypad.hpp
+++ b/src/ui/components/Keypad.hpp
@@ -304,7 +304,7 @@ class InputKeypad {
     std::unordered_map<std::string, int>    _manualyEditedPrecisions;
 
     //
-    bool        _visible     = true;
+    bool        _visible     = false;
     bool        _altMode     = false;
     bool        _invMode     = false;
     bool        _firstUpdate = true;
@@ -481,6 +481,76 @@ class InputKeypad {
         return instance;
     }
 
+    static constexpr const char* decrementButtonIcon = "\u{f146}";
+    static constexpr const char* incrementButtonIcon = "\u{f0fe}";
+
+    template<typename EdTy>
+    [[nodiscard]] static bool drawChangeButtons(const std::string& key, const char* label, EdTy* value) {
+        assert(label);
+        auto& keyPad = getInstance();
+
+        bool result = keyPad.editImpl(label, value);
+        if (result) {
+            const int precision = InputKeypad::getDecimalPrecision(keyPad._editBuffer);
+            keyPad._manualyEditedPrecisions.insert_or_assign(key, precision);
+
+            const double increment = InputKeypad::computeIncrement(keyPad._editBuffer);
+            keyPad._manualyEditedIncrements.insert_or_assign(key, increment);
+        }
+
+        {
+            ImGui::SameLine();
+            IMW::Font _(LookAndFeel::instance().fontIconsSolid);
+            if (ImGui::Button(decrementButtonIcon)) {
+                auto it = keyPad._manualyEditedIncrements.find(key);
+                if (it == keyPad._manualyEditedIncrements.end()) {
+                    const double increment = InputKeypad::computeIncrementNonZero(std::format("{:.4f}", static_cast<double>(*value)));
+                    auto         op        = keyPad._manualyEditedIncrements.insert_or_assign(key, increment);
+                    it                     = op.first;
+                }
+                *value -= static_cast<EdTy>(it->second);
+
+                result = true;
+            }
+        }
+        IMW::detail::setItemTooltip("Decrement");
+
+        {
+            ImGui::SameLine();
+            IMW::Font _(LookAndFeel::instance().fontIconsSolid);
+            if (ImGui::Button(incrementButtonIcon)) {
+                auto it = keyPad._manualyEditedIncrements.find(key);
+                if (it == keyPad._manualyEditedIncrements.end()) {
+                    const double increment = InputKeypad::computeIncrementNonZero(std::format("{:.4f}", static_cast<double>(*value)));
+                    auto         op        = keyPad._manualyEditedIncrements.insert_or_assign(key, increment);
+                    it                     = op.first;
+                }
+                *value += static_cast<EdTy>(it->second);
+
+                result = true;
+            }
+        }
+        IMW::detail::setItemTooltip("Increment");
+
+        return result;
+    }
+
+    template<std::floating_point EdTy>
+    [[nodiscard]] static std::string floatingPointDragFormat(const std::string& key, EdTy* value, std::string_view suffix) {
+        auto&     keyPad    = getInstance();
+        const int precision = [&keyPad, &key, value]() -> int {
+            if (auto it = keyPad._manualyEditedPrecisions.find(key); it != keyPad._manualyEditedPrecisions.end()) {
+                return it->second;
+            } else {
+                return InputKeypad::getDecimalPrecisionNonZero(std::format("{:.4f}", *value));
+            }
+        }();
+
+        return suffix.empty() ? std::format("%.{}f", precision) : std::format("%.{}f {}", precision, suffix);
+    }
+
+    static std::string intDragFormat(std::string_view suffix) { return suffix.empty() ? "%d" : std::format("%d {}", suffix); }
+
 public:
     static void clearIfNewBlock(std::string_view block) {
         auto& keyPad = getInstance();
@@ -493,83 +563,85 @@ public:
 
     template<typename EdTy>
     requires std::integral<EdTy> || std::floating_point<EdTy> || std::same_as<std::string, EdTy>
+    [[nodiscard]] static IMW::WidgetSize calcSize(const char* label, std::string_view suffix = {}) {
+        constexpr bool hasChangeButtons = !std::same_as<std::string, EdTy>;
+        // hardcode no. of digits in a drag/slider as being 5, it is okay to clip off big/long numbers
+        const auto      dragSize = IMW::CalcDragSize(label, 5 + suffix.size());
+        IMW::Font       iconFont(LookAndFeel::instance().fontIconsSolid);
+        const ImVec2    decBtn  = hasChangeButtons ? IMW::CalcButtonSize(decrementButtonIcon) : ImVec2{};
+        const ImVec2    incBtn  = hasChangeButtons ? IMW::CalcButtonSize(incrementButtonIcon) : ImVec2{};
+        const float     spacing = ImGui::GetStyle().ItemSpacing.x;
+        IMW::WidgetSize size{
+            .min                 = {dragSize.min.x, dragSize.min.y},
+            .preferred           = {dragSize.preferred.x, dragSize.preferred.y},
+            .labelPreferredWidth = dragSize.labelPreferredWidth,
+        };
+        if (hasChangeButtons) {
+            size.min.x += spacing + decBtn.x + spacing + incBtn.x;
+            size.min.y = std::max({size.min.y, decBtn.y, incBtn.y});
+            size.preferred.x += spacing + decBtn.x + spacing + incBtn.x;
+            size.preferred.y = std::max({size.preferred.y, decBtn.y, incBtn.y});
+        }
+        return size;
+    }
+
+    template<typename EdTy>
+    requires std::integral<EdTy> || std::floating_point<EdTy> || std::same_as<std::string, EdTy>
     [[nodiscard]] static bool edit(const std::string& key, const char* label, EdTy* value, std::string_view suffix = {}) {
         if (!label || !value) {
             return false;
         }
 
-        const auto drawChangeButtons = [&]() -> bool {
-            auto& keyPad = getInstance();
+        constexpr bool hasChangeButtons = !std::same_as<std::string, EdTy>;
 
-            bool result = keyPad.editImpl(label, value);
-            if (result) {
-                const int precision = InputKeypad::getDecimalPrecision(keyPad._editBuffer);
-                keyPad._manualyEditedPrecisions.insert_or_assign(key, precision);
+        const float totalWidth  = ImGui::CalcItemWidth();
+        float       buttonWidth = 0.f;
+        if constexpr (hasChangeButtons) {
+            IMW::Font iconFont(LookAndFeel::instance().fontIconsSolid);
+            buttonWidth = IMW::CalcButtonSize(decrementButtonIcon).x;
+        }
+        const float spacing                     = ImGui::GetStyle().ItemSpacing.x;
+        const float spaceAvailableBeforeButtons = std::max(1.f, totalWidth - (hasChangeButtons ? 2.f * (buttonWidth + spacing) : 0.f));
 
-                const double increment = InputKeypad::computeIncrement(keyPad._editBuffer);
-                keyPad._manualyEditedIncrements.insert_or_assign(key, increment);
-            }
-
-            {
-                ImGui::SameLine();
-                IMW::Font _(LookAndFeel::instance().fontIconsSolid);
-                if (ImGui::Button("\uf146")) {
-                    auto it = keyPad._manualyEditedIncrements.find(key);
-                    if (it == keyPad._manualyEditedIncrements.end()) {
-                        const double increment = InputKeypad::computeIncrementNonZero(std::format("{:.4f}", static_cast<double>(*value)));
-                        auto         op        = keyPad._manualyEditedIncrements.insert_or_assign(key, increment);
-                        it                     = op.first;
-                    }
-                    *value -= static_cast<EdTy>(it->second);
-
-                    result = true;
-                }
-            }
-            IMW::detail::setItemTooltip("Decrement");
-
-            {
-                ImGui::SameLine();
-                IMW::Font _(LookAndFeel::instance().fontIconsSolid);
-                if (ImGui::Button("\uf0fe")) {
-                    auto it = keyPad._manualyEditedIncrements.find(key);
-                    if (it == keyPad._manualyEditedIncrements.end()) {
-                        const double increment = InputKeypad::computeIncrementNonZero(std::format("{:.4f}", static_cast<double>(*value)));
-                        auto         op        = keyPad._manualyEditedIncrements.insert_or_assign(key, increment);
-                        it                     = op.first;
-                    }
-                    *value += static_cast<EdTy>(it->second);
-
-                    result = true;
-                }
-            }
-            IMW::detail::setItemTooltip("Increment");
-
-            return result;
-        };
-
-        auto& keyPad = getInstance();
+        auto&      keyPad = getInstance();
+        IMW::Group group;
 
         if constexpr (std::floating_point<EdTy>) {
-            const int precision = [&]() -> int {
-                if (auto it = keyPad._manualyEditedPrecisions.find(key); it != keyPad._manualyEditedPrecisions.end()) {
-                    return it->second;
-                } else {
-                    return InputKeypad::getDecimalPrecisionNonZero(std::format("{:.4f}", *value));
-                }
-            }();
+            ImGuiDataType type = ImGuiDataType_Float;
+            if constexpr (std::is_same_v<EdTy, double>) {
+                type = ImGuiDataType_Double;
+            } else {
+                static_assert(std::is_same_v<EdTy, float>, "unsupported type");
+            }
 
-            const std::string format = suffix.empty() ? std::format("%.{}f", precision) : std::format("%.{}f {}", precision, suffix);
-            ImGui::DragFloat(label, static_cast<float*>(value), 0.1f, 0.0f, 0.0f, format.c_str());
+            EdTy min = 0;
+            EdTy max = 0;
+            ImGui::SetNextItemWidth(spaceAvailableBeforeButtons);
+            ImGui::DragScalar(label, type, value, 1.f, &min, &max, floatingPointDragFormat(key, value, suffix).c_str());
             IMW::detail::setItemTooltip(key.c_str());
 
-            return drawChangeButtons();
+            return drawChangeButtons(key, label, value);
         } else if constexpr (std::integral<EdTy>) {
-            const std::string format = suffix.empty() ? "%d" : std::format("%d {}", suffix);
-            ImGui::DragInt(label, static_cast<int*>(value), 1.0f, 0, 0, format.c_str());
+            ImGuiDataType type = ImGuiDataType_S32;
+            if constexpr (std::is_same_v<EdTy, std::int64_t>) {
+                type = ImGuiDataType_S64;
+            } else if constexpr (std::is_same_v<EdTy, std::uint64_t>) {
+                type = ImGuiDataType_U64;
+            } else if constexpr (std::is_same_v<EdTy, std::uint32_t>) {
+                type = ImGuiDataType_U32;
+            } else {
+                static_assert(std::is_same_v<EdTy, std::int32_t>, "unsupported type");
+            }
+
+            EdTy min = 0;
+            EdTy max = 0;
+            ImGui::SetNextItemWidth(spaceAvailableBeforeButtons);
+            ImGui::DragScalar(label, type, value, 1.f, &min, &max, intDragFormat(suffix).c_str());
             IMW::detail::setItemTooltip(key.c_str());
 
-            return drawChangeButtons();
+            return drawChangeButtons(key, label, value);
         } else {
+            ImGui::SetNextItemWidth(spaceAvailableBeforeButtons);
             ImGui::InputText(label, value);
             IMW::detail::setItemTooltip(key.c_str());
 

--- a/src/ui/test/qa_flowgraph.cpp
+++ b/src/ui/test/qa_flowgraph.cpp
@@ -17,7 +17,6 @@
 
 // TODO: blocks are locally included/registered for this test -> should become a global feature
 #include "blocks/Arithmetic.hpp"
-#include "blocks/GlobalSignalLegend.hpp"
 #include "blocks/ImPlotSink.hpp"
 #include "blocks/SineSource.hpp"
 #include "blocks/TestSpectrumGenerator.hpp"


### PR DESCRIPTION
Adds a new `map<string, optional<size_t>>` to UiGraphBlocks called `exportedProperties`. This also adds corresponding UI: a new tab in the signal edit pane called "All exported properties", and an "Export" button next to every block property to add it to the aforementioned tab.
    
With the charts view selected, the user can click on the "..." button to the right of exported properties and select to add a new property control window. This window will contain a widget for controlling that one property. Additional properties may be controlled by it simultaneously by clicking and dragging exported properties from the pane onto the window (if the property type is compatible). Right clicking on a property control window will show a context menu with an option to remove the window or un-assign induvidual properties from it.

The syncing of properties is implemented from the UI side. `UiGraphBlock`s have a function `setSetting()` which properly traverses the graph and finds other blocks with matching export IDs and sets them as well. So block properties will come out of sync if the `gr::Graph` is modified directly. GlobalSignalLegend does modify the graph directly, so I changed it to go through the UI model.

I went back and forth and considered implementing something generic where the UI graph model could observe changes and send updates to matching exported blocks... but that invites more issues that have to be resolved, such as property update loops and a frame of lag before the update.


https://github.com/user-attachments/assets/b62fb0bb-fc28-43a5-8d5e-56863a95f4a0

