### PR TITLE
Add PulsedPowerDemo dashboard; log-frequency spectra + data-rate-gated plots

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -92,7 +92,8 @@ cmrc_add_resource_library(
   assets/sampleDashboards/dashboard.grc
   assets/sampleDashboards/ExtendedDemoDashboard.grc
   assets/sampleDashboards/PropertyControlDashboard.grc
-  assets/sampleDashboards/DemoDashboard.grc)
+  assets/sampleDashboards/DemoDashboard.grc
+  assets/sampleDashboards/PulsedPowerDemo.grc)
 
 if(EMSCRIPTEN)
   message(STATUS "Detected emscripten webassembly build")
@@ -256,6 +257,9 @@ target_link_libraries(
          GrHttpBlocksShared
          GrMathBlocksShared
          GrTestingBlocksShared)
+if(NOT EMSCRIPTEN) # PicoScope blocks (gr-digitizers), native-only
+  target_link_libraries(${target_name}lib PUBLIC fair-picoscope)
+endif()
 if(OD_DISABLE_DEMO_FLOWGRAPHS)
   target_compile_definitions(${target_name}lib PUBLIC OD_DISABLE_DEMO_FLOWGRAPHS)
 else()

--- a/src/ui/assets/sampleDashboards/PulsedPowerDemo.grc
+++ b/src/ui/assets/sampleDashboards/PulsedPowerDemo.grc
@@ -1,0 +1,165 @@
+blocks:
+  - id: fair::picoscope::Picoscope<float32, fair::picoscope::Picoscope4000a>
+    parameters:
+      name: PicoPulsedPower
+      auto_arm: true
+      sample_rate: 4000000
+      channel_ids: !!str [ A, B ]
+      signal_names: !!str [ "voltage", "current" ]
+      signal_units: !!str [ "V", "A" ]
+      signal_quantities: !!str [ "voltage", "current" ]
+      channel_couplings: !!str [ AC, AC ]
+      channel_ranges: !!float32 [ 10, 5 ] # scope full-scale [V] before signal_scales; tune to your probe/sensor
+      signal_scales: !!float32 [ 100, 2.5 ] # 100:1 HV probe (x100); 400 mV/A current sensor (1/0.4 = x2.5)
+      signal_offsets: !!float32 [ 0, 0 ]
+      trigger_source: ""                # empty -> free-running streaming
+      verbose_console: false
+  - id: gr::testing::NullSink<uint16>
+    parameters:
+      name: DigitalNullSink             # digital port must be connected or the graph blocks
+  - id: gr::testing::NullSink<float32>
+    parameters: { name: NullSinkC }
+  - id: gr::testing::NullSink<float32>
+    parameters: { name: NullSinkD }
+  - id: gr::testing::NullSink<float32>
+    parameters: { name: NullSinkE }
+  - id: gr::testing::NullSink<float32>
+    parameters: { name: NullSinkF }
+  - id: gr::testing::NullSink<float32>
+    parameters: { name: NullSinkG }
+  - id: gr::testing::NullSink<float32>
+    parameters: { name: NullSinkH }
+  # time-domain path: 4 MS/s -> 100 kHz; decimation ratio is the Resampling<40, 1> template (decimate must match)
+  - id: gr::filter::BasicFilterProto<float32, gr::Resampling<40u, 1u, false>>
+    parameters:
+      name: DecimateVoltage
+      sample_rate: 4000000
+      decimate: 40
+      f_low: 40000.0
+  - id: gr::filter::BasicFilterProto<float32, gr::Resampling<40u, 1u, false>>
+    parameters:
+      name: DecimateCurrent
+      sample_rate: 4000000
+      decimate: 40
+      f_low: 40000.0
+  # spectrum path: take one 2^19-sample window of the raw 4 MS/s current twice per second (stride = sample_rate/2),
+  # so the FFT runs on the full bandwidth (0-2 MHz) at ~2 Hz without filtering or per-sample cost on skipped data.
+  - id: opendigitizer::StridedWindow<float32>
+    parameters:
+      name: CurrentWindow
+      input_chunk_size: 524288
+      output_chunk_size: 524288
+      stride: 2000000
+  # time-domain path: stream the decimated 100 kHz signals straight to the plot sinks. The XYChart snapshot-gates
+  # the displayed window (caches it and refreshes on new samples, not per redraw), so it advances at the data rate
+  # rather than the mouse/redraw rate without needing flowgraph-level chunking.
+  - id: opendigitizer::ImPlotSink<float32>
+    parameters:
+      name: PlotVoltage
+      color: 0x000099
+      signal_name: voltage
+      signal_quantity: voltage
+      signal_unit: V
+      sample_rate: 100000
+      required_size: 20000
+  - id: opendigitizer::ImPlotSink<float32>
+    parameters:
+      name: PlotCurrent
+      color: 0x990000
+      signal_name: current
+      signal_quantity: current
+      signal_unit: A
+      sample_rate: 100000
+      required_size: 20000
+  # 2^19-pt FFT on the raw 4 MS/s window -> 7.6 Hz/bin, 0-2 MHz. The waterfall re-bins these 262145 linear bins
+  # onto a log frequency axis (see the plot), keeping the mains harmonics resolved at the low end.
+  - id: gr::blocks::fft::FFT<float32, gr::DataSet<float32>, gr::algorithm::FFT>
+    parameters:
+      name: CurrentSpectrumFFT
+      fftSize: 524288
+      sample_rate: 4000000
+      window: Hann                      # suppress leakage so the harmonic comb is sharp
+      outputInDb: true
+  - id: opendigitizer::ImPlotSink<gr::DataSet<float32>>
+    parameters:
+      name: PlotCurrentSpectrum
+      color: 0x990000
+      signal_name: current spectrum
+      abscissa_quantity: frequency
+      abscissa_unit: Hz
+      signal_quantity: magnitude
+      signal_unit: dB
+      dataset_index: 0
+connections:
+  # picoscope ports: digital is port 1, analog out[] is the port-0 collection ([0, channel]).
+  # 5th element is the edge buffer; keep every picoscope edge >= 2x the 32768 driver chunk (see availableBuffer note above).
+  - [ PicoPulsedPower, 1, DigitalNullSink, 0, 65536 ]
+  - [ PicoPulsedPower, [ 0, 0 ], DecimateVoltage, 0, 65536 ]
+  - [ PicoPulsedPower, [ 0, 1 ], DecimateCurrent, 0, 65536 ]
+  - [ PicoPulsedPower, [ 0, 2 ], NullSinkC, 0, 65536 ]
+  - [ PicoPulsedPower, [ 0, 3 ], NullSinkD, 0, 65536 ]
+  - [ PicoPulsedPower, [ 0, 4 ], NullSinkE, 0, 65536 ]
+  - [ PicoPulsedPower, [ 0, 5 ], NullSinkF, 0, 65536 ]
+  - [ PicoPulsedPower, [ 0, 6 ], NullSinkG, 0, 65536 ]
+  - [ PicoPulsedPower, [ 0, 7 ], NullSinkH, 0, 65536 ]
+  - [ DecimateVoltage, 0, PlotVoltage, 0 ]
+  - [ DecimateCurrent, 0, PlotCurrent, 0 ]
+  # raw current also feeds the strided window -> FFT (edge >= one 2^19 window)
+  - [ PicoPulsedPower, [ 0, 1 ], CurrentWindow, 0, 16777216 ]
+  - [ CurrentWindow, 0, CurrentSpectrumFFT, 0, 16777216 ]
+  - [ CurrentSpectrumFFT, 0, PlotCurrentSpectrum, 0, 16 ]
+dashboard:
+  layout: Free
+  sources:
+    - name: PlotVoltage
+      block: PlotVoltage
+    - name: PlotCurrent
+      block: PlotCurrent
+    - name: PlotCurrentSpectrum
+      block: PlotCurrentSpectrum
+  plots:
+    - name: Voltage & current
+      parameters:
+        show_legend: true
+        n_history: 6000      # 60 ms at 100 kHz
+        update_rate: 2       # Hz; refresh the 60 ms window twice per second (decoupled from the redraw rate)
+      axes:
+        - axis: X            # relative-to-now, newest on the right
+          min: -0.06
+          max: 0.0
+          scale: LinearReverse
+          format: Metric
+        - axis: Y          # voltage, left axis (fixed)
+          min: -400
+          max: 400
+        - axis: Y          # current, right axis (auto-range)
+          min: NaN
+          max: NaN
+          format: Metric
+      sources:
+        - PlotVoltage
+        - PlotCurrent
+      rect: [ 0, 0, 2, 1 ] # x, y, width, height
+    - name: Current magnitude spectrum
+      type: opendigitizer::charts::SpectrumView
+      parameters:
+        n_history: 60   # ~30 s history at ~2 spectra/s
+        colormap: ImPlotColormap_Jet
+      axes:
+        # log frequency: the chart re-bins the linear FFT onto log-spaced columns over [min, max], so the
+        # mains harmonics (low end) and the wideband up to ~2 MHz are both visible. min must be > 0 for log.
+        - axis: X
+          min: 10        # [Hz]
+          max: 2000000   # 2 MHz (Nyquist of the raw 4 MS/s current)
+          scale: Log10
+          format: MetricInline
+        - axis: Y
+          min: NaN
+          max: NaN
+        - axis: Z      # colour scale [dB], auto
+          min: NaN
+          max: NaN
+      sources:
+        - PlotCurrentSpectrum
+      rect: [ 0, 1, 2, 1 ]
+  flowgraphLayout: ""

--- a/src/ui/blocks/ImPlotSink.hpp
+++ b/src/ui/blocks/ImPlotSink.hpp
@@ -546,6 +546,11 @@ struct ImPlotSink : gr::Block<ImPlotSink<T>, gr::Drawable<gr::UICategory::Conten
                     }
                 }
             }
