### PR TITLE
Give "Add block" dialog a fuzzy searchable tree view

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -239,6 +239,7 @@ add_library(
   components/ExportedPropertiesList.hpp
   components/ExportedPropertiesList.cpp
   components/FilterComboBoxes.hpp
+  components/InputTextCompletion.hpp
   components/Keypad.hpp
   components/ListBox.hpp
   components/ImGuiNotify.hpp
@@ -248,6 +249,8 @@ add_library(
   components/SignalSelector.cpp
   components/NewBlockSelector.hpp
   components/NewBlockSelector.cpp
+  components/NewBlockSelectorFuzzySearch.hpp
+  components/NewBlockSelectorFuzzySearch.cpp
   components/Splitter.cpp
   components/Splitter.hpp
   components/Toolbar.hpp

--- a/src/ui/common/ImguiWrap.hpp
+++ b/src/ui/common/ImguiWrap.hpp
@@ -112,6 +112,21 @@ struct WidgetSize {
 /// and a given label. Buttons have a fixed size.
 ImVec2 CalcButtonSize(const char* label);
 
+/// Calculates how big a series of buttons will be if they are all drawn on the
+/// same line
+template<std::size_t N>
+requires(N > 0)
+inline ImVec2 CalcAdjacentButtonSizes(const std::array<const char*, N>& labels) {
+    ImVec2     total{};
+    const auto spacing = ImGui::GetStyle().ItemSpacing.x;
+    for (std::size_t i = 0; i < N; ++i) {
+        auto size = CalcButtonSize(labels[i]);
+        total.x += size.x + (i > 0 ? spacing : 0.f);
+        total.y = std::max(total.y, size.y);
+    }
+    return total;
+}
+
 WidgetSize CalcCheckboxSize(const char* label);
 /// Minimum size of a labelled color editor, not the color picker popup
 WidgetSize CalcColorEditorSize(const char* label, ImGuiColorEditFlags flags);

--- a/src/ui/common/LookAndFeel.cpp
+++ b/src/ui/common/LookAndFeel.cpp
@@ -33,39 +33,44 @@ LookAndFeel& LookAndFeel::mutableInstance() {
 const LookAndFeel& LookAndFeel::instance() { return mutableInstance(); }
 
 const Palette& LookAndFeel::palette() const noexcept {
+    static const auto    rgba                    = [](std::uint32_t color, std::uint8_t alpha = 0xFF) { return ImGui::ColorConvertU32ToFloat4(rgbToImGuiABGR(color, alpha)); };
     static const ImVec4  quarterTransparentWhite = {1.0f, 1.0f, 1.0f, 0.25f};
     static const ImVec4  quarterTransparentBlack = {0.0f, 0.0f, 0.0f, 0.25f};
     static const Palette darkModePalette{
         .gridLines = quarterTransparentWhite,
 
-        .mainWindowButtonIcon       = {.8f, .8f, .8f, 1.0f},
-        .mainWindowButtonBgInactive = {1.f, 1.f, 1.f, 0.0f},
-        .mainWindowButtonBgHovered  = {1.f, 1.f, 1.f, 0.1f},
-        .mainWindowButtonBgActive   = {1.f, 1.f, 1.f, 0.2f},
+        .mainWindowButtonIcon       = rgba(0xCCCCCC),
+        .mainWindowButtonBgInactive = rgba(0xFFFFFF, 0x00),
+        .mainWindowButtonBgHovered  = rgba(0xFFFFFF, 0x20),
+        .mainWindowButtonBgActive   = rgba(0xFFFFFF, 0x33),
 
-        .notificationWindowBg = {0.10f, 0.10f, 0.10f, 1.00f},
+        .notificationWindowBg = rgba(0x202020),
         .toolbarLineColor     = quarterTransparentWhite,
-        .flowgraphBg          = {0.1f, 0.1f, 0.1f, 1.f},
-        .flowgraphNodeBg      = {0.2f, 0.2f, 0.2f, 1.f},
-        .flowgraphNodeBorder  = {0.7f, 0.7f, 0.7f, 1.f},
+        .flowgraphBg          = rgba(0x202020),
+        .flowgraphNodeBg      = rgba(0x333333),
+        .flowgraphNodeBorder  = rgba(0xB3B3B3),
 
-        .rowBgAlt = ImVec4{0.2f, 0.2f, 0.2f, 1.0f},
+        .rowBgAlt = rgba(0x333333),
+
+        .highlightedSearchResultsBg = rgba(0x1A94F0, 0x66), // saturated but transparent blue, goes behind white text
     };
     static const Palette lightModePalette{
         .gridLines = quarterTransparentBlack,
 
-        .mainWindowButtonIcon       = {.8f, .8f, .8f, 0.6f},
-        .mainWindowButtonBgInactive = {0.f, 0.f, 0.f, 0.0f},
-        .mainWindowButtonBgHovered  = {0.f, 0.f, 0.f, 0.1f},
-        .mainWindowButtonBgActive   = {0.f, 0.f, 0.f, 0.2f},
+        .mainWindowButtonIcon       = rgba(0xCCCCCC, 0x99),
+        .mainWindowButtonBgInactive = rgba(0x000000, 0x00),
+        .mainWindowButtonBgHovered  = rgba(0x000000, 0x20),
+        .mainWindowButtonBgActive   = rgba(0x000000, 0x33),
 
-        .notificationWindowBg = {1.00f, 1.00f, 1.00f, 1.00f},
+        .notificationWindowBg = rgba(0xFFFFFF),
         .toolbarLineColor     = quarterTransparentBlack,
-        .flowgraphBg          = {1.f, 1.f, 1.f, 1.f},
-        .flowgraphNodeBg      = {0.94f, 0.92f, 1.f, 1.f},
-        .flowgraphNodeBorder  = {0.38f, 0.38f, 0.38f, 1.f},
+        .flowgraphBg          = rgba(0xFFFFFF),
+        .flowgraphNodeBg      = rgba(0xEFEAFF),
+        .flowgraphNodeBorder  = rgba(0x606060),
 
-        .rowBgAlt = {0.8f, 0.8f, 0.8f, 1.0f},
+        .rowBgAlt = rgba(0xCCCCCC),
+
+        .highlightedSearchResultsBg = rgba(0xFFFF00, 0x88),
     };
 
     return style == Style::Light ? lightModePalette : darkModePalette;

--- a/src/ui/common/LookAndFeel.hpp
+++ b/src/ui/common/LookAndFeel.hpp
@@ -48,6 +48,8 @@ struct Palette {
     ImVec4 flowgraphNodeBorder;
 
     ImVec4 rowBgAlt;
+
+    ImVec4 highlightedSearchResultsBg;
 };
 
 struct LookAndFeel {

--- a/src/ui/components/Docking.cpp
+++ b/src/ui/components/Docking.cpp
@@ -293,7 +293,7 @@ bool DockSpace::layoutInExactFree(const Windows& windows, bool isEditable) {
         }
         maxX = std::max(maxX, windowPtr->freeLayoutPosition->x + windowPtr->freeLayoutPosition->width);
         maxY = std::max(maxY, windowPtr->freeLayoutPosition->y + windowPtr->freeLayoutPosition->height);
-        windowAreasByOriginalIndex.try_emplace(static_cast<std::size_t>(index - 1), *windowPtr->freeLayoutPosition);
+        windowAreasByOriginalIndex.try_emplace(index - std::size_t{1}, *windowPtr->freeLayoutPosition);
         windowPtr->freeLayoutPosition.reset();
     }
 

--- a/src/ui/components/InputTextCompletion.hpp
+++ b/src/ui/components/InputTextCompletion.hpp
@@ -1,0 +1,82 @@
+#ifndef OPENDIGITIZER_UI_COMPONENTS_INPUT_TEXT_COMPLETION_HPP_
+#define OPENDIGITIZER_UI_COMPONENTS_INPUT_TEXT_COMPLETION_HPP_
+
+#include <imgui.h>
+#include <misc/cpp/imgui_stdlib.h>
+
+#include <limits>
+#include <ranges>
+#include <vector>
+
+namespace DigitizerUi::components {
+
+template<typename T>
+concept CompletionNamesCollection = !std::is_const_v<T> && std::ranges::forward_range<T> && std::is_same_v<std::remove_cvref_t<std::ranges::range_value_t<T>>, std::string>;
+
+/// Struct containing params to pass to ImGui::InputText. Intended use:
+/// InputTextCompletion(namesContainer}.inputText(...))
+template<CompletionNamesCollection Collection>
+struct InputTextCompletionContext {
+    static int inputTextCompletionCallback(ImGuiInputTextCallbackData* d) {
+        assert(d->UserData && "no userdata passed to ImGui::InputText()?");
+        if (d->EventKey == ImGuiKey_Tab) {
+            std::vector<std::string> candidates;
+            std::size_t              shortest         = std::numeric_limits<std::size_t>::max();
+            std::string_view         inputBufferSoFar = {d->Buf, static_cast<std::size_t>(d->BufTextLen)};
+
+            if (inputBufferSoFar.empty()) {
+                // user has not typed anything yet so we don't know what they
+                // want, and the rest of this function does not handle this case
+                return 0;
+            }
+
+            auto notEmpty = [](const auto& string) { return !string.empty(); };
+            for (const std::string& name : *static_cast<Collection*>(d->UserData) | std::views::filter(notEmpty)) {
+                if (name.starts_with(inputBufferSoFar)) {
+                    candidates.emplace_back(name);
+                    shortest = std::min(shortest, name.size());
+                }
+            }
+
+            if (candidates.empty()) {
+                return 0;
+            }
+
+            for (auto& c : candidates) {
+                c.resize(shortest);
+            }
+
+            while (candidates.size() > 1) {
+                if (auto s = candidates.size(); candidates[s - 2] == candidates[s - 1]) {
+                    candidates.pop_back();
+                    continue;
+                }
+
+                shortest--;
+                assert(shortest > 0);
+                for (auto& c : candidates) {
+                    c.resize(shortest);
+                }
+            }
+            const char* str = candidates.front().data();
+            d->InsertChars(d->BufTextLen, &str[d->BufTextLen], &str[candidates.front().size()]);
+        }
+        return 0;
+    }
+
+    Collection*            data     = nullptr;
+    ImGuiInputTextCallback callback = &inputTextCompletionCallback;
+
+    auto inputText(const char* label, std::string* buffer, ImGuiInputTextFlags flags = ImGuiInputTextFlags_None) { //
+        return ImGui::InputText(label, buffer, flags | ImGuiInputTextFlags_CallbackCompletion, callback, data);
+    }
+};
+
+template<CompletionNamesCollection Collection>
+InputTextCompletionContext<Collection> InputTextCompletion(Collection& collection) {
+    return {std::addressof(collection)};
+}
+
+} // namespace DigitizerUi::components
+
+#endif

--- a/src/ui/components/ListBox.hpp
+++ b/src/ui/components/ListBox.hpp
@@ -2,6 +2,9 @@
 #define OPENDIGITIZER_UI_COMPONENTS_LIST_BOX_HPP_
 
 #include "../common/ImguiWrap.hpp"
+#include "tolower.hpp"
+
+#include "InputTextCompletion.hpp"
 #include <misc/cpp/imgui_stdlib.h>
 
 #include <optional>
@@ -23,58 +26,83 @@ inline void ensureItemVisible() {
         ImGui::SetScrollHereY(0);
     }
 }
+
+template<typename T>
+struct FilterListContext {
+    std::optional<T> selected = {};
+    std::string      filterString;
+    std::vector<T>   filteredItems;
+    bool             filterInputReclaimFocus = false;
+
+    [[nodiscard]] bool filter(std::string_view name) {
+        if (!filterString.empty()) {
+            auto subrange = std::ranges::search(name, filterString, [](char a, char b) { return Digitizer::utils::safe_tolower(a) == Digitizer::utils::safe_tolower(b); });
+            if (std::begin(subrange) == name.end()) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    std::pair<int, bool> initSelection(bool shouldScrollToSelected) {
+        if (selected && !filter(selected->second)) {
+            selected = {};
+        }
+
+        if (selected) {
+            if (ImGui::IsKeyPressed(ImGuiKey_DownArrow)) {
+                return {1, true};
+            }
+            if (ImGui::IsKeyPressed(ImGuiKey_UpArrow)) {
+                return {-1, true};
+            }
+        }
+        return {0, shouldScrollToSelected};
+    }
+
+    template<typename Items, typename ItemGetter, typename ItemDrawer>
+    void draw(const Items& items, ItemGetter getItem, ItemDrawer drawItem, bool shouldScrollToSelected) {
+        auto [selectOffset, scrollToSelected] = initSelection(shouldScrollToSelected);
+
+        filteredItems.clear();
+        for (auto& t : items) {
+            auto [item, name] = getItem(t);
+            if (!name.empty() && filter(name)) {
+                filteredItems.push_back({item, name});
+            }
+        }
+
+        for (auto it = filteredItems.begin(); it != filteredItems.end(); ++it) {
+            if (!selected) {
+                selected = *it;
+            }
+
+            const bool isLastIteration = (it + 1) == filteredItems.end();
+            if (!isLastIteration) {
+                if (selectOffset == -1 && *(it + 1) == *selected) { // selectOffset = -1, go up, ie. next item is selected and current should be instead
+                    selected     = *it;
+                    selectOffset = 0;
+                } else if (selectOffset == 1 && *it == *selected) { // selectOffset = 1, go down, ie. this is selected and select next item
+                    selected     = {};
+                    selectOffset = 0;
+                }
+            }
+
+            if (drawItem(*it, selected && *it == *selected)) {
+                selected                = *it;
+                filterInputReclaimFocus = true;
+            }
+            if (selected && *selected == *it && scrollToSelected) {
+                detail::ensureItemVisible();
+            }
+        }
+    }
+};
+
 } // namespace detail
 
 template<typename T, typename Items, typename ItemGetter, typename ItemDrawer>
-std::optional<T> FilteredListBox(const char* id, const ImVec2& size, Items&& items, ItemGetter getItem, ItemDrawer drawItem) {
-    struct CallbackData {
-        const Items& items;
-        ItemGetter   getItem;
-    } cbdata = {items, getItem};
-
-    auto completeItemName = [](ImGuiInputTextCallbackData* d) -> int {
-        auto* _cbdata = static_cast<CallbackData*>(d->UserData);
-        if (d->EventKey == ImGuiKey_Tab) {
-            std::vector<std::string> candidates;
-            std::size_t              shortest = std::numeric_limits<std::size_t>::max();
-            for (auto& t : _cbdata->items) {
-                auto [item, name] = _cbdata->getItem(t);
-                if (name.empty()) {
-                    continue;
-                }
-                if (name.starts_with(std::string_view(d->Buf, static_cast<std::size_t>(d->BufTextLen)))) {
-                    candidates.push_back(name);
-                    shortest = std::min(shortest, name.size());
-                }
-            }
-
-            if (candidates.empty()) {
-                return 0;
-            }
-
-            for (auto& c : candidates) {
-                c.resize(shortest);
-            }
-
-            while (candidates.size() > 1) {
-                auto s = candidates.size();
-                if (candidates[s - 2] == candidates[s - 1]) {
-                    candidates.pop_back();
-                    continue;
-                }
-
-                shortest--;
-                assert(shortest > 0);
-                for (auto& c : candidates) {
-                    c.resize(shortest);
-                }
-            }
-            auto* str = candidates.front().data();
-            d->InsertChars(d->BufTextLen, &str[d->BufTextLen], &str[candidates.front().size()]);
-        }
-        return 0;
-    };
-
+std::optional<T> FilteredListBox(const char* id, const ImVec2& size, const Items& items, ItemGetter getItem, ItemDrawer&& drawItem) {
     IMW::ChangeStrId newId(id);
 
     IMW::Group group;
@@ -86,17 +114,12 @@ std::optional<T> FilteredListBox(const char* id, const ImVec2& size, Items&& ite
     ImGui::SameLine();
     ImGui::SetCursorPosY(y);
 
-    struct FilterListContext {
-        std::optional<T> selected = {};
-        std::string      filterString;
-        std::vector<T>   filteredItems;
-        bool             filterInputReclaimFocus = false;
-    };
     auto  storage = ImGui::GetStateStorage();
     auto  ctxid   = ImGui::GetID("context");
-    auto* ctx     = static_cast<FilterListContext*>(storage->GetVoidPtr(ctxid));
+    auto* ctx     = static_cast<detail::FilterListContext<T>*>(storage->GetVoidPtr(ctxid));
     if (!ctx) {
-        ctx = new FilterListContext;
+        // this new will leak this object but that is okay, it and ImGui live for the whole program
+        ctx = new detail::FilterListContext<T>; // NOSONAR
         storage->SetVoidPtr(ctxid, ctx);
     }
 
@@ -106,83 +129,32 @@ std::optional<T> FilteredListBox(const char* id, const ImVec2& size, Items&& ite
     }
 
     IMW::ItemWidth newItemWidth(size.x - (ImGui::GetCursorPosX() - x));
-    bool           scrollToSelected = ImGui::InputText("##filterBlockType", &ctx->filterString, ImGuiInputTextFlags_CallbackCompletion, completeItemName, &cbdata);
+    const bool     scrollToSelected = [&getItem, &items, ctx] {
+        auto completionNames = items | std::views::transform([&getItem](auto& item) { return getItem(item).second; });
+        return InputTextCompletion(completionNames).inputText("##filterBlockType", &ctx->filterString);
+    }();
 
     if (auto listbox = IMW::ListBox("##Available Block types", ImVec2{size.x, size.y - (ImGui::GetCursorPosY() - y)})) {
-        auto filter = [&](std::string_view name) {
-            if (!ctx->filterString.empty()) {
-                auto it = std::search(name.begin(), name.end(), ctx->filterString.begin(), ctx->filterString.end(), [](int a, int b) { return std::tolower(a) == std::tolower(b); });
-                if (it == name.end()) {
-                    return false;
-                }
-            }
-            return true;
-        };
-
-        if (ctx->selected && !filter(ctx->selected->second)) {
-            ctx->selected = {};
-        }
-
-        int selectOffset = 0;
-        if (ctx->selected) {
-            if (ImGui::IsKeyPressed(ImGuiKey_DownArrow)) {
-                ++selectOffset;
-                scrollToSelected = true;
-            }
-            if (ImGui::IsKeyPressed(ImGuiKey_UpArrow)) {
-                --selectOffset;
-                scrollToSelected = true;
-            }
-        }
-
-        ctx->filteredItems.clear();
-        for (auto& t : items) {
-            auto [item, name] = getItem(t);
-            if (!name.empty() && filter(name)) {
-                ctx->filteredItems.push_back({item, name});
-            }
-        }
-
-        for (auto it = ctx->filteredItems.begin(); it != ctx->filteredItems.end(); ++it) {
-            if (!ctx->selected) {
-                ctx->selected = *it;
-            }
-
-            if (selectOffset == -1 && *(it + 1) == *ctx->selected) {
-                ctx->selected = *it;
-                selectOffset  = 0;
-            } else if (selectOffset == 1 && *it == *ctx->selected && (it + 1) != ctx->filteredItems.end()) {
-                ctx->selected = {};
-                selectOffset  = 0;
-            }
-
-            if (drawItem(*it, ctx->selected && ctx->selected && *it == *ctx->selected)) {
-                ctx->selected                = *it;
-                ctx->filterInputReclaimFocus = true;
-            }
-            if (ctx->selected && *ctx->selected == *it && scrollToSelected) {
-                detail::ensureItemVisible();
-            }
-        }
+        ctx->draw(items, std::move(getItem), std::forward<ItemDrawer>(drawItem), scrollToSelected);
     }
 
     return ctx->selected;
 }
 
 template<typename Items, typename ItemGetter>
-auto FilteredListBox(const char* id, const ImVec2& size, Items&& items, ItemGetter getItem)
+auto FilteredListBox(const char* id, const ImVec2& size, const Items& items, ItemGetter&& getItem)
 requires std::is_invocable_v<ItemGetter, decltype(*items.begin())>
 {
     using T = decltype(getItem(*items.begin()));
-    return FilteredListBox<T>(id, size, items, getItem, [](auto&& item, bool selected) { return ImGui::Selectable(item.second.data(), selected); });
+    return FilteredListBox<T>(id, size, items, std::forward<ItemGetter>(getItem), [](auto&& item, bool selected) { return ImGui::Selectable(item.second.data(), selected); });
 }
 
 template<typename Items, typename ItemGetter, typename ItemDrawer>
-auto FilteredListBox(const char* id, const ImVec2& size, Items&& items, ItemGetter getItem, ItemDrawer drawItem)
+auto FilteredListBox(const char* id, const ImVec2& size, const Items& items, ItemGetter&& getItem, ItemDrawer&& drawItem)
 requires std::is_invocable_v<ItemGetter, decltype(*items.begin())>
 {
     using T = decltype(getItem(*items.begin()));
-    return FilteredListBox<T>(id, size, items, getItem, drawItem);
+    return FilteredListBox<T>(id, size, items, std::forward<ItemGetter>(getItem), std::forward<ItemDrawer>(drawItem));
 }
 
 } // namespace DigitizerUi::components

--- a/src/ui/components/NewBlockSelector.cpp
+++ b/src/ui/components/NewBlockSelector.cpp
@@ -1,76 +1,288 @@
 #include "NewBlockSelector.hpp"
+#include "InputTextCompletion.hpp"
 
-#include "../App.hpp"
-
-#include <gnuradio-4.0/Scheduler.hpp>
+#include "../common/ImguiWrap.hpp"
+#include "../common/LookAndFeel.hpp"
 
 #include "../components/Dialog.hpp"
 #include "../components/ListBox.hpp"
 
-#include <misc/cpp/imgui_stdlib.h>
+#include "../ui/GraphModel.hpp"
+
+#include "NewBlockSelectorFuzzySearch.hpp"
+#include "scope_exit.hpp"
+
+#include <gnuradio-4.0/Message.hpp>
+#include <gnuradio-4.0/Scheduler.hpp>
 
 using namespace std::string_literals;
+using DigitizerUi::components::FilterResult;
+using DigitizerUi::components::filterTypename;
+using DigitizerUi::components::NamespaceDelimitedSearchIterator;
+
+struct Symbol {
+    std::string_view    fullSymbolName;
+    const FilterResult& filterResult;
+
+    /// This draws the full name of the symbol with exact search matches highlighted. It is also a selectable and returns true if it was selected.
+    [[nodiscard]] bool draw(std::string_view currentlySelected, bool scrollToSelected) const {
+        bool selected = false;
+        assert(!fullSymbolName.empty());
+        auto       buttonWidth       = ImGui::GetContentRegionAvail().x;
+        const auto textCursorInitial = ImGui::GetCursorScreenPos() + ImVec2{ImGui::GetStyle().ItemInnerSpacing.x, 0.f};
+
+        const auto* window = ImGui::GetCurrentWindow();
+
+        const bool wasSelected = fullSymbolName == currentlySelected;
+        if (ImGui::Selectable(std::format("##{}", fullSymbolName).c_str(), wasSelected, ImGuiSelectableFlags_None, {buttonWidth, 0.f})) {
+            selected = true;
+        }
+
+        if (wasSelected && scrollToSelected) {
+            DigitizerUi::components::detail::ensureItemVisible();
+        }
+
+        const auto fontSize = ImGui::GetFontSize();
+
+        const auto& matches = filterResult.exactMatches;
+
+        for (std::string_view exactMatch : matches) {
+            assert(exactMatch.data() >= fullSymbolName.data() && exactMatch.data() + exactMatch.size() <= fullSymbolName.data() + fullSymbolName.size());
+
+            const char* matchStart = exactMatch.data();
+            const char* matchEnd   = exactMatch.data() + exactMatch.size();
+            const auto  boxPos     = textCursorInitial + ImVec2{ImGui::CalcTextSize(fullSymbolName.data(), matchStart).x, 0.0};
+            const auto  boxSize    = ImGui::CalcTextSize(matchStart, matchEnd);
+            window->DrawList->AddRectFilled(boxPos, boxPos + boxSize, ImGui::ColorConvertFloat4ToU32(DigitizerUi::LookAndFeel::instance().palette().highlightedSearchResultsBg));
+        }
+
+        ImFont*    font      = DigitizerUi::LookAndFeel::instance().fontNormal[DigitizerUi::LookAndFeel::instance().prototypeMode];
+        const auto textColor = ImGui::ColorConvertFloat4ToU32(ImGui::GetStyle().Colors[ImGuiCol_Text]);
+        window->DrawList->AddText(font, fontSize, textCursorInitial, textColor, fullSymbolName.data(), fullSymbolName.data() + fullSymbolName.size());
+        return selected;
+    }
+};
+
+/// A node in a tree of namespaces (branches) + symbols (leaf nodes). Built each frame based on the full typenames of registered blocks
+struct NamespaceOrSymbol {
+    struct NamespaceTag {};
+
+    struct Namespace {
+        using Pair = std::pair<std::string_view, std::unique_ptr<NamespaceOrSymbol>>;
+        std::vector<Pair> children;
+
+        template<typename... ConstructorArgs>
+        NamespaceOrSymbol* insertOrLeaveExistingElement(std::string_view key, ConstructorArgs&&... args) {
+            auto iter = std::ranges::find(children, key, &Pair::first);
+            if (iter != std::end(children)) {
+                return iter->second.get();
+            }
+            return children.emplace_back(key, std::make_unique<NamespaceOrSymbol>(std::forward<ConstructorArgs>(args)...)).second.get();
+        }
+    };
+
+    NamespaceOrSymbol() = delete;
+    explicit NamespaceOrSymbol(const Symbol& symbol) : variant(symbol) {}
+    explicit NamespaceOrSymbol(NamespaceTag) : variant(Namespace{}) {}
+
+    NamespaceOrSymbol* insertOrFindNameSpaceChild(std::string_view key) { //
+        return nameSpace()->insertOrLeaveExistingElement(key, NamespaceTag{});
+    }
+    void insertElementChild(std::string_view key, std::string_view element, const FilterResult& filter) { //
+        nameSpace()->insertOrLeaveExistingElement(key, Symbol{element, filter});
+    }
+
+    /// If nonempty, the returned string view is the full symbol name of the selected symbol
+    [[nodiscard]] std::string_view drawTreeRecursive(std::string_view currentlySelected, std::string& keyBuffer, bool scrollToSelected, std::optional<bool> newOpenValue) const {
+        std::string_view selected;
+        assert(nameSpace());
+
+        for (const auto& [key, child] : nameSpace()->children) {
+            const auto namespaceCase = [&keyBuffer, key, &newOpenValue, &child, &selected, scrollToSelected, currentlySelected](const Namespace&) {
+                // this is a branch
+                keyBuffer = key;
+                DigitizerUi::IMW::ChangeStrId id(keyBuffer.c_str());
+                if (newOpenValue) {
+                    ImGui::SetNextItemOpen(*newOpenValue);
+                }
+                if (ImGui::TreeNodeEx(keyBuffer.c_str(), ImGuiTreeNodeFlags_SpanAvailWidth | ImGuiTreeNodeFlags_DrawLinesFull)) {
+                    if (auto maybeSelected = child->drawTreeRecursive(currentlySelected, keyBuffer, scrollToSelected, newOpenValue); !maybeSelected.empty()) {
+                        selected = maybeSelected;
+                    }
+                    ImGui::TreePop();
+                }
+            };
+            const auto symbolCase = [currentlySelected, scrollToSelected, &selected](const Symbol& symbol) {
+                if (symbol.draw(currentlySelected, scrollToSelected)) {
+                    selected = symbol.fullSymbolName;
+                }
+            };
+            std::visit(gr::meta::overloaded{namespaceCase, symbolCase}, child->variant);
+        }
+
+        return selected;
+    }
+
+private:
+    Namespace*                      nameSpace() { return std::get_if<Namespace>(&variant); }
+    const Namespace*                nameSpace() const { return std::get_if<Namespace>(&variant); }
+    std::variant<Symbol, Namespace> variant;
+};
 
 namespace DigitizerUi {
+void NewBlockSelector::drawNamespaceTree(const ImVec2& size) {
+    IMW::Child window("##blockSelector", size, ImGuiChildFlags_None, ImGuiWindowFlags_None);
+
+    constexpr const char* clearButtonText  = "Clear";
+    constexpr const char* foldButtonText   = "Fold all";
+    constexpr const char* unfoldButtonText = "Unfold all";
+    const auto            originalCursorX  = ImGui::GetCursorPosX();
+    const auto            buttonStart      = ImGui::GetContentRegionAvail().x - (IMW::CalcAdjacentButtonSizes(std::array{clearButtonText, foldButtonText, unfoldButtonText})).x;
+    bool                  scrollToSelected = false;
+    ImGui::SetCursorPosX(buttonStart);
+    if (ImGui::Button(clearButtonText)) {
+        m_blockFilter.clear();
+        scrollToSelected = true; // more things are visible now that there is no filter
+    }
+    std::optional<bool> newUnfoldedValue;
+    ImGui::SameLine();
+    if (ImGui::Button(foldButtonText)) {
+        newUnfoldedValue = false;
+    }
+    ImGui::SameLine();
+    if (ImGui::Button(unfoldButtonText)) {
+        newUnfoldedValue = true;
+    }
+    ImGui::SameLine();
+    ImGui::SetCursorPosX(originalCursorX);
+
+    ImGui::SetNextItemWidth(buttonStart - ImGui::GetStyle().ItemSpacing.x); // since the InputTextCompletion has no label, this makes sense, otherwise subtract label width + spacing
+
+    if (auto completionNamesView = data | std::views::keys; DigitizerUi::components::InputTextCompletion(completionNamesView).inputText("##filterTypenameType", &m_blockFilter)) {
+        newUnfoldedValue = true; // user typed in the input filter, they probably want to see all matches
+        scrollToSelected = true;
+    }
+    if (!m_wasOpenLastFrame) {
+        ImGui::SetKeyboardFocusHere(-1);
+    }
+
+    struct FilteredEntry {
+        decltype(data)::iterator      originalElement;
+        std::unique_ptr<FilterResult> filterResult;
+
+        [[nodiscard]] constexpr std::string_view blockTypeName() const { return originalElement->first; }
+    };
+
+    // create filter results for every entry in `data`, sorted by relevance. results are
+    // passed when drawing the tree, so as to highlight matching substrings
+    const std::vector<FilteredEntry> filterResults = [this] {
+        std::vector<FilteredEntry> result;
+        result.reserve(this->data.size());
+
+        for (auto iterator = std::begin(this->data); iterator != std::end(this->data); ++iterator) {
+            std::string_view blockType{iterator->first};
+            result.emplace_back(iterator, std::make_unique<FilterResult>(filterTypename(blockType, m_blockFilter)));
+        }
+
+        if (this->m_blockFilter.empty()) {
+            return result;
+        }
+
+        // sort by relevance to the filter query
+        std::ranges::stable_sort(result, std::ranges::greater(), [](const FilteredEntry& entry) { return entry.filterResult->score; });
+
+        // remove all but roughly what will fit on the screen
+        const auto maxEntries = static_cast<std::size_t>(std::ceilf((ImGui::GetContentRegionAvail().y / ImGui::GetTextLineHeightWithSpacing()) / 2.f));
+        if (result.size() > maxEntries) {
+            result.resize(maxEntries);
+        }
+
+        return result;
+    }();
+
+    // if selected element is no longer available, deselect it
+    if (std::ranges::none_of(filterResults, [this](const FilteredEntry& entry) { return entry.blockTypeName() == m_currentlySelectedType; })) {
+        m_currentlySelectedType.clear();
+    }
+
+    auto globalNamespace = std::make_unique<NamespaceOrSymbol>(NamespaceOrSymbol::NamespaceTag{});
+    for (const FilteredEntry& entry : filterResults) {
+        NamespaceOrSymbol* cursor = globalNamespace.get();
+        using namespace std::literals;
+        for (const auto& namespaceElement : entry.blockTypeName() | std::views::split("::"sv)) {
+            if (namespaceElement.end() == entry.blockTypeName().end()) { // last element in thing::thing::thing chain
+                cursor->insertElementChild(std::string_view{namespaceElement}, entry.blockTypeName(), *entry.filterResult);
+            } else {
+                cursor = cursor->insertOrFindNameSpaceChild(std::string_view{namespaceElement});
+            }
+        }
+    }
+
+    std::string tempKeyBuffer;
+    auto        newSelected = globalNamespace->drawTreeRecursive(this->m_currentlySelectedType, tempKeyBuffer, scrollToSelected, newUnfoldedValue);
+    if (!newSelected.empty()) {
+        this->m_currentlySelectedType = newSelected;
+    }
+}
+
 void NewBlockSelector::draw() {
-    auto windowSize = ImGui::GetIO().DisplaySize - ImVec2(32, 32);
+    const auto windowSize = ImGui::GetIO().DisplaySize - ImVec2(32, 32);
     ImGui::SetNextWindowSize(windowSize, ImGuiCond_Once);
     auto x = ImGui::GetCursorPosX();
     ImGui::SetCursorPosX(x + 32);
 
-    if (auto menu = IMW::ModalPopup(m_windowName.c_str(), nullptr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse)) {
-        auto listSize = windowSize - ImVec2(64, 64);
-        listSize.x /= 2;
-        auto ret = components::FilteredListBox("blocks", listSize, data, [index = 0](auto& knownBlockTypesItem) mutable -> std::pair<int, std::string> {
-            index++;
-            return std::pair{index, knownBlockTypesItem.first};
-        });
+    auto menu = IMW::ModalPopup(m_windowName.c_str(), nullptr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+    if (!menu) {
+        m_wasOpenLastFrame = false;
+        return;
+    }
+    Digitizer::utils::scope_exit _([this] { this->m_wasOpenLastFrame = true; });
 
-        // If the type is empty, we treat it as invalid,
-        // but some types might not have parametrizations,
-        // that is their empty parametrization is valid,
-        // so we need std::optional
-        std::string                selectedType;
-        std::optional<std::string> selectedParametrization;
+    auto listSize = windowSize - ImVec2(64, 64);
+    listSize.x /= 2.f;
 
-        if (ret) {
-            selectedType = ret.value().second;
-        }
+    this->drawNamespaceTree(listSize);
 
-        if (!selectedType.empty()) {
-            if (auto typeIt = data.find(selectedType); typeIt != data.cend()) {
-                ImGui::SameLine();
+    // If the type is empty, we treat it as invalid,
+    // but some types might not have parametrizations,
+    // that is their empty parametrization is valid,
+    // so we need std::optional
+    std::optional<std::string> selectedParametrization;
 
-                if (selectedType != m_previouslySelectedType) {
-                    m_previouslySelectedType              = selectedType;
-                    m_selectedTypeParametrizationListName = "parametrizations_for_" + selectedType;
-                }
+    if (!m_currentlySelectedType.empty()) {
+        if (auto typeIt = data.find(m_currentlySelectedType); typeIt != data.cend()) {
+            ImGui::SameLine();
 
-                ret = components::FilteredListBox(m_selectedTypeParametrizationListName.c_str(), listSize, //
-                    typeIt->second, [index = 0](auto& parametrization) mutable -> std::pair<int, std::string> {
-                        index++;
-                        return std::pair{index, parametrization};
-                    });
+            if (m_currentlySelectedType != m_previouslySelectedType) {
+                m_previouslySelectedType              = m_currentlySelectedType;
+                m_selectedTypeParametrizationListName = "parametrizations_for_" + m_currentlySelectedType;
+            }
 
-                if (ret) {
-                    selectedParametrization = ret.value().second;
-                }
+            auto parameterization = components::FilteredListBox(m_selectedTypeParametrizationListName.c_str(), listSize, //
+                typeIt->second, [index = 0](auto& parametrization) mutable -> std::pair<int, std::string> {
+                    index++;
+                    return std::pair{index, parametrization};
+                });
+
+            if (parameterization) {
+                selectedParametrization = parameterization.value().second;
             }
         }
+    }
 
-        if (components::DialogButtons() == components::DialogButton::Ok) {
-            if (!selectedType.empty() && selectedParametrization) {
-                gr::Message message;
-                std::string type    = std::move(selectedType) + selectedParametrization.value_or(std::string());
-                message.cmd         = gr::message::Command::Set;
-                message.endpoint    = gr::scheduler::property::kEmplaceBlock;
-                message.serviceName = m_targetSchedulerUniqueName;
-                message.data        = gr::property_map{{"type", std::move(type)}};
-                if (!m_targetGraphUniqueName.empty()) {
-                    (*message.data)["_targetGraph"] = m_targetGraphUniqueName;
-                }
-                m_graphModel->sendMessage(message);
+    const bool okEnabled = !m_currentlySelectedType.empty();
+    if (components::DialogButtons(okEnabled) == components::DialogButton::Ok) {
+        if (!m_currentlySelectedType.empty() && selectedParametrization) {
+            gr::Message message;
+            std::string type    = std::format("{}{}", m_currentlySelectedType, selectedParametrization.value_or(std::string{}));
+            message.cmd         = gr::message::Command::Set;
+            message.endpoint    = gr::scheduler::property::kEmplaceBlock;
+            message.serviceName = m_targetSchedulerUniqueName;
+            message.data        = gr::property_map{{"type", std::move(type)}};
+            if (!m_targetGraphUniqueName.empty()) {
+                (*message.data)["_targetGraph"] = m_targetGraphUniqueName;
             }
+            m_graphModel->sendMessage(message);
         }
     }
 }

--- a/src/ui/components/NewBlockSelector.hpp
+++ b/src/ui/components/NewBlockSelector.hpp
@@ -1,12 +1,11 @@
 #ifndef OPENDIGITIZER_UI_COMPONENTS_NEW_BLOCK_SELECTOR_HPP_
 #define OPENDIGITIZER_UI_COMPONENTS_NEW_BLOCK_SELECTOR_HPP_
 
+#include <imgui.h>
+
+#include <map>
 #include <set>
 #include <string>
-
-#include <gnuradio-4.0/Message.hpp>
-
-#include "../common/ImguiWrap.hpp"
 
 namespace DigitizerUi {
 
@@ -16,12 +15,17 @@ class NewBlockSelector {
 private:
     std::string m_windowName = "New Block";
 
+    bool        m_wasOpenLastFrame = false;
+    std::string m_blockFilter;
+    std::string m_currentlySelectedType;
     std::string m_previouslySelectedType;
     std::string m_selectedTypeParametrizationListName;
     std::string m_targetSchedulerUniqueName;
     std::string m_targetGraphUniqueName;
 
     UiGraphModel* m_graphModel = nullptr;
+
+    void drawNamespaceTree(const ImVec2& size);
 
 public:
     std::map<std::string, std::set<std::string>> data;

--- a/src/ui/components/NewBlockSelectorFuzzySearch.cpp
+++ b/src/ui/components/NewBlockSelectorFuzzySearch.cpp
@@ -1,0 +1,94 @@
+#include "NewBlockSelectorFuzzySearch.hpp"
+
+#include "tolower.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <ranges>
+
+namespace {
+bool compareChars(char a, char b) { return Digitizer::utils::safe_tolower(a) == Digitizer::utils::safe_tolower(b); }
+} // namespace
+
+namespace DigitizerUi::components {
+std::size_t wordDistance(std::string_view a, std::string_view b) {
+    if (a.size() == 0) {
+        return b.size();
+    }
+    if (b.size() == 0) {
+        return a.size();
+    }
+
+    std::vector<std::size_t> prev(b.size() + 1);
+    std::vector<std::size_t> curr(b.size() + 1);
+
+    for (std::size_t x = 0; x <= b.size(); ++x) {
+        prev[x] = x;
+    }
+
+    for (std::size_t y = 1; y <= a.size(); ++y) {
+        curr[0] = y;
+        for (std::size_t x = 1; x <= b.size(); ++x) {
+            const std::size_t cost     = (compareChars(b[x - 1], a[y - 1])) ? 0 : 1;
+            const std::size_t above    = prev[x] + 1;
+            const std::size_t left     = curr[x - 1] + 1;
+            const std::size_t diagonal = prev[x - 1];
+            curr[x]                    = std::min(std::min(above, left), diagonal + cost);
+        }
+        std::swap(prev, curr);
+    }
+
+    return prev[b.size()];
+}
+
+void FilterResult::addExactMatchesInString(std::string_view string, std::string_view filter) {
+    std::string_view substring = string;
+    while (!substring.empty()) {
+        const auto tolower = [](char c) { return Digitizer::utils::safe_tolower(c); };
+        if (auto match = std::ranges::search(substring, filter, std::ranges::equal_to{}, tolower, tolower); !match.empty()) {
+            assert(match.data() >= substring.data() && match.data() < substring.data() + substring.size());
+
+            exactMatches.emplace_back(match);
+            const auto matchStart = match.data() - substring.data();
+            assert(matchStart >= 0);
+            substring = substring.substr(static_cast<std::size_t>(matchStart) + match.size());
+        } else {
+            break;
+        }
+    }
+}
+
+FilterResult filterTypename(std::string_view typenameString, std::string_view filter) {
+    FilterResult result{};
+    if (filter.empty()) {
+        return result;
+    }
+
+    double bestDistanceBasedScore = 0;
+
+    NamespaceDelimitedSearchIterator typenameIterator{typenameString};
+    while (auto typenameSubString = typenameIterator.next()) {
+        NamespaceDelimitedSearchIterator filterIterator{filter};
+        while (auto filterSubString = filterIterator.next()) {
+            result.addExactMatchesInString(*typenameSubString, *filterSubString);
+
+            const auto distance           = wordDistance(*typenameSubString, *filterSubString);
+            const auto guaranteedDistance = static_cast<std::size_t>(std::abs(static_cast<std::int64_t>(typenameSubString->size()) - static_cast<std::int64_t>(filterSubString->size())));
+            assert(distance >= guaranteedDistance);
+
+            const auto numReplacements = static_cast<double>(distance - guaranteedDistance);
+            const auto inverseWeight   = static_cast<double>(std::min(filterSubString->size(), typenameSubString->size()));
+            const auto scaledDistance  = numReplacements / inverseWeight;
+            assert(numReplacements <= inverseWeight);
+            assert(!filterSubString->empty() && !typenameSubString->empty());
+            bestDistanceBasedScore = std::max(bestDistanceBasedScore, 1.0 - scaledDistance);
+        }
+    }
+
+    result.score = bestDistanceBasedScore + static_cast<double>(result.exactMatches.size());
+
+    return result;
+}
+
+} // namespace DigitizerUi::components

--- a/src/ui/components/NewBlockSelectorFuzzySearch.hpp
+++ b/src/ui/components/NewBlockSelectorFuzzySearch.hpp
@@ -1,0 +1,47 @@
+#ifndef OPENDIGITIZER_COMPONENTS_NEW_BLOCK_SELECTOR_FUZZY_SEARCH_HPP
+#define OPENDIGITIZER_COMPONENTS_NEW_BLOCK_SELECTOR_FUZZY_SEARCH_HPP
+
+#include <cstddef>
+#include <optional>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace DigitizerUi::components {
+
+std::size_t wordDistance(std::string_view a, std::string_view b);
+
+struct FilterResult {
+    std::vector<std::string_view> exactMatches;
+    double                        score = 0.0;
+
+    void addExactMatchesInString(std::string_view string, std::string_view filter);
+};
+
+struct NamespaceDelimitedSearchIterator {
+    std::string_view contents;
+
+    constexpr std::optional<std::string_view> next() {
+        while (!contents.empty() && (contents.front() == ':' || contents.front() == ' ')) {
+            contents = contents.substr(1);
+        }
+
+        std::optional<std::string_view> result;
+        if (!contents.empty()) {
+            const std::size_t maybeNextIndex = std::min(contents.find(':'), contents.find(' '));
+            if (maybeNextIndex >= contents.size()) {
+                return std::exchange(contents, {});
+            }
+
+            result   = contents.substr(0, maybeNextIndex);
+            contents = contents.substr(maybeNextIndex);
+        }
+        return result;
+    }
+};
+
+[[nodiscard]] FilterResult filterTypename(std::string_view typenameString, std::string_view filter);
+
+} // namespace DigitizerUi::components
+
+#endif

--- a/src/ui/test/CMakeLists.txt
+++ b/src/ui/test/CMakeLists.txt
@@ -13,6 +13,11 @@ target_link_libraries(qa_ChartAbstraction PRIVATE ut opendigitizer-uilib)
 target_include_directories(qa_ChartAbstraction PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 add_test(NAME qa_ChartAbstraction COMMAND qa_ChartAbstraction)
 
+add_executable(qa_FuzzySearch qa_FuzzySearch.cpp)
+target_link_libraries(qa_FuzzySearch PRIVATE ut opendigitizer-uilib)
+target_include_directories(qa_FuzzySearch PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+add_test(NAME qa_FuzzySearch COMMAND qa_FuzzySearch)
+
 add_executable(qa_TestSpectrumGenerator qa_TestSpectrumGenerator.cpp)
 target_link_libraries(qa_TestSpectrumGenerator PRIVATE ut gnuradio4::gnuradio-core gnuradio4::gnuradio-blocklib-core)
 target_include_directories(qa_TestSpectrumGenerator PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..

--- a/src/ui/test/qa_FuzzySearch.cpp
+++ b/src/ui/test/qa_FuzzySearch.cpp
@@ -1,0 +1,120 @@
+#include "../components/NewBlockSelectorFuzzySearch.hpp"
+
+#include <boost/ut.hpp>
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+
+using namespace boost::ut;
+using namespace std::string_view_literals;
+using DigitizerUi::components::filterTypename;
+using DigitizerUi::components::wordDistance;
+
+namespace {
+
+double scoreOf(std::string_view block, std::string_view filter) { return filterTypename(block, filter).score; }
+
+template<std::size_t N>
+auto sortByScore(std::array<std::string_view, N> items, std::string_view filter) {
+    std::ranges::stable_sort(items, std::ranges::greater(), [filter](std::string_view item) { return scoreOf(item, filter); });
+    return items;
+}
+
+} // namespace
+
+const static boost::ut::suite<"Levenshtein word distance"> wordDistanceTests = [] {
+    "identical strings have zero distance"_test = [] {
+        expect(eq(wordDistance("hello", "hello"), 0uz));
+        expect(eq(wordDistance("", ""), 0uz));
+        expect(eq(wordDistance("a", "a"), 0uz));
+    };
+
+    "distance to empty string is the string length"_test = [] {
+        expect(eq(wordDistance("abc", ""), 3uz));
+        expect(eq(wordDistance("", "abcd"), 4uz));
+    };
+
+    "single character substitution"_test = [] {
+        expect(eq(wordDistance("cat", "car"), 1uz));
+        expect(eq(wordDistance("cat", "bat"), 1uz));
+    };
+
+    "single character insertion or deletion"_test = [] {
+        expect(eq(wordDistance("cat", "cats"), 1uz));
+        expect(eq(wordDistance("cats", "cat"), 1uz));
+        expect(eq(wordDistance("at", "cat"), 1uz));
+    };
+
+    "completely different strings"_test = [] { //
+        expect(eq(wordDistance("abc", "xyz"), 3uz));
+    };
+
+    "distance is symmetric"_test = [] {
+        expect(eq(wordDistance("kitten", "sitting"), wordDistance("sitting", "kitten")));
+        expect(eq(wordDistance("flaw", "lawn"), wordDistance("lawn", "flaw")));
+    };
+
+    "kitten/sitting example"_test = [] { //
+        expect(eq(wordDistance("kitten", "sitting"), 3uz));
+    };
+};
+
+const static boost::ut::suite<"fuzzy search scoring"> fuzzySearchTests = [] {
+    "progressively worse matches sort in expected order"_test = [] {
+        constexpr std::string_view                filter = "Multiply";
+        constexpr std::array<std::string_view, 4> items  = {"Multiply", "Multipl", "Multaaa", "Zzzzzzz"};
+
+        const auto sorted = sortByScore(items, filter);
+        expect(eq(sorted[0], "Multiply"sv));
+        expect(eq(sorted[1], "Multipl"sv));
+        expect(eq(sorted[2], "Multaaa"sv));
+        expect(eq(sorted[3], "Zzzzzzz"sv));
+    };
+
+    "exact substring match outranks close edit distance"_test = [] {
+        constexpr std::string_view filter = "Sink";
+
+        constexpr std::string_view exactMatch = "gr::basic::DataSink";
+        constexpr std::string_view closeA     = "Sank";
+        constexpr std::string_view closeB     = "Silk";
+        constexpr std::string_view closeC     = "Sint";
+
+        const auto exactScore = scoreOf(exactMatch, filter);
+        expect(gt(exactScore, scoreOf(closeA, filter)));
+        expect(gt(exactScore, scoreOf(closeB, filter)));
+        expect(gt(exactScore, scoreOf(closeC, filter)));
+    };
+
+    "best component of a namespaced identifier wins"_test = [] {
+        constexpr std::string_view filter = "Selector";
+
+        constexpr std::string_view goodComponent = "zz::xx::Selector";
+        constexpr std::string_view mediocre      = "Selecbar::Selectom::sekector";
+
+        expect(gt(scoreOf(goodComponent, filter), scoreOf(mediocre, filter)));
+    };
+
+    "search is case insensitive"_test = [] {
+        constexpr std::string_view filter = "sink";
+
+        const auto lower = scoreOf("DataSink", filter);
+        const auto upper = scoreOf("DATASINK", filter);
+        expect(eq(lower, upper));
+    };
+
+    "empty filter gives zero score"_test = [] { //
+        expect(eq(scoreOf("anything", ""), 0.0));
+    };
+
+    "search happens sections, split by namespace delimiters"_test = [] {
+        constexpr std::string_view filter = "basic::Selector";
+
+        constexpr std::string_view perfect  = "gr::basic::Selector";
+        constexpr std::string_view halfGood = "gr::other::Selector";
+
+        expect(gt(scoreOf(perfect, filter), scoreOf(halfGood, filter)));
+    };
+};
+
+int main() { return 0; }

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -14,7 +14,16 @@ add_library(digitizer_common_utils INTERFACE)
 
 target_include_directories(digitizer_common_utils INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                                                             $<INSTALL_INTERFACE:include>)
-set_target_properties(digitizer_common_utils PROPERTIES PUBLIC_HEADER include/conversion.hpp)
+
+target_sources(
+  digitizer_common_utils
+  PUBLIC FILE_SET
+         HEADERS
+         BASE_DIRS
+         ${CMAKE_CURRENT_SOURCE_DIR}/include/
+         FILES
+         ${CMAKE_CURRENT_SOURCE_DIR}/include/conversion.hpp
+         ${CMAKE_CURRENT_SOURCE_DIR}/include/tolower.hpp)
 
 if(OPENDIGITIZER_ENABLE_TESTING)
   add_subdirectory(test)

--- a/src/utils/include/tolower.hpp
+++ b/src/utils/include/tolower.hpp
@@ -1,0 +1,13 @@
+#ifndef OPENDIGITIZER_UTILS_TOLOWER_H
+#define OPENDIGITIZER_UTILS_TOLOWER_H
+
+#include <cctype>
+
+namespace Digitizer::utils {
+/// std::tolower but it does not exhibit undefined behavior when the char is not representable in an unsigned char
+inline char safe_tolower(char character) { //
+    return static_cast<char>(std::tolower(static_cast<unsigned char>(character)));
+}
+} // namespace Digitizer::utils
+
+#endif


### PR DESCRIPTION
The tree view sorts sibling elements by relevance to the search query and then hides all but a few (about as many as will fit in the screen without scrolling) results.


https://github.com/user-attachments/assets/aaea7c55-c871-46dc-80bb-b47ffe625629

