### PR TITLE
Check chart + signal type compatibility in UI

### DIFF
--- a/src/ui/GraphModel.hpp
+++ b/src/ui/GraphModel.hpp
@@ -22,7 +22,6 @@ struct UiGraphPort {
 
     std::string       portName;
     std::string       portType;
-    bool              portTypeIsDataset = false;
     gr::PortDirection portDirection;
 
     UiGraphPort(UiGraphBlock* owner) : ownerBlock(owner) {}

--- a/src/ui/blocks/ImPlotSink.hpp
+++ b/src/ui/blocks/ImPlotSink.hpp
@@ -74,6 +74,8 @@ struct ImPlotSink : gr::Block<ImPlotSink<T>, gr::Drawable<gr::UICategory::Conten
     static constexpr bool IsStreaming = std::is_arithmetic_v<T>;
     static constexpr bool IsDataSet   = gr::DataSetLike<T>;
 
+    static constexpr SignalKind kSignalKind = IsDataSet ? SignalKind::Dataset1D : SignalKind::Streaming;
+
     template<typename U, gr::meta::fixed_string description = "", typename... Arguments>
     using A = gr::Annotated<U, description, Arguments...>;
 
@@ -280,6 +282,7 @@ struct ImPlotSink : gr::Block<ImPlotSink<T>, gr::Drawable<gr::UICategory::Conten
 
     [[nodiscard]] bool        hasDataSets() const noexcept { return IsDataSet && _yValues.size() > 0; }
     [[nodiscard]] std::size_t dataSetCount() const noexcept { return IsDataSet ? _yValues.size() : 0; }
+    [[nodiscard]] SignalKind  signalKind() const noexcept { return kSignalKind; }
 
     [[nodiscard]] std::span<const gr::DataSet<float>> dataSets() const {
         if constexpr (IsDataSet) {

--- a/src/ui/charts/Chart.hpp
+++ b/src/ui/charts/Chart.hpp
@@ -423,6 +423,10 @@ inline std::size_t activeAxisCount(const std::array<std::optional<AxisCategory>,
 
 } // namespace axis
 
+namespace detail {
+constexpr bool isCompatible(SignalKind signal, SignalKind chartSupport) { return (std::to_underlying(signal) & std::to_underlying(chartSupport)) != 0; }
+} // namespace detail
+
 namespace tags {
 
 /// Marker key for tags that appear out-of-order or have suspicious timestamps.
@@ -700,8 +704,9 @@ constexpr void copyToBuffer(char (&dest)[N], std::string_view src) noexcept {
 }
 
 struct Payload {
-    char sink_name[256]      = {};
-    char source_chart_id[64] = {};
+    char       sink_name[256]      = {};
+    char       source_chart_id[64] = {};
+    SignalKind sink_type           = SignalKind::None;
 
     [[nodiscard]] bool hasSource() const noexcept { return source_chart_id[0] != '\0'; }
     [[nodiscard]] bool isValid() const noexcept { return sink_name[0] != '\0'; }
@@ -722,32 +727,46 @@ struct State {
 };
 inline State g_state;
 
+struct PayloadStatus {
+    const Payload* payload{};
+    bool           isCompatible{};
+};
+
+[[nodiscard]] inline PayloadStatus getPayloadStatus(const char* payloadType, SignalKind supportedKinds) {
+    if (const ImGuiPayload* payload = ImGui::GetDragDropPayload(); payload && payload->Data && payload->IsDataType(payloadType)) {
+        const auto* dnd = static_cast<const Payload*>(payload->Data);
+        return {.payload = dnd, .isCompatible = detail::isCompatible(dnd->sink_type, supportedKinds)};
+    }
+    return {};
+}
+
 template<typename Callable>
 requires std::is_invocable_r_v<bool, Callable, const Payload&>
 inline bool handleDropTarget(Callable&& handler, const char* payloadType) {
-    bool dropped = false;
-    if (ImGui::BeginDragDropTarget()) {
-        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(payloadType)) {
-            const auto* dnd = static_cast<const Payload*>(payload->Data);
-            if (dnd && dnd->isValid()) {
-                g_state.accepted = std::invoke(handler, *dnd);
-                dropped          = g_state.accepted;
-            }
-        }
-        ImGui::EndDragDropTarget();
+    const auto payloadResult = getPayloadStatus(payloadType, SignalKind::All);
+    if (payloadResult.payload && !payloadResult.isCompatible) {
+        return false;
     }
-    return dropped;
+
+    if (ImGui::BeginDragDropTarget()) {
+        Digitizer::utils::scope_exit _([] { ImGui::EndDragDropTarget(); });
+        if (ImGui::AcceptDragDropPayload(payloadType) && payloadResult.payload && payloadResult.payload->isValid()) {
+            g_state.accepted = std::invoke(handler, *payloadResult.payload);
+            return g_state.accepted;
+        }
+    }
+    return false;
 }
 
 inline bool handleLegendDropTarget(const char* payloadType = kPayloadType) {
     return handleDropTarget([](const Payload& payload) { return payload.hasSource(); }, payloadType);
 }
 
-inline void setupPayload(const std::shared_ptr<SignalSink>& sink, std::string_view sourceChartId, const char* payloadType = kPayloadType) {
+inline void setupPayload(const std::shared_ptr<SignalSink>& sink, std::string_view sourceChartId, const char* payloadType = kPayloadType, SignalKind signalKind = SignalKind::All) {
     if (!sink) {
         return;
     }
-    Payload           dnd{};
+    Payload           dnd{.sink_type = signalKind};
     const std::string sinkIdentifier = sink->signalName().empty() ? std::string(sink->name()) : std::string(sink->signalName());
     dnd::copyToBuffer(dnd.sink_name, sinkIdentifier);
     if (!sourceChartId.empty()) {
@@ -925,7 +944,20 @@ inline void onScrollWheel(auto&& apply) {
     }
 }
 
+/// We need to know the signal compatibilities for every chart type in order to
+/// enumerate the available types to switch to in the "Change Type" chart dropdown.
+/// This is a map of Chart typenames to the signals they can display
+inline std::unordered_map<std::string, SignalKind>& chartSignalCompatibilityRegistry() {
+    static std::unordered_map<std::string, SignalKind> s_instance;
+    return s_instance;
+}
 } // namespace detail
+
+template<typename T>
+int registerChartSignalCompatibility() {
+    detail::chartSignalCompatibilityRegistry().emplace(gr::refl::type_name<T>, T::supportedSignals);
+    return 0;
+}
 
 /// Non-polymorphic CRTP mixin for chart signal sink storage and D&D using C++23 deducing this.
 /// Derived classes must: inherit gr::Block<Derived>, define kChartTypeName, data_sinks.
@@ -985,6 +1017,17 @@ struct Chart {
     std::array<double, 3UZ> _prevYMax            = {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
     std::array<bool, 3UZ>   _limitsForceAppliedX = {}; // true on frame where limits were force-applied
     std::array<bool, 3UZ>   _limitsForceAppliedY = {};
+
+    template<typename Self>
+    [[nodiscard]] inline SignalKind minimumSinkCompatibility(this const Self& self) noexcept {
+        auto result = SignalKind::None;
+        for (const auto& signalSinkPtr : self._signalSinks) {
+            if (signalSinkPtr) {
+                result = result | signalSinkPtr->signalKind();
+            }
+        }
+        return result;
+    }
 
     template<typename Self>
     void setupSingleAxis(this Self& self, bool isX, ImAxis axisId, bool showGrid, LabelFormat defaultFormat = LabelFormat::Auto, bool foreground = false, std::optional<ImPlotCond> condOverride = std::nullopt, std::optional<AxisScale> scaleOverride = std::nullopt) {
@@ -1173,7 +1216,7 @@ struct Chart {
                 signalNameStr = std::string(sink->name());
             }
             if (ImPlot::BeginDragDropSourceItem(signalNameStr.c_str())) {
-                dnd::setupPayload(sink, self.unique_name);
+                dnd::setupPayload(sink, self.unique_name, dnd::kPayloadType, sink->signalKind());
                 dnd::renderDragTooltip(sink);
                 ImPlot::EndDragDropSource();
             }
@@ -1182,32 +1225,50 @@ struct Chart {
 
     template<typename Self>
     bool handlePlotDropTarget(this Self& self, const char* payloadType = dnd::kPayloadType) {
-        bool dropped = false;
-        if (ImPlot::BeginDragDropTargetPlot()) {
-            if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(payloadType)) {
-                const auto* dndPayload = static_cast<const dnd::Payload*>(payload->Data);
-                if (dndPayload && dndPayload->isValid()) {
-                    std::string sinkName(dndPayload->sink_name);
-                    auto        sinkSharedPtr = SinkRegistry::instance().findSink([&sinkName](const auto& s) { return s.signalName() == sinkName || s.name() == sinkName; });
-                    if (sinkSharedPtr) {
-                        self.onSinkAddedFromDnd(sinkName, sinkSharedPtr);
-                        if (dndPayload->hasSource()) {
-                            dnd::g_state.accepted = true;
-                        }
-                        dropped = true;
-                    }
-                }
-            }
-            ImPlot::EndDragDropTarget();
+        static constexpr bool hasSupportedSignals = requires {
+            { Self::supportedSignals };
+        };
+        static_assert(hasSupportedSignals, "Every chart type must define `static constexpr SignalKind supportedSignals = ...`");
+        const auto payloadResult = dnd::getPayloadStatus(payloadType, Self::supportedSignals);
+        if (payloadResult.payload && !payloadResult.isCompatible) {
+            return false;
         }
-        return dropped;
+
+        if (ImPlot::BeginDragDropTargetPlot()) {
+            Digitizer::utils::scope_exit _([] { ImPlot::EndDragDropTarget(); });
+
+            if (!ImGui::AcceptDragDropPayload(payloadType) || !payloadResult.payload || !payloadResult.payload->isValid()) {
+                return false;
+            }
+
+            std::string sinkName(payloadResult.payload->sink_name);
+            auto        sinkSharedPtr = SinkRegistry::instance().findSink([&sinkName](const auto& s) { return s.signalName() == sinkName || s.name() == sinkName; });
+            if (!sinkSharedPtr) {
+                return false;
+            }
+
+            self.onSinkAddedFromDnd(sinkName, sinkSharedPtr);
+            if (payloadResult.payload->hasSource()) {
+                dnd::g_state.accepted = true;
+            }
+            return true;
+        }
+        return false;
     }
 
     template<typename Self>
     void drawChartTypeSubmenu(this Self& self) {
         if (menu_icons::beginMenuWithIcon(menu_icons::kChangeType, "Change Type")) {
+            const auto minimumCompatibility = self.minimumSinkCompatibility();
             for (const auto& type : registeredChartTypes()) {
-                bool isCurrent = type.ends_with(std::remove_cvref_t<Self>::kChartTypeName);
+                bool disabled                     = false;
+                auto otherSignalCompatibilityIter = detail::chartSignalCompatibilityRegistry().find(type);
+                if (otherSignalCompatibilityIter != std::end(detail::chartSignalCompatibilityRegistry()) && (otherSignalCompatibilityIter->second & minimumCompatibility) != minimumCompatibility) {
+                    disabled = true; // this chart type does not support all the signal types we are displaying
+                }
+
+                DigitizerUi::IMW::Disabled _(disabled);
+                bool                       isCurrent = type.ends_with(std::remove_cvref_t<Self>::kChartTypeName);
                 if (ImGui::MenuItem(type.c_str(), nullptr, isCurrent)) {
                     if (!isCurrent && g_requestChartTransmutation) {
                         g_requestChartTransmutation(self.unique_name, type);

--- a/src/ui/charts/SignalSink.hpp
+++ b/src/ui/charts/SignalSink.hpp
@@ -50,6 +50,19 @@ enum class LineStyle : std::uint8_t {
     None     ///< No line drawn (markers only)
 };
 
+enum class SignalKind : std::uint8_t {
+    None      = 0,
+    Streaming = 1 << 0U,
+    Dataset1D = 1 << 1U,
+    All       = Streaming | Dataset1D,
+};
+constexpr SignalKind operator|(SignalKind a, SignalKind b) noexcept { //
+    return static_cast<SignalKind>(std::to_underlying(a) | std::to_underlying(b));
+}
+constexpr SignalKind operator&(SignalKind a, SignalKind b) noexcept { //
+    return static_cast<SignalKind>(std::to_underlying(a) & std::to_underlying(b));
+}
+
 /**
  * @brief RAII guard for thread-safe data access to signal sink buffers.
  *
@@ -123,6 +136,7 @@ struct SignalSink {
     [[nodiscard]] virtual bool                                hasDataSets() const noexcept  = 0;
     [[nodiscard]] virtual std::size_t                         dataSetCount() const noexcept = 0;
     [[nodiscard]] virtual std::span<const gr::DataSet<float>> dataSets() const              = 0;
+    [[nodiscard]] virtual SignalKind                          signalKind() const noexcept   = 0;
 
     [[nodiscard]] virtual bool                      hasStreamingTags() const noexcept                                                                    = 0;
     [[nodiscard]] virtual std::pair<double, double> tagTimeRange() const noexcept                                                                        = 0;
@@ -564,6 +578,17 @@ struct SinkAdapter : public SignalSink {
             return b->dataSets();
         }
         return {};
+    }
+
+    [[nodiscard]] SignalKind signalKind() const noexcept override {
+        auto* b = blockPtr();
+        if (!b) {
+            return {};
+        }
+        if constexpr (requires { b->signalKind(); }) {
+            return b->signalKind();
+        }
+        return SignalKind::None;
     }
 
     [[nodiscard]] bool hasStreamingTags() const noexcept override {

--- a/src/ui/charts/SpectrumDensity.hpp
+++ b/src/ui/charts/SpectrumDensity.hpp
@@ -56,6 +56,8 @@ struct SpectrumDensity : gr::Block<SpectrumDensity, gr::Drawable<gr::UICategory:
     A<double, "Y-axis min"> y_min        = -120.0;
     A<double, "Y-axis max"> y_max        = 0.0;
 
+    static constexpr SignalKind supportedSignals = SignalKind::Dataset1D;
+
     GR_MAKE_REFLECTABLE(SpectrumDensity, chart_name, chart_title, data_sinks, show_legend, show_grid, amplitude_bins, colormap, histogram_decay_tau_frames, gpu_acceleration, adaptive_y_range, show_current_overlay, show_max_hold, show_min_hold, show_average, trace_color, trace_decay_tau_frames, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max);
 
     DensityHistogram             _density;
@@ -220,6 +222,7 @@ struct SpectrumDensity : gr::Block<SpectrumDensity, gr::Drawable<gr::UICategory:
 } // namespace opendigitizer::charts
 
 GR_REGISTER_BLOCK("opendigitizer::charts::SpectrumDensity", opendigitizer::charts::SpectrumDensity)
-inline auto registerSpectrumDensity = gr::registerBlock<opendigitizer::charts::SpectrumDensity>(gr::globalBlockRegistry());
+inline auto registerSpectrumDensity                = gr::registerBlock<opendigitizer::charts::SpectrumDensity>(gr::globalBlockRegistry());
+inline auto registerSpectrumDensityCompatibilities = opendigitizer::charts::registerChartSignalCompatibility<opendigitizer::charts::SpectrumDensity>();
 
 #endif // OPENDIGITIZER_CHARTS_SPECTRUMDENSITY_HPP

--- a/src/ui/charts/SpectrumPlot.hpp
+++ b/src/ui/charts/SpectrumPlot.hpp
@@ -49,6 +49,8 @@ struct SpectrumPlot : gr::Block<SpectrumPlot, gr::Drawable<gr::UICategory::Conte
     A<double, "Y-axis min"> y_min        = -120.0;
     A<double, "Y-axis max"> y_max        = 0.0;
 
+    static constexpr SignalKind supportedSignals = SignalKind::Dataset1D;
+
     GR_MAKE_REFLECTABLE(SpectrumPlot, chart_name, chart_title, data_sinks, show_legend, show_grid, show_max_hold, show_min_hold, show_average, trace_color, decay_tau_frames, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max);
 
     std::unordered_map<std::string, TraceAccumulator> _tracesPerSink;
@@ -110,6 +112,7 @@ struct SpectrumPlot : gr::Block<SpectrumPlot, gr::Drawable<gr::UICategory::Conte
 } // namespace opendigitizer::charts
 
 GR_REGISTER_BLOCK("opendigitizer::charts::SpectrumPlot", opendigitizer::charts::SpectrumPlot)
-inline auto registerSpectrumPlot = gr::registerBlock<opendigitizer::charts::SpectrumPlot>(gr::globalBlockRegistry());
+inline auto registerSpectrumPlot                = gr::registerBlock<opendigitizer::charts::SpectrumPlot>(gr::globalBlockRegistry());
+inline auto registerSpectrumPlotCompatibilities = opendigitizer::charts::registerChartSignalCompatibility<opendigitizer::charts::SpectrumPlot>();
 
 #endif // OPENDIGITIZER_CHARTS_SPECTRUMPLOT_HPP

--- a/src/ui/charts/SpectrumView.hpp
+++ b/src/ui/charts/SpectrumView.hpp
@@ -68,6 +68,8 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
     A<double, "Y-axis min"> y_min        = -120.0;
     A<double, "Y-axis max"> y_max        = 0.0;
 
+    static constexpr SignalKind supportedSignals = SignalKind::Dataset1D;
+
     GR_MAKE_REFLECTABLE(SpectrumView, chart_name, data_sinks, show_legend, show_grid, top_pane_mode, show_max_hold, show_min_hold, show_average, trace_color, decay_tau_frames, amplitude_bins, histogram_decay_tau_frames, show_current_overlay, n_history, colormap, gpu_acceleration, top_pane_ratio, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max);
 
     std::unordered_map<std::string, TraceAccumulator> _tracesPerSink;
@@ -300,6 +302,7 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
 } // namespace opendigitizer::charts
 
 GR_REGISTER_BLOCK("opendigitizer::charts::SpectrumView", opendigitizer::charts::SpectrumView)
-inline auto registerSpectrumView = gr::registerBlock<opendigitizer::charts::SpectrumView>(gr::globalBlockRegistry());
+inline auto registerSpectrumView                = gr::registerBlock<opendigitizer::charts::SpectrumView>(gr::globalBlockRegistry());
+inline auto registerSpectrumViewCompatibilities = opendigitizer::charts::registerChartSignalCompatibility<opendigitizer::charts::SpectrumView>();
 
 #endif // OPENDIGITIZER_CHARTS_SPECTRUMVIEW_HPP

--- a/src/ui/charts/SurfacePlot.hpp
+++ b/src/ui/charts/SurfacePlot.hpp
@@ -716,6 +716,8 @@ struct SurfacePlot : gr::Block<SurfacePlot, gr::Drawable<gr::UICategory::Content
     A<double, "Z-axis min"> z_min        = std::numeric_limits<double>::lowest();
     A<double, "Z-axis max"> z_max        = std::numeric_limits<double>::max();
 
+    static constexpr SignalKind supportedSignals = SignalKind::Dataset1D;
+
     GR_MAKE_REFLECTABLE(SurfacePlot, chart_name, chart_title, data_sinks, show_legend, show_grid, show_minor_grid, grid_color, grid_opacity, n_history, colormap, gpu_acceleration, x_auto_scale, y_auto_scale, z_auto_scale, x_min, x_max, y_min, y_max, z_min, z_max);
 
     SurfaceBuffer              _surface;
@@ -1213,6 +1215,7 @@ struct SurfacePlot : gr::Block<SurfacePlot, gr::Drawable<gr::UICategory::Content
 } // namespace opendigitizer::charts
 
 GR_REGISTER_BLOCK("opendigitizer::charts::SurfacePlot", opendigitizer::charts::SurfacePlot)
-inline auto registerSurfacePlot = gr::registerBlock<opendigitizer::charts::SurfacePlot>(gr::globalBlockRegistry());
+inline auto registerSurfacePlot                = gr::registerBlock<opendigitizer::charts::SurfacePlot>(gr::globalBlockRegistry());
+inline auto registerSurfacePlotCompatibilities = opendigitizer::charts::registerChartSignalCompatibility<opendigitizer::charts::SurfacePlot>();
 
 #endif // OPENDIGITIZER_CHARTS_SURFACEPLOT_HPP

--- a/src/ui/charts/WaterfallPlot.hpp
+++ b/src/ui/charts/WaterfallPlot.hpp
@@ -46,6 +46,8 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
     A<double, "Y-axis min"> y_min        = std::numeric_limits<double>::lowest();
     A<double, "Y-axis max"> y_max        = std::numeric_limits<double>::max();
 
+    static constexpr SignalKind supportedSignals = SignalKind::Dataset1D;
+
     GR_MAKE_REFLECTABLE(WaterfallPlot, chart_name, chart_title, data_sinks, show_legend, show_grid, n_history, colormap, gpu_acceleration, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max);
 
     struct RenderInfo {
@@ -234,6 +236,7 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
 } // namespace opendigitizer::charts
 
 GR_REGISTER_BLOCK("opendigitizer::charts::WaterfallPlot", opendigitizer::charts::WaterfallPlot)
-inline auto registerWaterfallPlot = gr::registerBlock<opendigitizer::charts::WaterfallPlot>(gr::globalBlockRegistry());
+inline auto registerWaterfallPlot                = gr::registerBlock<opendigitizer::charts::WaterfallPlot>(gr::globalBlockRegistry());
+inline auto registerWaterfallPlotCompatibilities = opendigitizer::charts::registerChartSignalCompatibility<opendigitizer::charts::WaterfallPlot>();
 
 #endif // OPENDIGITIZER_CHARTS_WATERFALLPLOT_HPP

--- a/src/ui/charts/XYChart.hpp
+++ b/src/ui/charts/XYChart.hpp
@@ -63,6 +63,8 @@ struct XYChart : gr::Block<XYChart, gr::Drawable<gr::UICategory::Content, "ImGui
     A<std::array<double, 3UZ>, "Y-axis max">                                        y_max                   = std::array{std::numeric_limits<double>::max(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
     A<gr::Size_t, "history depth", gr::Unit<"samples">, gr::Limits<4U, 2'000'000U>> n_history               = kDefaultHistorySize;
 
+    static constexpr SignalKind supportedSignals = SignalKind::Streaming | SignalKind::Dataset1D;
+
     GR_MAKE_REFLECTABLE(XYChart, chart_name, chart_title, data_sinks, x_axis_mode, show_legend, show_tags, show_grid, anti_aliasing, max_history_count, history_opacity_decay, history_vertical_offset, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max, n_history);
 
     std::array<std::optional<AxisCategory>, 3UZ> _xCategories{};
@@ -325,6 +327,7 @@ struct XYChart : gr::Block<XYChart, gr::Drawable<gr::UICategory::Content, "ImGui
 // register XYChart with the GR4 block registry
 // GR_REGISTER_BLOCK is a marker macro for build tools; actual registration via gr::registerBlock
 GR_REGISTER_BLOCK("opendigitizer::charts::XYChart", opendigitizer::charts::XYChart)
-inline auto registerXYChart = gr::registerBlock<opendigitizer::charts::XYChart>(gr::globalBlockRegistry());
+inline auto registerXYChart                = gr::registerBlock<opendigitizer::charts::XYChart>(gr::globalBlockRegistry());
+inline auto registerXYChartCompatibilities = opendigitizer::charts::registerChartSignalCompatibility<opendigitizer::charts::XYChart>();
 
 #endif // OPENDIGITIZER_CHARTS_XYCHART_HPP

--- a/src/ui/charts/YYChart.hpp
+++ b/src/ui/charts/YYChart.hpp
@@ -44,6 +44,8 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
     A<std::array<double, 3UZ>, "Y-axis max">               y_max         = std::array{std::numeric_limits<double>::max(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
     A<gr::Size_t, "history depth", gr::Unit<"samples">>    n_history     = kDefaultHistorySize;
 
+    static constexpr SignalKind supportedSignals = SignalKind::Streaming;
+
     GR_MAKE_REFLECTABLE(YYChart, chart_name, chart_title, data_sinks, show_legend, show_grid, anti_aliasing, x_axis_scale, y_axis_scale, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max, n_history);
 
     mutable std::array<std::string, 6UZ> _unitStringStorage{};
@@ -410,6 +412,7 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
 // Register YYChart with the GR4 block registry
 // GR_REGISTER_BLOCK is a marker macro for build tools; actual registration via gr::registerBlock
 GR_REGISTER_BLOCK("opendigitizer::charts::YYChart", opendigitizer::charts::YYChart)
-inline auto registerYYChart = gr::registerBlock<opendigitizer::charts::YYChart>(gr::globalBlockRegistry());
+inline auto registerYYChart                = gr::registerBlock<opendigitizer::charts::YYChart>(gr::globalBlockRegistry());
+inline auto registerYYChartCompatibilities = opendigitizer::charts::registerChartSignalCompatibility<opendigitizer::charts::YYChart>();
 
 #endif // OPENDIGITIZER_CHARTS_YYCHART_HPP

--- a/src/ui/components/ExportedPropertiesList.hpp
+++ b/src/ui/components/ExportedPropertiesList.hpp
@@ -100,7 +100,7 @@ struct ExportedPropertyDragDropPayload {
     static void payloadSource(const std::string& block, const std::string& property);
 
     [[nodiscard]] static ExportedPropertyPair getCurrentPayload() {
-        if (const auto* payload = ImGui::GetDragDropPayload(); payload && payload->Data) {
+        if (const auto* payload = ImGui::GetDragDropPayload(); payload && payload->Data && payload->IsDataType(kType)) {
             return ExportedPropertyPair(*static_cast<ExportedPropertyDragDropPayload*>(payload->Data));
         }
         return {};

--- a/src/ui/components/GlobalSignalLegend.hpp
+++ b/src/ui/components/GlobalSignalLegend.hpp
@@ -2,7 +2,8 @@
 #define OPENDIGITIZER_GLOBAL_SIGNAL_LEGEND_HPP
 
 #include "../GraphModel.hpp"
-#include "../charts/Charts.hpp"
+#include "../charts/Chart.hpp"
+#include "../charts/SinkRegistry.hpp"
 #include "../common/ImguiWrap.hpp"
 #include "../common/LookAndFeel.hpp"
 
@@ -125,10 +126,12 @@ struct GlobalSignalLegend {
         if (_dragDropEnabled) {
             if (auto dndSource = IMW::DragDropSource(ImGuiDragDropFlags_None)) {
                 using namespace opendigitizer::charts;
-                dnd::Payload payload{};
-                dnd::copyToBuffer(payload.sink_name, label);
-                ImGui::SetDragDropPayload(dnd::kPayloadType, &payload, sizeof(payload));
-                drawLegendItem(color, label, visible);
+                if (const auto& signalSink = SinkRegistry::instance().getSink(sink.blockUniqueName)) {
+                    dnd::Payload payload{.sink_type = signalSink->signalKind()};
+                    dnd::copyToBuffer(payload.sink_name, label);
+                    ImGui::SetDragDropPayload(dnd::kPayloadType, &payload, sizeof(payload));
+                    drawLegendItem(color, label, visible);
+                }
             }
         }
         return clickResult == ClickResult::RightName;

--- a/src/ui/test/TestSinks.hpp
+++ b/src/ui/test/TestSinks.hpp
@@ -65,6 +65,7 @@ public:
     [[nodiscard]] bool                                hasDataSets() const noexcept override { return false; }
     [[nodiscard]] std::size_t                         dataSetCount() const noexcept override { return 0; }
     [[nodiscard]] std::span<const gr::DataSet<float>> dataSets() const override { return {}; }
+    [[nodiscard]] SignalKind                          signalKind() const noexcept override { return SignalKind::Streaming; }
 
     [[nodiscard]] bool                      hasStreamingTags() const noexcept override { return false; }
     [[nodiscard]] std::pair<double, double> tagTimeRange() const noexcept override { return {0.0, 0.0}; }
@@ -225,6 +226,7 @@ public:
     [[nodiscard]] bool                                hasDataSets() const noexcept override { return !_dataSets.empty(); }
     [[nodiscard]] std::size_t                         dataSetCount() const noexcept override { return _dataSets.size(); }
     [[nodiscard]] std::span<const gr::DataSet<float>> dataSets() const override { return {}; }
+    [[nodiscard]] SignalKind                          signalKind() const noexcept override { return SignalKind::Dataset1D; }
 
     [[nodiscard]] bool                      hasStreamingTags() const noexcept override { return false; }
     [[nodiscard]] std::pair<double, double> tagTimeRange() const noexcept override { return {0.0, 0.0}; }


### PR DESCRIPTION
This makes the "Change Type" context menu option for charts check that the given type actually supports the currently shown signals, and makes sure you cannot drag and drop signals to display on charts that do not support them.

There is a bit of code in the PR where the `UiGraphModel` has to figure out whether the input ports of a chart sink are dataset-like or not, and my current solution is to check if the typename string received from the block inspection message looks like `uint%d` or `float%d` etc. This seems... probably fine, unless something like knowing the dimensionality of a dataset type is needed in the future in order to determine chart compatibility. In that case I think it might be preferable to make a change in GR to add some fields to `BLOCK_INPUT_PORTS` to describe the port type a bit.

Closes #441 

Also includes a fix for some potential UB cause by my previous PR...

https://github.com/user-attachments/assets/8fa718a8-d3a7-4a9d-9cdd-dc0216006c8e