+
+            // surface dropped-sample tags at the current position so the gap is visible in the plot
+            if (plot_tags && IsStreaming && tagMap.contains("droppedSamples")) {
+                _tagValues.push_back({.timestamp = _xUtcOffset + static_cast<double>(_sample_count) * _sample_period, .map = tagMap});
+            }
         }
 
         // Process all samples in the span

--- a/src/ui/blocks/StridedWindow.hpp
+++ b/src/ui/blocks/StridedWindow.hpp
@@ -1,0 +1,34 @@
+#ifndef OPENDIGITIZER_BLOCKS_STRIDEDWINDOW_HPP
+#define OPENDIGITIZER_BLOCKS_STRIDEDWINDOW_HPP
+
+#include <algorithm>
+#include <span>
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/BlockRegistry.hpp>
+
+namespace opendigitizer {
+
+/**
+ * @brief Forwards a contiguous window of `input_chunk_size` samples, then skips ahead by `stride` samples.
+ *
+ * With `stride` larger than the window it takes one window every `stride` input samples (the gr4 FFT block has
+ * no `Stride<>`, so this provides the strided windowing in front of it). Skipped samples are consumed
+ * incrementally, so it drains a fast stream cheaply — e.g. one 2^19-sample window per second of a 4 MS/s signal.
+ */
+template<typename T>
+struct StridedWindow : gr::Block<StridedWindow<T>, gr::Resampling<1U, 1U, false>, gr::Stride<0U, false>> {
+    gr::PortIn<T>  in;
+    gr::PortOut<T> out;
+
+    GR_MAKE_REFLECTABLE(StridedWindow, in, out);
+
+    [[nodiscard]] gr::work::Status processBulk(std::span<const T> input, std::span<T> output) const noexcept {
+        std::copy_n(input.begin(), std::min(input.size(), output.size()), output.begin());
+        return gr::work::Status::OK;
+    }
+};
+
+} // namespace opendigitizer
+
+#endif // OPENDIGITIZER_BLOCKS_STRIDEDWINDOW_HPP

--- a/src/ui/charts/Chart.hpp
+++ b/src/ui/charts/Chart.hpp
@@ -74,6 +74,20 @@ struct AxisConfig {
     bool                     plotTags = true;
 };
 
