### PR TITLE
meta: fix Zenodo software metadata; stop screenshots polluting the concept DOI

### DIFF
--- a/.github/workflows/upload-reference-screencaptures.yml
+++ b/.github/workflows/upload-reference-screencaptures.yml
@@ -29,12 +29,22 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         if [ -d captures ]; then
-          # Delete/recreate release, as there's no easy API to just rsync new pngs
-          gh release delete reference_screen_captures-main --repo ${{ github.repository }} -y
-          gh release create reference_screen_captures-main --notes "Reference screen captures" --repo ${{ github.repository }}
+          # Update assets in place — never delete/recreate this release. Recreating
+          # publishes a GitHub Release that Zenodo archives as a new screenshots version
+          # under the software concept DOI (see CONTRIBUTING.md → Releasing and Zenodo archiving).
+          REPO="${{ github.repository }}"
+          REF_RELEASE="reference_screen_captures-main"
 
-          # upload new captures
-          gh release upload reference_screen_captures-main captures/*.png --clobber --repo ${{ github.repository }}
+          # create the storage release once; afterwards only its assets change
+          gh release view "$REF_RELEASE" --repo "$REPO" >/dev/null 2>&1 \
+            || gh release create "$REF_RELEASE" --notes "Reference screen captures" --repo "$REPO"
 
-          gh release delete-asset test_screen_captures ${{ github.event.pull_request.number }}-all-captures.tgz --repo ${{ github.repository }}
+          # drop the previous reference pngs so removed/renamed captures don't linger
+          for asset in $(gh release view "$REF_RELEASE" --repo "$REPO" --json assets --jq '.assets[].name'); do
+            gh release delete-asset "$REF_RELEASE" "$asset" --repo "$REPO" --yes || true
+          done
+
+          gh release upload "$REF_RELEASE" captures/*.png --clobber --repo "$REPO"
+
+          gh release delete-asset test_screen_captures "${{ github.event.pull_request.number }}-all-captures.tgz" --repo "$REPO" --yes
         fi

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,44 +1,37 @@
 {
   "title": "OpenDigitizer",
-  "description": "OpenDigitizer — an open-source digitiser UI for signal acquisition and visualisation.",
-  "license": {
-    "id": "LGPL-3.0-only"
-  },
   "upload_type": "software",
-  "creators": [
-    {
-      "name": "Krimm, Alexander",
-      "affiliation": "GSI Helmholtzzentrum für Schwerionenforschung",
-      "orcid": "0000-0003-0804-756X"
-    },
-    {
-      "name": "Steinhagen, Ralph J.",
-      "affiliation": "GSI Helmholtzzentrum für Schwerionenforschung / FAIR",
-      "orcid": "0009-0009-8537-7029"
-    },
-    {
-      "name": "Lebedev, Simon",
-      "affiliation": "GSI Helmholtzzentrum für Schwerionenforschung",
-      "orcid": "0009-0006-8329-990X"
-    },
-    {
-      "name": "Čukić, Ivan",
-      "affiliation": "KDAB",
-      "orcid": "0000-0001-5358-0828"
-    }
-  ],
+  "license": "lgpl-3.0-only",
+  "description": "OpenDigitizer — an open-source digitiser framework and user interface for signal acquisition and visualisation, built on OpenCMW and GNU Radio 4.0.",
   "keywords": [
     "digitiser",
     "signal acquisition",
+    "signal processing",
     "data visualisation",
-    "C++",
-    "accelerator controls"
+    "accelerator controls",
+    "accelerator diagnostics",
+    "OpenCMW",
+    "GNU Radio",
+    "C++"
+  ],
+  "creators": [
+    {"name": "Krimm, Alexander", "affiliation": "GSI Helmholtzzentrum für Schwerionenforschung", "orcid": "0000-0003-0804-756X"},
+    {"name": "Steinhagen, Ralph J.", "affiliation": "GSI Helmholtzzentrum für Schwerionenforschung / FAIR", "orcid": "0009-0009-8537-7029"},
+    {"name": "Lebedev, Simon", "affiliation": "GSI Helmholtzzentrum für Schwerionenforschung", "orcid": "0009-0006-8329-990X"},
+    {"name": "Čukić, Ivan", "affiliation": "KDAB", "orcid": "0000-0001-5358-0828"},
+    {"name": "Martins, Sergio", "affiliation": "KDAB"},
+    {"name": "Camuffo, Giulio", "affiliation": "KDAB"},
+    {"name": "Osterfeld, Frank", "affiliation": "KDAB"},
+    {"name": "Nicoletti, Daniel", "affiliation": "KDAB"},
+    {"name": "Groß, Magnus", "affiliation": "KDAB"},
+    {"name": "Ahmed, Waqar", "affiliation": "KDAB"},
+    {"name": "Doroshenko, Ilya", "affiliation": "KDAB"},
+    {"name": "McFarlane, Ian"},
+    {"name": "Busse, Alexander"}
   ],
   "related_identifiers": [
-    {
-      "identifier": "https://github.com/fair-acc/opendigitizer",
-      "relation": "isSupplementTo",
-      "scheme": "url"
-    }
+    {"relation": "isSupplementTo", "identifier": "https://github.com/fair-acc/opendigitizer", "scheme": "url"},
+    {"relation": "references", "identifier": "10.5281/zenodo.19010697", "scheme": "doi"},
+    {"relation": "references", "identifier": "10.5281/zenodo.19007383", "scheme": "doi"}
   ]
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,21 +2,30 @@ cff-version: 1.2.0
 title: "OpenDigitizer"
 message: "If you use this software, please cite it using the metadata from this file."
 type: software
+abstract: "OpenDigitizer — an open-source digitiser framework and user interface for signal acquisition and visualisation, built on OpenCMW and GNU Radio 4.0."
 license: LGPL-3.0-only
 repository-code: "https://github.com/fair-acc/opendigitizer"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.19105696"
+    description: "Concept DOI resolving to the latest published version of OpenDigitizer on Zenodo."
 keywords:
   - digitiser
   - signal acquisition
+  - signal processing
   - data visualisation
-  - C++
   - accelerator controls
+  - accelerator diagnostics
+  - OpenCMW
+  - GNU Radio
+  - C++
 authors:
   - family-names: Krimm
     given-names: Alexander
     affiliation: "GSI Helmholtzzentrum für Schwerionenforschung"
     orcid: "https://orcid.org/0000-0003-0804-756X"
   - family-names: Steinhagen
-    given-names: Ralph J.
+    given-names: "Ralph J."
     affiliation: "GSI Helmholtzzentrum für Schwerionenforschung / FAIR"
     orcid: "https://orcid.org/0009-0009-8537-7029"
   - family-names: Lebedev
@@ -27,3 +36,28 @@ authors:
     given-names: Ivan
     affiliation: "KDAB"
     orcid: "https://orcid.org/0000-0001-5358-0828"
+  - family-names: Martins
+    given-names: Sergio
+    affiliation: "KDAB"
+  - family-names: Camuffo
+    given-names: Giulio
+    affiliation: "KDAB"
+  - family-names: Osterfeld
+    given-names: Frank
+    affiliation: "KDAB"
+  - family-names: Nicoletti
+    given-names: Daniel
+    affiliation: "KDAB"
+  - family-names: Groß
+    given-names: Magnus
+    affiliation: "KDAB"
+  - family-names: Ahmed
+    given-names: Waqar
+    affiliation: "KDAB"
+  - family-names: Doroshenko
+    given-names: Ilya
+    affiliation: "KDAB"
+  - family-names: McFarlane
+    given-names: Ian
+  - family-names: Busse
+    given-names: Alexander

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,20 @@ EITHER EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION,
 ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
 MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 
+## Releasing and Zenodo archiving
+
+This repository is linked to Zenodo: **every published GitHub Release is archived by Zenodo as a new version** under the OpenDigitizer concept DOI [`10.5281/zenodo.19105696`](https://doi.org/10.5281/zenodo.19105696). The concept DOI always resolves to the **most recently published** version (by date, not by version string), and that latest version is what linked communities (e.g. iRIS) display.
+
+Consequences for day-to-day work:
+
+- **Only cut GitHub Releases for software versions** — a semver tag `vX.Y.Z` on `main`. Never create a release on a side branch or for non-software assets; doing so mints a spurious Zenodo version and pushes it to "latest".
+- The `reference_screen_captures-main` and `test_screen_captures` releases are **internal asset storage** for the visual-regression workflow, not real releases. The merge workflow updates their assets in place and must **never** delete/recreate them — recreating republishes the release and triggers a fresh (screenshots) Zenodo deposit. This is what previously buried the software record.
+- If reference or screenshot artefacts ever need a citable archive, deposit them as a **separate** Zenodo record (its own concept), not through this repository's release hook.
+
+### Citation metadata
+
+Author and project metadata for the Zenodo deposit live in [`CITATION.cff`](CITATION.cff) and [`.zenodo.json`](.zenodo.json). When the deposit is built from a release tag, **`.zenodo.json` takes precedence** over `CITATION.cff`, which in turn takes precedence over GitHub-derived defaults. Keep both files in sync and edit the author roster there — not in the GitHub release UI.
+
 ## Code of Conduct
 
 To ensure an inclusive community, contributors and users in the GNU Radio


### PR DESCRIPTION
## Problem

The OpenDigitizer concept DOI [`10.5281/zenodo.19105696`](https://doi.org/10.5281/zenodo.19105696) resolves to a **screenshots** snapshot instead of the software. Investigation found:

- **All 12 versions under the concept are screenshots** (`reference_screen_captures-main`) — no software version has ever been archived. The concept was created as a screenshots archive on 2026-03-19.
- The pollution is **automated**: `upload-reference-screencaptures.yml` runs on every merged PR and `gh release delete` + `create`s the `reference_screen_captures-main` release. Each recreation is a new "published release" event → a new Zenodo version that becomes "latest".
- `.zenodo.json` was being **ignored**: `gh release delete` never removes the git *tag*, so `reference_screen_captures-main` is frozen at commit `0d6d1d39` (2024-10-23), predating the metadata files. Every archive used that stale tree (no `.zenodo.json`), so Zenodo fell back to the raw GitHub contributor graph (bots, duplicates, login handles).
- `.zenodo.json` had the license as an object; Zenodo only accepts the lowercase SPDX string `lgpl-3.0-only`.

## Changes

- **`.zenodo.json`** — license → `"lgpl-3.0-only"`; full 13-author roster (no bots/dupes/handles); keywords; GNU Radio 4.0 + OpenCMW **concept**-DOI cross-links.
- **`CITATION.cff`** — full 13-author roster; concept DOI; abstract; keywords.
- **`.github/workflows/upload-reference-screencaptures.yml`** — no longer deletes/recreates the storage release on every merge; updates its assets in place (prune + re-upload). Asset edits do **not** trigger Zenodo — proven by `test_screen_captures`, which is `--clobber`-uploaded on every PR build yet has zero Zenodo versions — so this stops the recurring pollution while keeping the visual-regression workflow intact.
- **`CONTRIBUTING.md`** — new "Releasing and Zenodo archiving" policy.

## Follow-up (not in this PR)

1. Cut the first software release `v1.0.0` on `main`. A fresh tag contains the corrected metadata, so Zenodo finally honours `.zenodo.json` and the new version becomes the concept's "latest" software.
2. Submit the software record to the **iRIS** community (slug `101275935`, UUID `9b5e752a-…`) — not the unrelated `iris` / "IRIS-JPI" community.