+struct LogFreqRange {
+    double min;
+    double max;
+};
+
+/// The [min, max] display range when `xCfg` is a Log10 axis with a finite, strictly-positive range, else nullopt.
+/// Texture/surface spectrum charts re-bin a linear FFT onto log-spaced columns drawn over this range (buildLogBinnedRow).
+[[nodiscard]] inline std::optional<LogFreqRange> logFreqRange(const std::optional<AxisConfig>& xCfg) {
+    if (xCfg && xCfg->scale == AxisScale::Log10 && std::isfinite(xCfg->min) && std::isfinite(xCfg->max) && xCfg->min > 0.f) {
+        return LogFreqRange{static_cast<double>(xCfg->min), static_cast<double>(xCfg->max)};
+    }
+    return std::nullopt;
+}
+
 [[nodiscard]] inline std::optional<AxisConfig> parseAxisConfig(const gr::property_map& constraints, AxisKind targetKind, std::size_t index = 0) {
     auto axesIt = constraints.find("axes");
     if (axesIt == constraints.end()) {
@@ -114,11 +128,16 @@ struct AxisConfig {
 
         AxisConfig cfg;
         cfg.axis = parsedKind;
+        // accept both integer and floating-point literals from the .grc (value_or<float> alone returns NaN on an int)
         if (auto it = axisMap->find("min"); it != axisMap->end()) {
-            cfg.min = it->second.value_or(std::numeric_limits<float>::quiet_NaN());
+            if (auto v = gr::pmt::convert_safely<float>(it->second); v) {
+                cfg.min = *v;
+            }
         }
         if (auto it = axisMap->find("max"); it != axisMap->end()) {
-            cfg.max = it->second.value_or(std::numeric_limits<float>::quiet_NaN());
+            if (auto v = gr::pmt::convert_safely<float>(it->second); v) {
+                cfg.max = *v;
+            }
         }
         if (auto it = axisMap->find("scale"); it != axisMap->end()) {
             if (it->second.is_string()) {
@@ -484,9 +503,12 @@ inline void drawTags(ForEachTagFn&& forEachTagFn, AxisScale axisScale, double xM
         double      xTagPosition = transformX(timestamp, axisScale, xMin, xMax);
         const float xPixelPos    = ImPlot::PlotToPixels(xTagPosition, 0.0).x;
 
-        // highlight fishy tags (out-of-order timestamps) in magenta
+        const bool isDrop = properties.contains("droppedSamples");
+        // highlight fishy tags (out-of-order timestamps) magenta, lost-sample markers red
         if (properties.contains(std::string(kFishyTagKey))) {
             ImPlot::SetNextLineStyle(ImVec4(1.0f, 0.0f, 1.0f, 1.0f));
+        } else if (isDrop) {
+            ImPlot::SetNextLineStyle(ImVec4(1.0f, 0.2f, 0.2f, 1.0f));
         } else {
             ImPlot::SetNextLineStyle(tagColor);
         }
@@ -494,6 +516,10 @@ inline void drawTags(ForEachTagFn&& forEachTagFn, AxisScale axisScale, double xM
 
         // suppress tag labels if too close to previous or to axis extremities
         if ((xPixelPos - lastTextPixelX) > 1.5f * fontHeight && (lastAxisPixelX - xPixelPos) > 2.0f * fontHeight) {
+            if (isDrop) {
+                lastTextPixelX = plotVerticalTagLabel("dropped samples", xTagPosition, plotLimits, true).x;
+                return;
+            }
             std::string triggerLabel = "TRIGGER";
             if (const auto it = properties.find(std::string(gr::tag::TRIGGER_NAME.shortKey())); it != properties.end()) {
                 if (const auto str = it->second.value_or(std::string_view{}); str.data() != nullptr) {

--- a/src/ui/charts/SpectrumDensity.hpp
+++ b/src/ui/charts/SpectrumDensity.hpp
@@ -62,6 +62,8 @@ struct SpectrumDensity : gr::Block<SpectrumDensity, gr::Drawable<gr::UICategory:
 
     DensityHistogram             _density;
     TraceAccumulator             _traces;
+    std::vector<float>           _logRow; // scratch: linear spectrum re-binned onto log-spaced columns
+    std::size_t                  _lastSampleCount = std::numeric_limits<std::size_t>::max();
     std::array<std::string, 6UZ> _unitStore{};
     double                       _lastSetYMin         = std::numeric_limits<double>::quiet_NaN();
     double                       _lastSetYMax         = std::numeric_limits<double>::quiet_NaN();
@@ -128,6 +130,7 @@ struct SpectrumDensity : gr::Block<SpectrumDensity, gr::Drawable<gr::UICategory:
     void reset() {
         _density.reset();
         _traces.reset();
+        _lastSampleCount = std::numeric_limits<std::size_t>::max();
     }
 
     // effective Y-range considering dashboard config override (always finite, needed for histogram binning)
@@ -194,6 +197,7 @@ struct SpectrumDensity : gr::Block<SpectrumDensity, gr::Drawable<gr::UICategory:
     }
 
     void drawDensitySignals() {
+        const auto logRange = logFreqRange(parseAxisConfig(this->ui_constraints.value, AxisKind::X));
         forEachValidSpectrum(_signalSinks, [&](const auto& sink, const SpectrumFrame& f) {
             const auto ampBins      = static_cast<std::size_t>(amplitude_bins);
             auto [effYMin, effYMax] = effectiveYRange();
@@ -204,11 +208,23 @@ struct SpectrumDensity : gr::Block<SpectrumDensity, gr::Drawable<gr::UICategory:
                 effYMax     = std::min(limits.Y.Max, effYMax);
             }
 
-            _density.update(f.yValues, f.nBins, ampBins, static_cast<double>(histogram_decay_tau_frames), effYMin, effYMax, colormap.value, gpu_acceleration);
-            _density.plot(f.xValues, effYMin, effYMax);
+            const bool newData = consumeNewData(_lastSampleCount, sink.totalSampleCount());
+            if (logRange) {
+                if (newData) {
+                    _logRow.resize(kLogSpectrumColumns);
+                    buildLogBinnedRow(f.xValues, f.yValues, f.nBins, logRange->min, logRange->max, _logRow);
+                    _density.update(_logRow, kLogSpectrumColumns, ampBins, static_cast<double>(histogram_decay_tau_frames), effYMin, effYMax, colormap.value, gpu_acceleration);
+                }
+                _density.plot(logRange->min, logRange->max, effYMin, effYMax);
+            } else {
+                if (newData) {
+                    _density.update(f.yValues, f.nBins, ampBins, static_cast<double>(histogram_decay_tau_frames), effYMin, effYMax, colormap.value, gpu_acceleration);
+                }
+                _density.plot(f.xValues, effYMin, effYMax);
+            }
 
             ImVec4 traceBase = sinkColor(trace_color);
-            drawTraceOverlays(_traces, f.xValues, f.yValues, f.nBins, static_cast<double>(trace_decay_tau_frames), traceBase, show_max_hold, show_min_hold, show_average);
+            drawTraceOverlays(_traces, newData, f.xValues, f.yValues, f.nBins, static_cast<double>(trace_decay_tau_frames), traceBase, show_max_hold, show_min_hold, show_average);
 
             if (show_current_overlay.value && sink.drawEnabled()) {
                 plotTrace("##current", f.xValues, f.yValues, f.nBins, ImVec4(traceBase.x, traceBase.y, traceBase.z, 1.0f));

--- a/src/ui/charts/SpectrumHelper.hpp
+++ b/src/ui/charts/SpectrumHelper.hpp
@@ -43,7 +43,7 @@ inline ImVec4 contrastingGridColor(ImPlotColormap cmap, float alpha = 0.3f) {
 }
 
 inline uint32_t colormapLookup(double value, double scaleMin, double scaleMax, std::span<const uint32_t, kColormapSize> lut) {
-    if (scaleMax <= scaleMin) {
+    if (scaleMax <= scaleMin || !std::isfinite(value)) {
         return lut[0];
     }
     double norm = (value - scaleMin) / (scaleMax - scaleMin);
@@ -176,9 +176,64 @@ inline void plotTrace(const char* label, std::span<const float> xValues, std::sp
         &ctx, static_cast<int>(count));
 }
 
-inline void drawTraceOverlays(TraceAccumulator& traces, std::span<const float> xValues, std::span<const float> yValues, std::size_t nBins, double decayTau, const ImVec4& baseColor, bool showMaxHold, bool showMinHold, bool showAverage) {
+/// True (and updates `lastCount`) when `currentCount` advanced, i.e. a new spectrum arrived. Gates per-frame
+/// accumulation (hold/decay, waterfall/surface rows) to the data rate, not the UI redraw rate. The DataSet
+/// timestamp can't serve this because gr::blocks::fft::FFT hardcodes it to 0.
+[[nodiscard]] inline bool consumeNewData(std::size_t& lastCount, std::size_t currentCount) noexcept {
+    if (lastCount == currentCount) {
+        return false;
+    }
+    lastCount = currentCount;
+    return true;
+}
+
+/// fixed number of log-spaced display columns for a log-frequency spectrum (waterfall/density/surface).
+inline constexpr std::size_t kLogSpectrumColumns = 2048;
+
+/// Re-sample a linear spectrum (`freqs`/`mags`, `nBins`) onto `out.size()` log-spaced columns over [fMin, fMax]:
+/// peak-preserving max-aggregate, then fill columns finer than the bin spacing. Keeps low-frequency detail on a log axis.
+inline void buildLogBinnedRow(std::span<const float> freqs, std::span<const float> mags, std::size_t nBins, double fMin, double fMax, std::span<float> out) {
+    std::ranges::fill(out, -std::numeric_limits<float>::infinity());
+    const std::size_t nCols  = out.size();
+    const double      logMin = std::log(fMin);
+    const double      span   = std::log(fMax) - logMin;
+    for (std::size_t k = 0; k < nBins; ++k) {
+        const double freq = static_cast<double>(freqs[k]);
+        if (freq < fMin || freq > fMax) {
+            continue;
+        }
+        const auto col = std::min(static_cast<std::size_t>((std::log(freq) - logMin) / span * static_cast<double>(nCols)), nCols - 1);
+        out[col]       = std::max(out[col], mags[k]);
+    }
+    float carry     = 0.0f;
+    bool  seen      = false;
+    float firstVal  = 0.0f;
+    bool  haveFirst = false;
+    for (float& v : out) { // forward-fill: propagate the last occupied column into the gaps above it
+        if (std::isfinite(v)) {
+            carry = v;
+            seen  = true;
+            if (!haveFirst) {
+                firstVal  = v;
+                haveFirst = true;
+            }
+        } else if (seen) {
+            v = carry;
+        }
+    }
+    for (float& v : out) { // back-fill leading columns (below the first occupied bin) with the first value
+        if (std::isfinite(v)) {
+            break;
+        }
+        v = haveFirst ? firstVal : 0.0f;
+    }
+}
+
+inline void drawTraceOverlays(TraceAccumulator& traces, bool newData, std::span<const float> xValues, std::span<const float> yValues, std::size_t nBins, double decayTau, const ImVec4& baseColor, bool showMaxHold, bool showMinHold, bool showAverage) {
     const bool anyEnabled = showMaxHold || showMinHold || showAverage;
-    traces.update(yValues, nBins, decayTau, anyEnabled);
+    if (newData) {
+        traces.update(yValues, nBins, decayTau, anyEnabled);
+    }
 
     if (traces.empty()) {
         return;
@@ -725,14 +780,14 @@ void main() {
         }
     }
 
-    void plot(std::span<const float> xValues, double yMin, double yMax) {
+    void plot(std::span<const float> xValues, double yMin, double yMax) { plot(static_cast<double>(xValues.front()), static_cast<double>(xValues.back()), yMin, yMax); }
+
+    void plot(double freqMin, double freqMax, double yMin, double yMax) {
         GLuint tex = _gpuAvailable ? _colormapTexture : _cpuTexture;
         if (!tex) {
             return;
         }
-        const double freqMin     = static_cast<double>(xValues.front());
-        const double freqMax     = static_cast<double>(xValues.back());
-        auto         toTextureId = []<typename TexId = ImTextureID>(GLuint id) -> TexId {
+        auto toTextureId = []<typename TexId = ImTextureID>(GLuint id) -> TexId {
             if constexpr (std::is_pointer_v<TexId>) {
                 return reinterpret_cast<TexId>(static_cast<std::uintptr_t>(id));
             } else {
@@ -822,9 +877,12 @@ struct WaterfallBuffer {
 
         _timestamps.assign(_height, 0.0);
 
-        if (_preferGpu) {
+        // Always create the GPU texture: PlotImage maps it in screen space, so it renders correctly on log-frequency axes,
+        // whereas PlotHeatmap places cells in linear data space and mis-positions log-binned columns. The renderCpu/
+        // PlotHeatmap path below is retained only as a fallback for the rare case where no GL texture can be allocated.
+        glGenTextures(1, &_texture);
+        if (_texture != 0U) {
             _pixels.assign(_width * _height, 0U);
-            glGenTextures(1, &_texture);
             glBindTexture(GL_TEXTURE_2D, _texture);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -855,7 +913,7 @@ struct WaterfallBuffer {
 
         auto n = std::min(count, _width);
 
-        if (_preferGpu && _texture) {
+        if (_texture) {
             if (_activeColormap != colormap || (_colormapLut[0] == 0 && _colormapLut[1] == 0)) {
                 _colormapLut = buildColormapLut(colormap);
             }
@@ -887,44 +945,79 @@ struct WaterfallBuffer {
         }
     }
 
-    void render(double freqMin, double freqMax, double yMin, double yMax, bool newestAtTop = true) const {
+    // `horizontal` transposes the display: frequency on Y, time on X (default: frequency on X, time on Y).
+    void render(double freqMin, double freqMax, double timeLo, double timeHi, bool newestLeading = true, bool horizontal = false) const {
         if (_filledRows == 0) {
             return;
         }
+        if (!_texture) {
+            renderCpu(freqMin, freqMax, timeLo, timeHi, newestLeading, horizontal);
+            return;
+        }
 
-        if (_texture) {
-            // center-of-texel UVs avoid GL_NEAREST boundary ambiguity at the write-head seam
-            const auto fHeight = static_cast<float>(_height);
-            float      vNewest = (static_cast<float>(_writeRow) - 0.5f) / fHeight;
-            float      vOldest = (static_cast<float>(_writeRow) - static_cast<float>(_filledRows) + 0.5f) / fHeight;
+        // center-of-texel UVs avoid GL_NEAREST boundary ambiguity at the write-head seam; the time axis (texture V)
+        // wraps via GL_REPEAT, so vNewest/vOldest may fall outside [0,1].
+        const auto  fHeight     = static_cast<float>(_height);
+        const float vNewest     = (static_cast<float>(_writeRow) - 0.5f) / fHeight;
+        const float vOldest     = (static_cast<float>(_writeRow) - static_cast<float>(_filledRows) + 0.5f) / fHeight;
+        auto        toTextureId = []<typename TexId = ImTextureID>(GLuint id) -> TexId {
+            if constexpr (std::is_pointer_v<TexId>) {
+                return reinterpret_cast<TexId>(static_cast<std::uintptr_t>(id));
+            } else {
+                return static_cast<TexId>(id);
+            }
+        };
 
-            // uv0 maps to (bmin.x, bmax.y) = screen top-left = plot yMax
-            // uv1 maps to (bmax.x, bmin.y) = screen bottom-right = plot yMin
-            float vTop        = newestAtTop ? vNewest : vOldest;
-            float vBottom     = newestAtTop ? vOldest : vNewest;
-            auto  toTextureId = []<typename TexId = ImTextureID>(GLuint id) -> TexId {
-                if constexpr (std::is_pointer_v<TexId>) {
-                    return reinterpret_cast<TexId>(static_cast<std::uintptr_t>(id));
-                } else {
-                    return static_cast<TexId>(id);
-                }
-            };
-            ImPlot::PlotImage("##waterfall", toTextureId(_texture), ImPlotPoint(freqMin, yMin), ImPlotPoint(freqMax, yMax), ImVec2(0.0f, vTop), ImVec2(1.0f, vBottom));
+        if (horizontal) {
+            // PlotImage can't transpose, so map the quad explicitly: texture U (freq) -> Y, V (time) -> X.
+            // U 0->freqMin (bottom) .. 1->freqMax (top); V newest at the high-time end (right) when newestLeading.
+            const float  vRight   = newestLeading ? vNewest : vOldest;
+            const float  vLeft    = newestLeading ? vOldest : vNewest;
+            ImDrawList*  drawList = ImPlot::GetPlotDrawList();
+            const ImVec2 topLeft  = ImPlot::PlotToPixels(timeLo, freqMax);
+            const ImVec2 topRight = ImPlot::PlotToPixels(timeHi, freqMax);
+            const ImVec2 botRight = ImPlot::PlotToPixels(timeHi, freqMin);
+            const ImVec2 botLeft  = ImPlot::PlotToPixels(timeLo, freqMin);
+            ImPlot::PushPlotClipRect();
+            drawList->AddImageQuad(toTextureId(_texture), topLeft, topRight, botRight, botLeft, ImVec2(1.f, vLeft), ImVec2(1.f, vRight), ImVec2(0.f, vRight), ImVec2(0.f, vLeft));
+            ImPlot::PopPlotClipRect();
         } else {
-            renderCpu(freqMin, freqMax, yMin, yMax, newestAtTop);
+            // uv0 maps to (bmin.x, bmax.y) = screen top-left = plot timeHi; newest at top when newestLeading
+            const float vTop    = newestLeading ? vNewest : vOldest;
+            const float vBottom = newestLeading ? vOldest : vNewest;
+            ImPlot::PlotImage("##waterfall", toTextureId(_texture), ImPlotPoint(freqMin, timeLo), ImPlotPoint(freqMax, timeHi), ImVec2(0.0f, vTop), ImVec2(1.0f, vBottom));
         }
     }
 
-    void renderCpu(double freqMin, double freqMax, double yMin, double yMax, bool newestAtTop) const {
+    void renderCpu(double freqMin, double freqMax, double timeLo, double timeHi, bool newestLeading, bool horizontal = false) const {
+        if (horizontal) {
+            renderCpuHorizontal(freqMin, freqMax, timeLo, timeHi, newestLeading);
+            return;
+        }
         _linearized.resize(_filledRows * _width);
         for (std::size_t i = 0; i < _filledRows; ++i) {
-            // PlotHeatmap maps row 0 to the top of the bounding box
-            std::size_t srcRow = newestAtTop ? (_writeRow + _height - 1 - i) % _height : (_writeRow + _height - _filledRows + i) % _height;
+            std::size_t srcRow = newestLeading ? (_writeRow + _height - 1 - i) % _height : (_writeRow + _height - _filledRows + i) % _height;
             std::copy_n(_rawMagnitudes.data() + srcRow * _width, _width, _linearized.data() + i * _width);
         }
 
         ImPlot::PushColormap(_activeColormap);
-        ImPlot::PlotHeatmap("##waterfall", _linearized.data(), static_cast<int>(_filledRows), static_cast<int>(_width), _effectiveScaleMin, _effectiveScaleMax, nullptr, ImPlotPoint(freqMin, yMin), ImPlotPoint(freqMax, yMax));
+        ImPlot::PlotHeatmap("##waterfall", _linearized.data(), static_cast<int>(_filledRows), static_cast<int>(_width), _effectiveScaleMin, _effectiveScaleMax, nullptr, ImPlotPoint(freqMin, timeLo), ImPlotPoint(freqMax, timeHi));
+        ImPlot::PopColormap();
+    }
+
+    // transposed CPU fallback: rows = frequency (Y), cols = time (X)
+    void renderCpuHorizontal(double freqMin, double freqMax, double timeLo, double timeHi, bool newestLeading) const {
+        _linearized.resize(_width * _filledRows);
+        for (std::size_t r = 0; r < _width; ++r) {
+            const std::size_t freqCol = _width - 1 - r;
+            for (std::size_t c = 0; c < _filledRows; ++c) {
+                const std::size_t order          = newestLeading ? c : (_filledRows - 1 - c); // col 0 = left = oldest when newest trails right
+                const std::size_t srcRow         = (_writeRow + _height - _filledRows + order) % _height;
+                _linearized[r * _filledRows + c] = _rawMagnitudes[srcRow * _width + freqCol];
+            }
+        }
+        ImPlot::PushColormap(_activeColormap);
+        ImPlot::PlotHeatmap("##waterfall", _linearized.data(), static_cast<int>(_width), static_cast<int>(_filledRows), _effectiveScaleMin, _effectiveScaleMax, nullptr, ImPlotPoint(timeLo, freqMin), ImPlotPoint(timeHi, freqMax));
         ImPlot::PopColormap();
     }
 
@@ -936,7 +1029,7 @@ struct WaterfallBuffer {
         std::vector<double> newTimestamps(newHeight, 0.0);
         std::size_t         rowsToCopy = std::min(_filledRows, newHeight);
 
-        if (_preferGpu) {
+        if (_texture) {
             std::vector<uint32_t> newPixels(_width * newHeight, 0U);
             for (std::size_t i = 0; i < rowsToCopy; ++i) {
                 std::size_t srcRow = (_writeRow + _height - rowsToCopy + i) % _height;
@@ -969,7 +1062,7 @@ struct WaterfallBuffer {
     }
 
     void clear() {
-        if (_preferGpu) {
+        if (_texture) {
             std::ranges::fill(_pixels, uint32_t(0));
         } else {
             std::ranges::fill(_rawMagnitudes, 0.0f);
@@ -1002,9 +1095,20 @@ struct WaterfallBuffer {
     }
 
     void updateAutoScale(std::span<const float> yValues, std::size_t nBins) {
-        auto [minIt, maxIt] = std::ranges::minmax_element(yValues | std::views::take(static_cast<std::ptrdiff_t>(nBins)));
-        double fMin         = static_cast<double>(*minIt);
-        double fMax         = static_cast<double>(*maxIt);
+        // ignore non-finite bins: a dB spectrum has -inf where the magnitude is ~0 (e.g. empty bands of a
+        // wideband FFT), which would otherwise drag scaleMin to -inf and collapse the whole colour mapping.
+        double fMin = std::numeric_limits<double>::infinity();
+        double fMax = -std::numeric_limits<double>::infinity();
+        for (const float y : yValues | std::views::take(static_cast<std::ptrdiff_t>(nBins))) {
+            if (!std::isfinite(y)) {
+                continue;
+            }
+            fMin = std::min(fMin, static_cast<double>(y));
+            fMax = std::max(fMax, static_cast<double>(y));
+        }
+        if (fMax <= fMin) {
+            return; // no finite range this frame -> keep the previous colour scale
+        }
         if (_filledRows == 0) {
             _scaleMin = fMin;
             _scaleMax = fMax;

--- a/src/ui/charts/SpectrumPlot.hpp
+++ b/src/ui/charts/SpectrumPlot.hpp
@@ -54,6 +54,7 @@ struct SpectrumPlot : gr::Block<SpectrumPlot, gr::Drawable<gr::UICategory::Conte
     GR_MAKE_REFLECTABLE(SpectrumPlot, chart_name, chart_title, data_sinks, show_legend, show_grid, show_max_hold, show_min_hold, show_average, trace_color, decay_tau_frames, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max);
 
     std::unordered_map<std::string, TraceAccumulator> _tracesPerSink;
+    std::unordered_map<std::string, std::size_t>      _lastSampleCountPerSink;
     std::array<std::string, 6UZ>                      _unitStore{};
 
     static constexpr std::string_view kChartTypeName = "SpectrumPlot";
@@ -90,7 +91,10 @@ struct SpectrumPlot : gr::Block<SpectrumPlot, gr::Drawable<gr::UICategory::Conte
         return gr::work::Status::OK;
     }
 
-    void reset() { _tracesPerSink.clear(); }
+    void reset() {
+        _tracesPerSink.clear();
+        _lastSampleCountPerSink.clear();
+    }
 
     void setupAxes(bool showGrid) {
         setupSingleAxis(true, ImAxis_X1, showGrid, LabelFormat::MetricInline);
@@ -102,8 +106,10 @@ struct SpectrumPlot : gr::Block<SpectrumPlot, gr::Drawable<gr::UICategory::Conte
             if (sink.drawEnabled()) {
                 plotTrace(std::string(sink.signalName()).c_str(), f.xValues, f.yValues, f.nBins, sinkColor(sink.color()));
             }
-            auto& traces = _tracesPerSink[std::string(sink.signalName())];
-            drawTraceOverlays(traces, f.xValues, f.yValues, f.nBins, static_cast<double>(decay_tau_frames), sinkColor(trace_color), show_max_hold, show_min_hold, show_average);
+            const std::string sinkKey = std::string(sink.signalName());
+            auto&             traces  = _tracesPerSink[sinkKey];
+            const bool        newData = consumeNewData(_lastSampleCountPerSink[sinkKey], sink.totalSampleCount());
+            drawTraceOverlays(traces, newData, f.xValues, f.yValues, f.nBins, static_cast<double>(decay_tau_frames), sinkColor(trace_color), show_max_hold, show_min_hold, show_average);
             return true;
         });
     }

--- a/src/ui/charts/SpectrumView.hpp
+++ b/src/ui/charts/SpectrumView.hpp
@@ -73,11 +73,13 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
     GR_MAKE_REFLECTABLE(SpectrumView, chart_name, data_sinks, show_legend, show_grid, top_pane_mode, show_max_hold, show_min_hold, show_average, trace_color, decay_tau_frames, amplitude_bins, histogram_decay_tau_frames, show_current_overlay, n_history, colormap, gpu_acceleration, top_pane_ratio, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max);
 
     std::unordered_map<std::string, TraceAccumulator> _tracesPerSink;
+    std::unordered_map<std::string, std::size_t>      _topPaneSampleCountPerSink;
     DensityHistogram                                  _density;
     WaterfallBuffer                                   _waterfall;
-    std::size_t                                       _lastSpectrumSize    = 0;
-    int64_t                                           _lastPushedTimestamp = 0;
-    std::array<float, 2UZ>                            _rowRatios           = {0.4f, 0.6f};
+    std::vector<float>                                _logRow; // scratch: linear spectrum re-binned onto log-spaced columns
+    std::size_t                                       _lastSpectrumSize         = 0;
+    std::size_t                                       _lastWaterfallSampleCount = std::numeric_limits<std::size_t>::max();
+    std::array<float, 2UZ>                            _rowRatios                = {0.4f, 0.6f};
     std::array<std::string, 6UZ>                      _unitStore{};
     std::array<std::string, 6UZ>                      _waterfallUnitStore{};
 
@@ -101,6 +103,8 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
 
     void reset() {
         _tracesPerSink.clear();
+        _topPaneSampleCountPerSink.clear();
+        _lastWaterfallSampleCount = std::numeric_limits<std::size_t>::max();
         _density.reset();
         _waterfall.clear();
     }
@@ -195,24 +199,38 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
             if (sink.drawEnabled()) {
                 plotTrace(std::string(sink.signalName()).c_str(), f.xValues, f.yValues, f.nBins, sinkColor(sink.color()));
             }
-            auto& traces = _tracesPerSink[std::string(sink.signalName())];
-            drawTraceOverlays(traces, f.xValues, f.yValues, f.nBins, static_cast<double>(decay_tau_frames), sinkColor(trace_color), show_max_hold, show_min_hold, show_average);
+            const std::string sinkKey = std::string(sink.signalName());
+            const bool        newData = consumeNewData(_topPaneSampleCountPerSink[sinkKey], sink.totalSampleCount());
+            drawTraceOverlays(_tracesPerSink[sinkKey], newData, f.xValues, f.yValues, f.nBins, static_cast<double>(decay_tau_frames), sinkColor(trace_color), show_max_hold, show_min_hold, show_average);
             return true;
         });
     }
 
     void drawDensitySignals() {
+        const auto logRange = logFreqRange(parseAxisConfig(this->ui_constraints.value, AxisKind::X));
         forEachValidSpectrum(_signalSinks, [&](const auto& sink, const SpectrumFrame& f) {
             const auto ampBins = static_cast<std::size_t>(amplitude_bins);
             double     effYMin = y_min.value;
             double     effYMax = y_max.value;
 
-            _density.update(f.yValues, f.nBins, ampBins, static_cast<double>(histogram_decay_tau_frames), effYMin, effYMax, colormap.value, gpu_acceleration);
-            _density.plot(f.xValues, effYMin, effYMax);
+            const std::string sinkKey = std::string(sink.signalName());
+            const bool        newData = consumeNewData(_topPaneSampleCountPerSink[sinkKey], sink.totalSampleCount());
+            if (logRange) {
+                if (newData) {
+                    _logRow.resize(kLogSpectrumColumns);
+                    buildLogBinnedRow(f.xValues, f.yValues, f.nBins, logRange->min, logRange->max, _logRow);
+                    _density.update(_logRow, kLogSpectrumColumns, ampBins, static_cast<double>(histogram_decay_tau_frames), effYMin, effYMax, colormap.value, gpu_acceleration);
+                }
+                _density.plot(logRange->min, logRange->max, effYMin, effYMax);
+            } else {
+                if (newData) {
+                    _density.update(f.yValues, f.nBins, ampBins, static_cast<double>(histogram_decay_tau_frames), effYMin, effYMax, colormap.value, gpu_acceleration);
+                }
+                _density.plot(f.xValues, effYMin, effYMax);
+            }
 
             ImVec4 traceBase = sinkColor(trace_color);
-            auto&  traces    = _tracesPerSink[std::string(sink.signalName())];
-            drawTraceOverlays(traces, f.xValues, f.yValues, f.nBins, static_cast<double>(decay_tau_frames), traceBase, show_max_hold, show_min_hold, show_average);
+            drawTraceOverlays(_tracesPerSink[sinkKey], newData, f.xValues, f.yValues, f.nBins, static_cast<double>(decay_tau_frames), traceBase, show_max_hold, show_min_hold, show_average);
 
             if (show_current_overlay.value && sink.drawEnabled()) {
                 plotTrace("##current", f.xValues, f.yValues, f.nBins, ImVec4(traceBase.x, traceBase.y, traceBase.z, 1.0f));
@@ -260,7 +278,7 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
         ImGui::PopID();
     }
 
-    void setupBottomFrequencyAxis(bool showGrid) { setupSingleAxis(true, ImAxis_X1, showGrid, LabelFormat::None, /*foreground=*/true, _sharedXCond, AxisScale::Linear); }
+    void setupBottomFrequencyAxis(bool showGrid) { setupSingleAxis(true, ImAxis_X1, showGrid, LabelFormat::None, /*foreground=*/true, _sharedXCond); }
 
     void setupWaterfallYAxis(bool showGrid) {
         ImPlotAxisFlags yFlags = (showGrid ? ImPlotAxisFlags_None : ImPlotAxisFlags_NoGridLines) | ImPlotAxisFlags_Foreground;
@@ -277,22 +295,29 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
 
     [[nodiscard]] std::optional<RenderInfo> fetchAndPushData() {
         std::optional<RenderInfo> result;
-        forEachValidSpectrum(_signalSinks, [&](const auto& /*sink*/, const SpectrumFrame& f) -> bool {
-            if (f.timestamp == _lastPushedTimestamp && _lastPushedTimestamp != 0) {
+        const auto                logRange = logFreqRange(parseAxisConfig(this->ui_constraints.value, AxisKind::X));
+        forEachValidSpectrum(_signalSinks, [&](const auto& sink, const SpectrumFrame& f) -> bool {
+            if (!consumeNewData(_lastWaterfallSampleCount, sink.totalSampleCount())) {
                 return false;
             }
-            _lastPushedTimestamp = f.timestamp;
 
-            if (_lastSpectrumSize != f.nBins) {
-                _waterfall.init(f.nBins, static_cast<std::size_t>(n_history), gpu_acceleration);
-                _lastSpectrumSize = f.nBins;
+            const std::size_t width = logRange ? kLogSpectrumColumns : f.nBins;
+            if (_lastSpectrumSize != width) {
+                _waterfall.init(width, static_cast<std::size_t>(n_history), gpu_acceleration);
+                _lastSpectrumSize = width;
             }
 
             _waterfall.updateAutoScale(f.yValues, f.nBins);
-            _waterfall.pushRow(f.yValues, f.nBins, _topPaneYMin, _topPaneYMax, timestampFromNanos(f.timestamp), colormap.value);
-
-            _lastRenderInfo = RenderInfo{.freqMin = static_cast<double>(f.xValues.front()), .freqMax = static_cast<double>(f.xValues.back())};
-            result          = _lastRenderInfo;
+            if (logRange) {
+                _logRow.resize(kLogSpectrumColumns);
+                buildLogBinnedRow(f.xValues, f.yValues, f.nBins, logRange->min, logRange->max, _logRow);
+                _waterfall.pushRow(_logRow, kLogSpectrumColumns, _topPaneYMin, _topPaneYMax, timestampFromNanos(f.timestamp), colormap.value);
+                _lastRenderInfo = RenderInfo{.freqMin = logRange->min, .freqMax = logRange->max};
+            } else {
+                _waterfall.pushRow(f.yValues, f.nBins, _topPaneYMin, _topPaneYMax, timestampFromNanos(f.timestamp), colormap.value);
+                _lastRenderInfo = RenderInfo{.freqMin = static_cast<double>(f.xValues.front()), .freqMax = static_cast<double>(f.xValues.back())};
+            }
+            result = _lastRenderInfo;
             return false;
         });
         return result;

--- a/src/ui/charts/SurfacePlot.hpp
+++ b/src/ui/charts/SurfacePlot.hpp
@@ -722,9 +722,12 @@ struct SurfacePlot : gr::Block<SurfacePlot, gr::Drawable<gr::UICategory::Content
 
     SurfaceBuffer              _surface;
     SurfaceGpuRenderer         _gpuRenderer;
-    std::size_t                _lastSpectrumSize    = 0;
-    int64_t                    _lastPushedTimestamp = 0;
-    ImPlot3DColormap           _implot3dColormap    = -1;
+    std::vector<float>         _logRow;      // scratch: linear spectrum re-binned onto log-spaced columns
+    std::vector<float>         _logFreqAxis; // log10(centre frequency) per log column — the X coordinate in log mode
+    bool                       _logModeActive         = false;
+    std::size_t                _lastSpectrumSize      = 0;
+    std::size_t                _lastPushedSampleCount = std::numeric_limits<std::size_t>::max();
+    ImPlot3DColormap           _implot3dColormap      = -1;
     std::array<std::string, 6> _unitStore{};
     bool                       _needsRefit       = true;
     std::array<int, 3>         _pendingScale     = {-1, -1, -1}; // -1 = no change
@@ -826,6 +829,10 @@ struct SurfacePlot : gr::Block<SurfacePlot, gr::Drawable<gr::UICategory::Content
             auto  axisId  = static_cast<ImAxis3D>(i);
             auto  ai      = static_cast<std::size_t>(i);
             void* unitPtr = const_cast<char*>(_unitStore[ai].c_str());
+            if (i == 0 && _logModeActive) { // X holds log10(freq); relabel ticks back to real frequency
+                ImPlot3D::SetupAxisFormat(axisId, formatLog10Metric, unitPtr);
+                continue;
+            }
             switch (_axisFormat[ai]) {
             case LabelFormat::Metric: ImPlot3D::SetupAxisFormat(axisId, static_cast<ImPlot3DFormatter>(axis::formatMetric), nullptr); break;
             case LabelFormat::MetricInline: ImPlot3D::SetupAxisFormat(axisId, static_cast<ImPlot3DFormatter>(axis::formatMetric), unitPtr); break;
@@ -1191,22 +1198,46 @@ struct SurfacePlot : gr::Block<SurfacePlot, gr::Drawable<gr::UICategory::Content
         }
     }
 
+    // log10(centre frequency) of each log-spaced column — the linear X coordinate used in log mode (matches the
+    // column mapping of buildLogBinnedRow). A linear axis over [log10(fMin), log10(fMax)] then renders correctly on
+    // both the CPU and the GPU mesh path (which projects vertices linearly), with decade-uniform grid spacing.
+    void buildLog10FreqAxis(double fMin, double fMax) {
+        _logFreqAxis.resize(kLogSpectrumColumns);
+        const double logMin  = std::log(fMin);
+        const double span    = std::log(fMax) - logMin;
+        const double invLn10 = 1.0 / std::log(10.0);
+        for (std::size_t c = 0; c < kLogSpectrumColumns; ++c) {
+            const double naturalLog = logMin + (static_cast<double>(c) + 0.5) / static_cast<double>(kLogSpectrumColumns) * span;
+            _logFreqAxis[c]         = static_cast<float>(naturalLog * invLn10);
+        }
+    }
+
+    static int formatLog10Metric(double value, char* buf, int size, void* unitPtr) { return axis::formatMetric(std::pow(10.0, value), buf, size, unitPtr); }
+
     void fetchAndPushData() {
-        forEachValidSpectrum(_signalSinks, [&](const auto& /*sink*/, const SpectrumFrame& f) -> bool {
-            if (f.timestamp == _lastPushedTimestamp && _lastPushedTimestamp != 0) {
+        const auto logRange = logFreqRange(parseAxisConfig(this->ui_constraints.value, AxisKind::X));
+        forEachValidSpectrum(_signalSinks, [&](const auto& sink, const SpectrumFrame& f) -> bool {
+            if (!consumeNewData(_lastPushedSampleCount, sink.totalSampleCount())) {
                 return false;
             }
-            _lastPushedTimestamp = f.timestamp;
 
-            if (_lastSpectrumSize != f.nBins) {
-                _surface.init(f.nBins, static_cast<std::size_t>(n_history));
-                _lastSpectrumSize = f.nBins;
+            const std::size_t width = logRange ? kLogSpectrumColumns : f.nBins;
+            if (_lastSpectrumSize != width || _logModeActive != logRange.has_value()) {
+                _surface.init(width, static_cast<std::size_t>(n_history));
+                _lastSpectrumSize = width;
+                _logModeActive    = logRange.has_value();
                 _needsRefit       = true;
             }
 
             _surface.updateAutoScale(f.yValues, f.nBins);
-            _surface.pushRow(f.xValues, f.yValues, f.nBins, timestampFromNanos(f.timestamp));
-
+            if (logRange) {
+                _logRow.resize(kLogSpectrumColumns);
+                buildLogBinnedRow(f.xValues, f.yValues, f.nBins, logRange->min, logRange->max, _logRow);
+                buildLog10FreqAxis(logRange->min, logRange->max);
+                _surface.pushRow(_logFreqAxis, _logRow, kLogSpectrumColumns, timestampFromNanos(f.timestamp));
+            } else {
+                _surface.pushRow(f.xValues, f.yValues, f.nBins, timestampFromNanos(f.timestamp));
+            }
             return false;
         });
     }

--- a/src/ui/charts/WaterfallPlot.hpp
+++ b/src/ui/charts/WaterfallPlot.hpp
@@ -21,6 +21,8 @@
 
 namespace opendigitizer::charts {
 
+enum class WaterfallOrientation : int { Vertical = 0, Horizontal = 1 }; // time on Y (Vertical) or on X with frequency on Y (Horizontal)
+
 struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Content, "ImGui">>, Chart {
     using Description = gr::Doc<"Scrolling spectrogram using a GPU ring-buffer texture with single-row updates.">;
 
@@ -35,9 +37,10 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
     A<bool, "show grid", gr::Visible>                      show_grid   = true;
 
     // waterfall
-    A<gr::Size_t, "history depth", gr::Visible, gr::Limits<16U, 4096U>>                                      n_history        = 256U;
-    A<ImPlotColormap_, "colormap", gr::Visible>                                                              colormap         = ImPlotColormap_Viridis;
-    A<bool, "GPU acceleration", gr::Doc<"use GPU texture for rendering (falls back to CPU if unavailable)">> gpu_acceleration = true;
+    A<gr::Size_t, "history depth", gr::Visible, gr::Limits<16U, 4096U>>                                                                         n_history        = 256U;
+    A<ImPlotColormap_, "colormap", gr::Visible>                                                                                                 colormap         = ImPlotColormap_Viridis;
+    A<bool, "GPU acceleration", gr::Doc<"use GPU texture for rendering (falls back to CPU if unavailable)">>                                    gpu_acceleration = true;
+    A<WaterfallOrientation, "orientation", gr::Visible, gr::Doc<"scroll axis: Vertical (time on Y) or Horizontal (time on X, frequency on Y)">> orientation      = WaterfallOrientation::Vertical;
     // axis limits (Z = colour scale: NaN min/max → auto-scale from data)
     A<bool, "X auto-scale"> x_auto_scale = true;
     A<bool, "Y auto-scale"> y_auto_scale = true;
@@ -48,7 +51,7 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
 
     static constexpr SignalKind supportedSignals = SignalKind::Dataset1D;
 
-    GR_MAKE_REFLECTABLE(WaterfallPlot, chart_name, chart_title, data_sinks, show_legend, show_grid, n_history, colormap, gpu_acceleration, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max);
+    GR_MAKE_REFLECTABLE(WaterfallPlot, chart_name, chart_title, data_sinks, show_legend, show_grid, n_history, colormap, gpu_acceleration, orientation, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max);
 
     struct RenderInfo {
         double freqMin;
@@ -56,10 +59,11 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
     };
 
     WaterfallBuffer            _waterfall;
-    std::size_t                _lastSpectrumSize = 0;
+    std::size_t                _lastInitWidth = 0; // allocated texture width (nBins, or kLogSpectrumColumns in log mode)
     std::array<std::string, 6> _unitStore{};
-    int64_t                    _lastPushedTimestamp = 0;
+    std::size_t                _lastPushedSampleCount = std::numeric_limits<std::size_t>::max();
     std::optional<RenderInfo>  _lastRenderInfo;
+    std::vector<float>         _logRow; // scratch: linear spectrum re-binned onto log-spaced columns
 
     static constexpr std::string_view kChartTypeName = "WaterfallPlot";
 
@@ -109,13 +113,15 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
         // phase 2: fetch new data and push into waterfall (skips duplicate frames)
         auto renderInfo = fetchAndPushData();
 
-        // phase 3: compute Y-axis bounds in the coordinate system determined by the scale
-        const AxisScale yScale  = getAxisScale(AxisKind::Y).value_or(AxisScale::LinearReverse);
-        auto [tOldest, tNewest] = _waterfall.rawTimeBounds();
-        auto [yLo, yHi]         = transformedYBounds(tOldest, tNewest, yScale);
+        // phase 3: compute the time-axis bounds; in horizontal mode time is on X, otherwise on Y
+        const bool      horizontal = orientation.value == WaterfallOrientation::Horizontal;
+        const ImAxis    timeAxis   = horizontal ? ImAxis_X1 : ImAxis_Y1;
+        const AxisScale timeScale  = getAxisScale(AxisKind::Y).value_or(AxisScale::LinearReverse);
+        auto [tOldest, tNewest]    = _waterfall.rawTimeBounds();
+        auto [timeLo, timeHi]      = transformedYBounds(tOldest, tNewest, timeScale);
 
-        if (_waterfall.filledRows() > 0 && yHi > yLo) {
-            ImPlot::SetupAxisLimits(ImAxis_Y1, yLo, yHi, ImPlotCond_Always);
+        if (_waterfall.filledRows() > 0 && timeHi > timeLo) {
+            ImPlot::SetupAxisLimits(timeAxis, timeLo, timeHi, ImPlotCond_Always);
         }
 
         ImPlot::SetupFinish();
@@ -128,11 +134,11 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
         }
 
         // phase 4: render waterfall image (always, even when no new data this frame)
-        const bool newestAtTop = (yScale == AxisScale::LinearReverse);
+        const bool newestLeading = (timeScale == AxisScale::LinearReverse);
         if (renderInfo) {
-            _waterfall.render(renderInfo->freqMin, renderInfo->freqMax, yLo, yHi, newestAtTop);
+            _waterfall.render(renderInfo->freqMin, renderInfo->freqMax, timeLo, timeHi, newestLeading, horizontal);
         } else if (_waterfall.filledRows() > 0 && _lastRenderInfo) {
-            _waterfall.render(_lastRenderInfo->freqMin, _lastRenderInfo->freqMax, yLo, yHi, newestAtTop);
+            _waterfall.render(_lastRenderInfo->freqMin, _lastRenderInfo->freqMax, timeLo, timeHi, newestLeading, horizontal);
         }
 
         tooltip::showPlotMouseTooltip();
@@ -167,7 +173,12 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
     }
 
     void setupAxes(bool showGrid) {
-        // x-axis: frequency
+        // frequency keeps the "X" dashboard entry, time the "Y" entry; orientation only rotates which screen axis each uses
+        const bool   horizontal = orientation.value == WaterfallOrientation::Horizontal;
+        const ImAxis freqAxis   = horizontal ? ImAxis_Y1 : ImAxis_X1;
+        const ImAxis timeAxis   = horizontal ? ImAxis_X1 : ImAxis_Y1;
+
+        // frequency axis
         {
             const auto      dashCfg = parseAxisConfig(this->ui_constraints.value, true);
             const AxisScale scale   = dashCfg ? dashCfg->scale.value_or(AxisScale::Linear) : AxisScale::Linear;
@@ -182,27 +193,26 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
 
             auto [xQuantity, xUnit] = sinkAxisInfo(true);
             AxisCategory xCat{.quantity = xQuantity, .unit = xUnit};
-            axis::setupAxis(ImAxis_X1, xCat, format, 100.f, minLimit, maxLimit, 1, scale, _unitStore, showGrid, /*foreground=*/true);
+            axis::setupAxis(freqAxis, xCat, format, 100.f, minLimit, maxLimit, 1, scale, _unitStore, showGrid, /*foreground=*/true);
         }
 
-        // y-axis: time — limits are set in draw() after data push so axis and image stay synchronised.
-        // ImPlotScale_Time is X-axis-only; we use Linear + custom formatter.
+        // time axis — limits are set in draw() after data push so axis and image stay synchronised.
+        // ImPlotScale_Time is X-axis-only; we use Linear + a custom formatter uniformly.
         {
-            AxisScale scale = getAxisScale(AxisKind::Y).value_or(AxisScale::LinearReverse);
-
-            ImPlotAxisFlags yFlags = (showGrid ? ImPlotAxisFlags_None : ImPlotAxisFlags_NoGridLines) | ImPlotAxisFlags_Foreground;
-            ImPlot::SetupAxis(ImAxis_Y1, "", yFlags);
+            AxisScale       scale  = getAxisScale(AxisKind::Y).value_or(AxisScale::LinearReverse);
+            ImPlotAxisFlags tFlags = (showGrid ? ImPlotAxisFlags_None : ImPlotAxisFlags_NoGridLines) | ImPlotAxisFlags_Foreground;
+            ImPlot::SetupAxis(timeAxis, "", tFlags);
 
             if (scale == AxisScale::Time) {
-                ImPlot::SetupAxisFormat(ImAxis_Y1, formatTimeAxis, nullptr);
-                ImPlot::SetupAxisScale(ImAxis_Y1, ImPlotScale_Linear);
+                ImPlot::SetupAxisFormat(timeAxis, formatTimeAxis, nullptr);
+                ImPlot::SetupAxisScale(timeAxis, ImPlotScale_Linear);
             } else {
-                _unitStore[ImAxis_Y1] = "s";
-                ImPlot::SetupAxisFormat(ImAxis_Y1, axis::formatMetric, const_cast<void*>(static_cast<const void*>(_unitStore[ImAxis_Y1].c_str())));
+                _unitStore[static_cast<std::size_t>(timeAxis)] = "s";
+                ImPlot::SetupAxisFormat(timeAxis, axis::formatMetric, const_cast<void*>(static_cast<const void*>(_unitStore[static_cast<std::size_t>(timeAxis)].c_str())));
                 switch (scale) {
-                case AxisScale::Log10: ImPlot::SetupAxisScale(ImAxis_Y1, ImPlotScale_Log10); break;
-                case AxisScale::SymLog: ImPlot::SetupAxisScale(ImAxis_Y1, ImPlotScale_SymLog); break;
-                default: ImPlot::SetupAxisScale(ImAxis_Y1, ImPlotScale_Linear); break;
+                case AxisScale::Log10: ImPlot::SetupAxisScale(timeAxis, ImPlotScale_Log10); break;
+                case AxisScale::SymLog: ImPlot::SetupAxisScale(timeAxis, ImPlotScale_SymLog); break;
+                default: ImPlot::SetupAxisScale(timeAxis, ImPlotScale_Linear); break;
                 }
             }
         }
@@ -210,23 +220,32 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
 
     [[nodiscard]] std::optional<RenderInfo> fetchAndPushData() {
         std::optional<RenderInfo> result;
-        forEachValidSpectrum(_signalSinks, [&](const auto& /*sink*/, const SpectrumFrame& f) -> bool {
-            if (f.timestamp == _lastPushedTimestamp && _lastPushedTimestamp != 0) {
+        const auto                logRange = logFreqRange(parseAxisConfig(this->ui_constraints.value, AxisKind::X));
+
+        forEachValidSpectrum(_signalSinks, [&](const auto& sink, const SpectrumFrame& f) -> bool {
+            if (!consumeNewData(_lastPushedSampleCount, sink.totalSampleCount())) {
                 return false;
             }
-            _lastPushedTimestamp = f.timestamp;
 
-            if (_lastSpectrumSize != f.nBins) {
-                _waterfall.init(f.nBins, static_cast<std::size_t>(n_history), gpu_acceleration);
-                _lastSpectrumSize = f.nBins;
+            const std::size_t width = logRange ? kLogSpectrumColumns : f.nBins;
+            if (_lastInitWidth != width) {
+                _waterfall.init(width, static_cast<std::size_t>(n_history), gpu_acceleration);
+                _lastInitWidth = width;
             }
 
             _waterfall.updateAutoScale(f.yValues, f.nBins);
             auto [cMin, cMax] = effectiveColourRange(this->ui_constraints.value, _waterfall.scaleMin(), _waterfall.scaleMax());
-            _waterfall.pushRow(f.yValues, f.nBins, cMin, cMax, timestampFromNanos(f.timestamp), colormap.value);
 
-            _lastRenderInfo = RenderInfo{.freqMin = static_cast<double>(f.xValues.front()), .freqMax = static_cast<double>(f.xValues.back())};
-            result          = _lastRenderInfo;
+            if (logRange) {
+                _logRow.resize(kLogSpectrumColumns);
+                buildLogBinnedRow(f.xValues, f.yValues, f.nBins, logRange->min, logRange->max, _logRow);
+                _waterfall.pushRow(_logRow, kLogSpectrumColumns, cMin, cMax, timestampFromNanos(f.timestamp), colormap.value);
+                _lastRenderInfo = RenderInfo{.freqMin = logRange->min, .freqMax = logRange->max};
+            } else {
+                _waterfall.pushRow(f.yValues, f.nBins, cMin, cMax, timestampFromNanos(f.timestamp), colormap.value);
+                _lastRenderInfo = RenderInfo{.freqMin = static_cast<double>(f.xValues.front()), .freqMax = static_cast<double>(f.xValues.back())};
+            }
+            result = _lastRenderInfo;
             return false;
         });
         return result;

--- a/src/ui/charts/XYChart.hpp
+++ b/src/ui/charts/XYChart.hpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <gnuradio-4.0/Block.hpp>
@@ -21,15 +22,6 @@
 #include <implot.h>
 
 namespace opendigitizer::charts {
-
-struct PlotLineContext {
-    const SignalSink* sink;
-    AxisScale         axis_scale;
-    double            x_min;
-    double            x_max;
-    float             y_offset{0.0f};
-    std::size_t       offset{0};
-};
 
 struct DataSetPlotContext {
     const gr::DataSet<float>* data_set;
@@ -44,34 +36,42 @@ struct XYChart : gr::Block<XYChart, gr::Drawable<gr::UICategory::Content, "ImGui
     template<typename T, gr::meta::fixed_string description = "", typename... Arguments>
     using A = gr::Annotated<T, description, Arguments...>;
 
-    A<std::string, "chart name", gr::Visible>                                       chart_name;
-    A<std::string, "chart title">                                                   chart_title;
-    A<std::vector<std::string>, "data sinks", gr::Visible>                          data_sinks              = {};
-    A<int, "X-axis mode", gr::Visible>                                              x_axis_mode             = static_cast<int>(XAxisMode::RelativeTime);
-    A<bool, "show legend", gr::Visible>                                             show_legend             = false;
-    A<bool, "show tags", gr::Visible>                                               show_tags               = true;
-    A<bool, "show grid", gr::Visible>                                               show_grid               = true;
-    A<bool, "anti-aliasing">                                                        anti_aliasing           = true;
-    A<gr::Size_t, "max history count", gr::Limits<1U, 128U>>                        max_history_count       = 3U;
-    A<float, "history opacity decay", gr::Limits<0.001f, 1.f>>                      history_opacity_decay   = 0.3f;
-    A<float, "history vertical offset", gr::Limits<0.f, 100.f>>                     history_vertical_offset = 0.0f;
-    A<std::array<bool, 3UZ>, "X auto-scale">                                        x_auto_scale            = std::array{true, true, true};
-    A<std::array<bool, 3UZ>, "Y auto-scale">                                        y_auto_scale            = std::array{true, true, true};
-    A<std::array<double, 3UZ>, "X-axis min">                                        x_min                   = std::array{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
-    A<std::array<double, 3UZ>, "X-axis max">                                        x_max                   = std::array{std::numeric_limits<double>::max(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
-    A<std::array<double, 3UZ>, "Y-axis min">                                        y_min                   = std::array{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
-    A<std::array<double, 3UZ>, "Y-axis max">                                        y_max                   = std::array{std::numeric_limits<double>::max(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
-    A<gr::Size_t, "history depth", gr::Unit<"samples">, gr::Limits<4U, 2'000'000U>> n_history               = kDefaultHistorySize;
+    A<std::string, "chart name", gr::Visible>                                                                                                                                      chart_name;
+    A<std::string, "chart title">                                                                                                                                                  chart_title;
+    A<std::vector<std::string>, "data sinks", gr::Visible>                                                                                                                         data_sinks              = {};
+    A<int, "X-axis mode", gr::Visible>                                                                                                                                             x_axis_mode             = static_cast<int>(XAxisMode::RelativeTime);
+    A<bool, "show legend", gr::Visible>                                                                                                                                            show_legend             = false;
+    A<bool, "show tags", gr::Visible>                                                                                                                                              show_tags               = true;
+    A<bool, "show grid", gr::Visible>                                                                                                                                              show_grid               = true;
+    A<bool, "anti-aliasing">                                                                                                                                                       anti_aliasing           = true;
+    A<gr::Size_t, "max history count", gr::Limits<1U, 128U>>                                                                                                                       max_history_count       = 3U;
+    A<float, "history opacity decay", gr::Limits<0.001f, 1.f>>                                                                                                                     history_opacity_decay   = 0.3f;
+    A<float, "history vertical offset", gr::Limits<0.f, 100.f>>                                                                                                                    history_vertical_offset = 0.0f;
+    A<std::array<bool, 3UZ>, "X auto-scale">                                                                                                                                       x_auto_scale            = std::array{true, true, true};
+    A<std::array<bool, 3UZ>, "Y auto-scale">                                                                                                                                       y_auto_scale            = std::array{true, true, true};
+    A<std::array<double, 3UZ>, "X-axis min">                                                                                                                                       x_min                   = std::array{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
+    A<std::array<double, 3UZ>, "X-axis max">                                                                                                                                       x_max                   = std::array{std::numeric_limits<double>::max(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
+    A<std::array<double, 3UZ>, "Y-axis min">                                                                                                                                       y_min                   = std::array{std::numeric_limits<double>::lowest(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
+    A<std::array<double, 3UZ>, "Y-axis max">                                                                                                                                       y_max                   = std::array{std::numeric_limits<double>::max(), std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
+    A<gr::Size_t, "history depth", gr::Unit<"samples">, gr::Limits<4U, 2'000'000U>>                                                                                                n_history               = kDefaultHistorySize;
+    A<float, "update rate", gr::Unit<"Hz">, gr::Limits<0.f, 240.f>, gr::Doc<"streaming-trace redraw cadence; decouples the display from the mouse/redraw rate (0 = every frame)">> update_rate             = 25.0f;
 
     static constexpr SignalKind supportedSignals = SignalKind::Streaming | SignalKind::Dataset1D;
 
-    GR_MAKE_REFLECTABLE(XYChart, chart_name, chart_title, data_sinks, x_axis_mode, show_legend, show_tags, show_grid, anti_aliasing, max_history_count, history_opacity_decay, history_vertical_offset, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max, n_history);
+    GR_MAKE_REFLECTABLE(XYChart, chart_name, chart_title, data_sinks, x_axis_mode, show_legend, show_tags, show_grid, anti_aliasing, max_history_count, history_opacity_decay, history_vertical_offset, x_auto_scale, y_auto_scale, x_min, x_max, y_min, y_max, n_history, update_rate);
 
     std::array<std::optional<AxisCategory>, 3UZ> _xCategories{};
     std::array<std::optional<AxisCategory>, 3UZ> _yCategories{};
     std::array<std::vector<std::string>, 3UZ>    _xAxisGroups{};
     std::array<std::vector<std::string>, 3UZ>    _yAxisGroups{};
     mutable std::array<std::string, 6UZ>         _unitStringStorage{};
+
+    struct StreamSnapshot {
+        std::vector<double> x; // window X, pre-transformed for the active axis scale (double: absolute timestamps lose precision as float)
+        std::vector<double> y;
+        double              lastRefresh = 0.0;
+    };
+    std::unordered_map<std::string, StreamSnapshot> _streamSnapshots;
 
     static constexpr std::string_view kChartTypeName = "XYChart";
 
@@ -234,39 +234,36 @@ struct XYChart : gr::Block<XYChart, gr::Drawable<gr::UICategory::Content, "ImGui
         }
 
         // clamp to n_history: show only the most recent samples
-        std::size_t dataCount = totalCount;
-        std::size_t offset    = 0;
-        if (dataCount > static_cast<std::size_t>(n_history.value)) {
-            dataCount = static_cast<std::size_t>(n_history.value);
-            offset    = totalCount - dataCount;
+        std::size_t dataCount = std::min(totalCount, static_cast<std::size_t>(n_history.value));
+        std::size_t offset    = totalCount - dataCount;
+
+        const AxisScale xAxisScale = _xCategories[0].has_value() ? _xCategories[0]->scale : AxisScale::Linear;
+
+        // snapshot-gate: rebuild the displayed window at most update_rate times/s instead of re-reading the live
+        // ring buffer each redraw, so the trace advances at a steady cadence rather than with the mouse/redraw rate.
+        StreamSnapshot& snap            = _streamSnapshots[std::string(sink.uniqueName())];
+        const double    now             = ImGui::GetTime();
+        const double    refreshInterval = update_rate.value > 0.f ? 1.0 / static_cast<double>(update_rate.value) : 0.0;
+        if (snap.x.size() != dataCount || (now - snap.lastRefresh) >= refreshInterval) {
+            const double xMin = sink.xAt(offset);
+            const double xMax = sink.xAt(offset + dataCount - 1);
+            snap.x.resize(dataCount);
+            snap.y.resize(dataCount);
+            for (std::size_t i = 0; i < dataCount; ++i) {
+                double xVal = sink.xAt(offset + i);
+                switch (xAxisScale) {
+                case AxisScale::Time: break;
+                case AxisScale::LinearReverse: xVal -= xMax; break;
+                default: xVal -= xMin; break;
+                }
+                snap.x[i] = xVal;
+                snap.y[i] = static_cast<double>(sink.yAt(offset + i));
+            }
+            snap.lastRefresh = now;
         }
 
-        ImVec4 lineColor = sinkColor(sink.color());
-        ImPlot::SetNextLineStyle(lineColor);
-
-        double xMin = sink.xAt(offset);
-        double xMax = sink.xAt(offset + dataCount - 1);
-
-        AxisScale       xAxisScale = _xCategories[0].has_value() ? _xCategories[0]->scale : AxisScale::Linear;
-        PlotLineContext ctx{&sink, xAxisScale, xMin, xMax, 0.0f, offset};
-
-        ImPlot::PlotLineG(
-            sink.signalName().data(),
-            [](int idx, void* user_data) -> ImPlotPoint {
-                auto*       context   = static_cast<PlotLineContext*>(user_data);
-                std::size_t actualIdx = context->offset + static_cast<std::size_t>(idx);
-                double      xVal      = context->sink->xAt(actualIdx);
-                double      yVal      = static_cast<double>(context->sink->yAt(actualIdx)) + static_cast<double>(context->y_offset);
-
-                switch (context->axis_scale) {
-                case AxisScale::Time: break;
-                case AxisScale::LinearReverse: xVal = xVal - context->x_max; break;
-                default: xVal = xVal - context->x_min; break;
-                }
-
-                return ImPlotPoint(xVal, yVal);
-            },
-            &ctx, static_cast<int>(dataCount));
+        ImPlot::SetNextLineStyle(sinkColor(sink.color()));
+        ImPlot::PlotLine(sink.signalName().data(), snap.x.data(), snap.y.data(), static_cast<int>(snap.x.size()));
     }
 
     void drawDataSetSignal(const SignalSink& sink) {

--- a/src/ui/cmake/Dependencies.cmake
+++ b/src/ui/cmake/Dependencies.cmake
@@ -73,6 +73,16 @@ FetchContent_MakeAvailable(
 
 od_set_release_flags_on_gnuradio_targets("${gnuradio4_SOURCE_DIR}")
 
+# PicoScope blocks (gr-digitizers) for local hardware dashboards; native-only (SDK + USB, not under emscripten)
+if (NOT EMSCRIPTEN)
+    FetchContent_Declare(
+            gr-digitizers
+            GIT_REPOSITORY https://github.com/fair-acc/gr-digitizers.git
+            GIT_TAG ${GIT_SHA_GR_DIGITIZERS}
+            EXCLUDE_FROM_ALL SYSTEM)
+    FetchContent_MakeAvailable(gr-digitizers)
+endif ()
+
 if(NOT EMSCRIPTEN)
   find_package(SDL3 QUIET)
 

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -32,15 +32,24 @@
 #include <GrHttpBlocks.hpp>
 #include <GrMathBlocks.hpp>
 #include <GrTestingBlocks.hpp>
+
+#ifndef __EMSCRIPTEN__
+// gr-digitizers is a native-only run-time dependency (PicoScope SDK, USB); unavailable under emscripten.
+#include <fair/picoscope/Picoscope.hpp>
+#include <fair/picoscope/Picoscope4000a.hpp>
+#endif
+
 #include <gnuradio-4.0/BlockRegistry.hpp>
 #include <gnuradio-4.0/Scheduler.hpp>
 #include <gnuradio-4.0/basic/ConverterBlocks.hpp>
 #include <gnuradio-4.0/basic/SignalGenerator.hpp>
+#include <gnuradio-4.0/filter/time_domain_filter.hpp>
 
 #include "blocks/Arithmetic.hpp"
 #include "blocks/ImPlotSink.hpp"
 #include "blocks/RemoteSource.hpp"
 #include "blocks/SineSource.hpp"
+#include "blocks/StridedWindow.hpp"
 #include "blocks/TagToSample.hpp"
 #include "blocks/TestSpectrumGenerator.hpp"
 
@@ -230,6 +239,19 @@ int main(int argc, char** argv) {
     gr::blocklib::initGrHttpBlocks(*registry);
     gr::blocklib::initGrMathBlocks(*registry);
     gr::blocklib::initGrTestingBlocks(*registry);
+
+    // decimating BasicFilterProto variants: the ratio is the Resampling<in,out> template integers, and the
+    // gr::filter blocklib registers only the <1,1> identity (used by PulsedPowerDemo.grc).
+    gr::registerBlock<gr::filter::BasicFilterProto<float, gr::Resampling<100UZ, 1UZ, false>>, "">(*registry);
+    gr::registerBlock<gr::filter::BasicFilterProto<float, gr::Resampling<40UZ, 1UZ, false>>, "">(*registry);
+
+    // strided windowing in front of the FFT (the gr4 FFT has no Stride<>); see PulsedPowerDemo.grc
+    gr::registerBlock<opendigitizer::StridedWindow<float>, "">(*registry);
+
+#ifndef __EMSCRIPTEN__
+    gr::registerBlock<fair::picoscope::Picoscope<float, fair::picoscope::Picoscope4000a>, "">(*registry);
+    gr::registerBlock<fair::picoscope::Picoscope<gr::DataSet<float>, fair::picoscope::Picoscope4000a>, "">(*registry);
+#endif
 
     // Register schedulers
     gr::globalSchedulerRegistry().insert<gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::singleThreadedBlocking>>();


### PR DESCRIPTION
- PulsedPowerDemo.grc: local PicoScope 4000a voltage/current time plot + current-spectrum waterfall
- spectrum charts (WaterfallPlot, SpectrumView, SpectrumDensity, SurfacePlot): log-frequency re-binning on a Log10 axis (shared buildLogBinnedRow/logFreqRange; SurfacePlot uses log10 coordinates); per-frame accumulation gated to the data rate (consumeNewData); auto-scale and colormap ignore non-finite bins
- WaterfallPlot: allows vertical and horizontal scrolling now (see below).
- XYChart: snapshot-gated streaming trace with configurable update_rate, decoupling the display cadence from the redraw rate
- ImPlotSink: surface droppedSamples tags as plot markers
- Chart.hpp: accept integer axis min/max literals (convert_safely); draw dropped-sample marker
- StridedWindow: strided windowing in front of the gr4 FFT
- main.cpp: register PicoScope4000a, StridedWindow, and decimating BasicFilterProto variants
- CMake: link fair-picoscope, fetch gr-digitizers, bundle PulsedPowerDemo

<img width="1909" height="1012" alt="pastedImage (1)" src="https://github.com/user-attachments/assets/b8d885c6-8ad4-426e-9081-0c700b49327e" />
<img width="1270" height="739" alt="image" src="https://github.com/user-attachments/assets/b97ae251-00cd-4f85-86d6-6a29719723ef" />
