### PR TITLE
Extend axis label truncation

### DIFF
--- a/src/ui/assets/sampleDashboards/DemoDashboard.grc
+++ b/src/ui/assets/sampleDashboards/DemoDashboard.grc
@@ -1,7 +1,7 @@
 blocks:
   - id: opendigitizer::Arithmetic<float32>
     parameters:
-      name: sum sigs
+      name: sineSum
       ui_constraints:
         x: 30
         y: 40
@@ -13,11 +13,11 @@ blocks:
       unwrapPhase: true
   - id: opendigitizer::SineSource<float32>
     parameters:
-      name: sine source 1
+      name: sineSource1
       frequency: 2
   - id: opendigitizer::SineSource<float32>
     parameters:
-      name: sine source 3
+      name: sineSource2
       frequency: 5
       ui_constraints:
         x: 30
@@ -25,8 +25,22 @@ blocks:
   - id: opendigitizer::ImPlotSink<float32>
     parameters:
       name: sinesSink
-      signal_name: value
+      signal_name: sine2Hz+5Hz
       signal_quantity: sum voltage
+      signal_unit: V
+  - id: opendigitizer::ImPlotSink<float32>
+    parameters:
+      name: sineSink1
+      color: 0x00C800
+      signal_name: sine2Hz
+      signal_quantity: long long sine voltage 1
+      signal_unit: V
+  - id: opendigitizer::ImPlotSink<float32>
+    parameters:
+      name: sineSink2
+      color: 0xC800C8
+      signal_name: sine5Hz
+      signal_quantity: sine voltage 2
       signal_unit: V
   - id: opendigitizer::ImPlotSink<gr::DataSet<float32>>
     parameters:
@@ -175,20 +189,6 @@ blocks:
       signal_name: beam intensity
       signal_quantity: BeamIntensity
       signal_unit: ppp
-  - id: opendigitizer::ImPlotSink<float32>
-    parameters:
-      name: sineSink1
-      color: 0x00C800
-      signal_name: sine 2Hz
-      signal_quantity: voltage
-      signal_unit: V
-  - id: opendigitizer::ImPlotSink<float32>
-    parameters:
-      name: sineSink3
-      color: 0xC800C8
-      signal_name: sine 5Hz
-      signal_quantity: voltage
-      signal_unit: V
   - id: gr::basic::ClockSource
     parameters:
       name: SpectrumClock
@@ -217,33 +217,33 @@ blocks:
       signal_quantity: magnitude
       signal_unit: dB
 connections:
-  - [sine source 1, 0, sum sigs, 0]
-  - [sine source 3, 0, sum sigs, 1]
-  - [ sine source 1, 0, sineSink1, 0 ]
-  - [ sine source 3, 0, sineSink3, 0 ]
-  - [sum sigs, 0, FFT, 0]
-  - [sum sigs, 0, sinesSink, 0]
-  - [FFT, 0, fftSink, 0]
-  - [ClockSource, 0, DipoleCurrentGenerator, 0]
-  - [DipoleCurrentGenerator, 0, DipoleCurrentSink, 0]
-  - [ClockSource, 0, IntensityGenerator, 0]
-  - [IntensityGenerator, 0, IntensitySink, 0]
-  - [SpectrumClock, 0, SpectrumGenerator, 0]
-  - [SpectrumGenerator, 0, spectrumSink, 0]
+  - [ sineSource1, 0, sineSum, 0 ]
+  - [ sineSource2, 0, sineSum, 1 ]
+  - [ sineSource1, 0, sineSink1, 0 ]
+  - [ sineSource2, 0, sineSink2, 0 ]
+  - [ sineSum, 0, FFT, 0 ]
+  - [ sineSum, 0, sinesSink, 0 ]
+  - [ FFT, 0, fftSink, 0 ]
+  - [ ClockSource, 0, DipoleCurrentGenerator, 0 ]
+  - [ DipoleCurrentGenerator, 0, DipoleCurrentSink, 0 ]
+  - [ ClockSource, 0, IntensityGenerator, 0 ]
+  - [ IntensityGenerator, 0, IntensitySink, 0 ]
+  - [ SpectrumClock, 0, SpectrumGenerator, 0 ]
+  - [ SpectrumGenerator, 0, spectrumSink, 0 ]
 dashboard:
   layout: Free
   windowLayout:
-    floatingWindows:  {}
+    floatingWindows: { }
     dockSpace:
       hsplit:
-        second:  "Spectrum View"
+        second: "Spectrum View"
         first:
           vsplit:
-            second:  "Function Generators"
+            second: "Function Generators"
             first:
               hsplit:
-                second:  "FFT Spectrum"
-                first:  "Raw Signal"
+                second: "FFT Spectrum"
+                first: "Raw Signal"
                 ratio: !!float32 0.498815
             ratio: !!float32 0.497561
         ratio: !!float32 0.665091
@@ -260,8 +260,8 @@ dashboard:
       port: 0
     - name: sineSink1
       block: sineSink1
-    - name: sineSink3
-      block: sineSink3
+    - name: sineSink2
+      block: sineSink2
     - name: spectrumSink
       block: spectrumSink
   plots:
@@ -279,6 +279,8 @@ dashboard:
           format: Default # options: Auto, Metric, MetricInline, Scientific, None, Default
       sources:
         - sinesSink
+        - sineSink1
+        - sineSink2
     - name: FFT Spectrum
       axes:
         - axis: X

--- a/src/ui/charts/Chart.hpp
+++ b/src/ui/charts/Chart.hpp
@@ -70,9 +70,20 @@ struct AxisConfig {
     float                    max  = std::numeric_limits<float>::quiet_NaN();
     std::optional<AxisScale> scale;
     LabelFormat              format   = LabelFormat::Auto;
-    float                    width    = std::numeric_limits<float>::max();
+    float                    width    = std::numeric_limits<float>::quiet_NaN();
     bool                     plotTags = true;
 };
+
+inline constexpr float defaultAxisLabelWidth = std::numeric_limits<float>::max();
+
+[[nodiscard]] inline float axisLabelWidthOrDefault(const std::optional<AxisConfig>& config, float defaultWidth = defaultAxisLabelWidth) noexcept { return config && std::isfinite(config->width) ? config->width : defaultWidth; }
+
+[[nodiscard]] inline float defaultAxisLabelWidthFor(ImAxis axisId, const ImVec2& plotSize) noexcept {
+    constexpr float labelBudgetFraction = 0.9f;
+    const bool      isX                 = axisId == ImAxis_X1 || axisId == ImAxis_X2 || axisId == ImAxis_X3;
+    const float     axisExtent          = isX ? plotSize.x : plotSize.y;
+    return std::isfinite(axisExtent) && axisExtent > 0.f ? axisExtent * labelBudgetFraction : defaultAxisLabelWidth;
+}
 
 struct LogFreqRange {
     double min;
@@ -147,6 +158,11 @@ struct LogFreqRange {
         if (auto it = axisMap->find("format"); it != axisMap->end()) {
             if (it->second.is_string()) {
                 cfg.format = magic_enum::enum_cast<LabelFormat>(it->second.value_or(std::string()), magic_enum::case_insensitive).value_or(LabelFormat::Auto);
+            }
+        }
+        if (auto it = axisMap->find("width"); it != axisMap->end()) {
+            if (auto v = gr::pmt::convert_safely<float>(it->second); v) {
+                cfg.width = *v;
             }
         }
         if (auto it = axisMap->find("plot_tags"); it != axisMap->end()) {
@@ -288,6 +304,9 @@ inline int formatDefault(double value, char* buff, int size, void* data) {
 }
 
 inline std::string truncateLabel(std::string_view original, float availableWidth) {
+    if (!std::isfinite(availableWidth) || availableWidth <= 0.f) {
+        return std::string(original);
+    }
     const float textWidth = ImGui::CalcTextSize(original.data()).x;
     if (textWidth <= availableWidth) {
         return std::string(original);
@@ -1056,7 +1075,7 @@ struct Chart {
     }
 
     template<typename Self>
-    void setupSingleAxis(this Self& self, bool isX, ImAxis axisId, bool showGrid, LabelFormat defaultFormat = LabelFormat::Auto, bool foreground = false, std::optional<ImPlotCond> condOverride = std::nullopt, std::optional<AxisScale> scaleOverride = std::nullopt) {
+    void setupSingleAxis(this Self& self, bool isX, ImAxis axisId, const ImVec2& plotSize, bool showGrid, LabelFormat defaultFormat = LabelFormat::Auto, bool foreground = false, std::optional<ImPlotCond> condOverride = std::nullopt, std::optional<AxisScale> scaleOverride = std::nullopt) {
         const auto      dashCfg = parseAxisConfig(self.ui_constraints.value, isX);
         const AxisScale scale   = scaleOverride.value_or(dashCfg ? dashCfg->scale.value_or(AxisScale::Linear) : AxisScale::Linear);
         const auto      format  = dashCfg ? dashCfg->format : defaultFormat;
@@ -1077,7 +1096,7 @@ struct Chart {
         auto [quantity, unit] = self.sinkAxisInfo(isX);
         AxisCategory cat{.quantity = quantity, .unit = unit};
         auto         cond = condOverride.value_or(self.trackLimitsCond(isX, minLimit, maxLimit));
-        axis::setupAxis(axisId, cat, format, 100.f, minLimit, maxLimit, 1UZ, scale, self._unitStore, showGrid, foreground, cond);
+        axis::setupAxis(axisId, cat, format, axisLabelWidthOrDefault(dashCfg, defaultAxisLabelWidthFor(axisId, plotSize)), minLimit, maxLimit, 1UZ, scale, self._unitStore, showGrid, foreground, cond);
     }
 
     ImPlotCond trackLimitsCond(bool isX, double newMin, double newMax, std::size_t axisIdx = 0UZ) {

--- a/src/ui/charts/SpectrumDensity.hpp
+++ b/src/ui/charts/SpectrumDensity.hpp
@@ -93,7 +93,7 @@ struct SpectrumDensity : gr::Block<SpectrumDensity, gr::Drawable<gr::UICategory:
             return gr::work::Status::OK;
         }
 
-        setupAxes(showGrid);
+        setupAxes(plotSize, showGrid);
         ImPlot::SetupFinish();
 
         // detect user zoom on Y-axis: if auto-fit is active and the actual plot limits
@@ -148,7 +148,7 @@ struct SpectrumDensity : gr::Block<SpectrumDensity, gr::Drawable<gr::UICategory:
         return {yMin, yMax};
     }
 
-    void setupAxes(bool showGrid) {
+    void setupAxes(const ImVec2& plotSize, bool showGrid) {
         // x-axis: frequency
         {
             const auto      dashCfg = parseAxisConfig(this->ui_constraints.value, true);
@@ -168,7 +168,7 @@ struct SpectrumDensity : gr::Block<SpectrumDensity, gr::Drawable<gr::UICategory:
 
             auto [xQuantity, xUnit] = sinkAxisInfo(true);
             AxisCategory xCat{.quantity = xQuantity, .unit = xUnit};
-            axis::setupAxis(ImAxis_X1, xCat, format, 100.f, minLimit, maxLimit, 1UZ, scale, _unitStore, showGrid, /*foreground=*/true);
+            axis::setupAxis(ImAxis_X1, xCat, format, axisLabelWidthOrDefault(dashCfg, defaultAxisLabelWidthFor(ImAxis_X1, plotSize)), minLimit, maxLimit, 1UZ, scale, _unitStore, showGrid, /*foreground=*/true);
         }
 
         // y-axis: amplitude — always use finite limits because the heatmap provides no
@@ -192,7 +192,7 @@ struct SpectrumDensity : gr::Block<SpectrumDensity, gr::Drawable<gr::UICategory:
             _yLimitsForceApplied = limitsChanged;
 
             AxisCategory yCat{.quantity = yQuantity, .unit = yUnit};
-            axis::setupAxis(ImAxis_Y1, yCat, format, 100.f, minLimit, maxLimit, 1UZ, scale, _unitStore, showGrid, /*foreground=*/true, limitCond);
+            axis::setupAxis(ImAxis_Y1, yCat, format, axisLabelWidthOrDefault(dashCfg, defaultAxisLabelWidthFor(ImAxis_Y1, plotSize)), minLimit, maxLimit, 1UZ, scale, _unitStore, showGrid, /*foreground=*/true, limitCond);
         }
     }
 

--- a/src/ui/charts/SpectrumPlot.hpp
+++ b/src/ui/charts/SpectrumPlot.hpp
@@ -81,7 +81,7 @@ struct SpectrumPlot : gr::Block<SpectrumPlot, gr::Drawable<gr::UICategory::Conte
             return gr::work::Status::OK;
         }
 
-        setupAxes(showGrid);
+        setupAxes(plotSize, showGrid);
         ImPlot::SetupFinish();
         drawSpectrumSignals();
         tooltip::showPlotMouseTooltip();
@@ -96,9 +96,9 @@ struct SpectrumPlot : gr::Block<SpectrumPlot, gr::Drawable<gr::UICategory::Conte
         _lastSampleCountPerSink.clear();
     }
 
-    void setupAxes(bool showGrid) {
-        setupSingleAxis(true, ImAxis_X1, showGrid, LabelFormat::MetricInline);
-        setupSingleAxis(false, ImAxis_Y1, showGrid);
+    void setupAxes(const ImVec2& plotSize, bool showGrid) {
+        setupSingleAxis(true, ImAxis_X1, plotSize, showGrid, LabelFormat::MetricInline);
+        setupSingleAxis(false, ImAxis_Y1, plotSize, showGrid);
     }
 
     void drawSpectrumSignals() {

--- a/src/ui/charts/SpectrumView.hpp
+++ b/src/ui/charts/SpectrumView.hpp
@@ -146,17 +146,18 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
             return gr::work::Status::OK;
         }
 
-        drawTopPane(plotFlags, showGrid, chartMode);
-        drawBottomPane(plotFlags, showGrid);
+        drawTopPane(plotFlags, plotSize, showGrid, chartMode);
+        drawBottomPane(plotFlags, plotSize, showGrid);
 
         ImPlot::EndSubplots();
         return gr::work::Status::OK;
     }
 
-    void setupFrequencyAxis(bool showGrid) { setupSingleAxis(true, ImAxis_X1, showGrid, LabelFormat::MetricInline, /*foreground=*/true, _sharedXCond); }
+    void setupFrequencyAxis(const ImVec2& plotSize, bool showGrid) { setupSingleAxis(true, ImAxis_X1, plotSize, showGrid, LabelFormat::MetricInline, /*foreground=*/true, _sharedXCond); }
 
-    void drawTopPane(ImPlotFlags plotFlags, bool showGrid, ChartMode chartMode) {
-        const bool isDensity = (top_pane_mode.value == TopPaneMode::Density);
+    void drawTopPane(ImPlotFlags plotFlags, const ImVec2& plotSize, bool showGrid, ChartMode chartMode) {
+        const bool   isDensity = (top_pane_mode.value == TopPaneMode::Density);
+        const ImVec2 paneSize{plotSize.x, plotSize.y * _rowRatios[0]};
 
         ImGui::PushID("top");
         if (isDensity) {
@@ -165,8 +166,8 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
 
         ImPlot::PushStyleVar(ImPlotStyleVar_FitPadding, ImVec2{0.0f, 0.05f});
         if (ImPlot::BeginPlot("##spectrum", ImVec2(0, 0), plotFlags)) {
-            setupFrequencyAxis(showGrid);
-            setupMagnitudeAxis(showGrid);
+            setupFrequencyAxis(paneSize, showGrid);
+            setupMagnitudeAxis(paneSize, showGrid);
             ImPlot::SetupFinish();
 
             if (isDensity) {
@@ -192,7 +193,7 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
         ImGui::PopID();
     }
 
-    void setupMagnitudeAxis(bool showGrid) { setupSingleAxis(false, ImAxis_Y1, showGrid); }
+    void setupMagnitudeAxis(const ImVec2& plotSize, bool showGrid) { setupSingleAxis(false, ImAxis_Y1, plotSize, showGrid); }
 
     void drawSpectrumSignals() {
         forEachValidSpectrum(_signalSinks, [&](const auto& sink, const SpectrumFrame& f) {
@@ -240,13 +241,15 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
         });
     }
 
-    void drawBottomPane(ImPlotFlags plotFlags, bool showGrid) {
+    void drawBottomPane(ImPlotFlags plotFlags, const ImVec2& plotSize, bool showGrid) {
+        const ImVec2 paneSize{plotSize.x, plotSize.y * _rowRatios[1]};
+
         ImGui::PushID("bottom");
         ImPlot::PushStyleColor(ImPlotCol_AxisGrid, contrastingGridColor(colormap.value));
         ImPlot::PushStyleVar(ImPlotStyleVar_FitPadding, ImVec2{0.0f, 0.05f});
 
         if (ImPlot::BeginPlot("##waterfall", ImVec2(0, 0), plotFlags | ImPlotFlags_NoLegend)) {
-            setupBottomFrequencyAxis(showGrid);
+            setupBottomFrequencyAxis(paneSize, showGrid);
             setupWaterfallYAxis(showGrid);
 
             auto renderInfo = fetchAndPushData();
@@ -278,7 +281,7 @@ struct SpectrumView : gr::Block<SpectrumView, gr::Drawable<gr::UICategory::Conte
         ImGui::PopID();
     }
 
-    void setupBottomFrequencyAxis(bool showGrid) { setupSingleAxis(true, ImAxis_X1, showGrid, LabelFormat::None, /*foreground=*/true, _sharedXCond); }
+    void setupBottomFrequencyAxis(const ImVec2& plotSize, bool showGrid) { setupSingleAxis(true, ImAxis_X1, plotSize, showGrid, LabelFormat::None, /*foreground=*/true, _sharedXCond); }
 
     void setupWaterfallYAxis(bool showGrid) {
         ImPlotAxisFlags yFlags = (showGrid ? ImPlotAxisFlags_None : ImPlotAxisFlags_NoGridLines) | ImPlotAxisFlags_Foreground;

--- a/src/ui/charts/WaterfallPlot.hpp
+++ b/src/ui/charts/WaterfallPlot.hpp
@@ -108,7 +108,7 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
         }
 
         // phase 1: set up axes (X fully, Y skeleton without limits)
-        setupAxes(showGrid);
+        setupAxes(plotSize, showGrid);
 
         // phase 2: fetch new data and push into waterfall (skips duplicate frames)
         auto renderInfo = fetchAndPushData();
@@ -172,7 +172,7 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
         return static_cast<int>(result.out - buff);
     }
 
-    void setupAxes(bool showGrid) {
+    void setupAxes(const ImVec2& plotSize, bool showGrid) {
         // frequency keeps the "X" dashboard entry, time the "Y" entry; orientation only rotates which screen axis each uses
         const bool   horizontal = orientation.value == WaterfallOrientation::Horizontal;
         const ImAxis freqAxis   = horizontal ? ImAxis_Y1 : ImAxis_X1;
@@ -193,7 +193,7 @@ struct WaterfallPlot : gr::Block<WaterfallPlot, gr::Drawable<gr::UICategory::Con
 
             auto [xQuantity, xUnit] = sinkAxisInfo(true);
             AxisCategory xCat{.quantity = xQuantity, .unit = xUnit};
-            axis::setupAxis(freqAxis, xCat, format, 100.f, minLimit, maxLimit, 1, scale, _unitStore, showGrid, /*foreground=*/true);
+            axis::setupAxis(freqAxis, xCat, format, axisLabelWidthOrDefault(dashCfg, defaultAxisLabelWidthFor(freqAxis, plotSize)), minLimit, maxLimit, 1, scale, _unitStore, showGrid, /*foreground=*/true);
         }
 
         // time axis — limits are set in draw() after data push so axis and image stay synchronised.

--- a/src/ui/charts/XYChart.hpp
+++ b/src/ui/charts/XYChart.hpp
@@ -98,7 +98,7 @@ struct XYChart : gr::Block<XYChart, gr::Drawable<gr::UICategory::Content, "ImGui
             return gr::work::Status::OK;
         }
 
-        setupAxes(showGrid);
+        setupAxes(plotSize, showGrid);
         ImPlot::SetupFinish();
         drawSignals();
         tooltip::showPlotMouseTooltip();
@@ -122,11 +122,9 @@ struct XYChart : gr::Block<XYChart, gr::Drawable<gr::UICategory::Content, "ImGui
         }
     }
 
-    void setupAxes(bool showGrid = true) {
-        constexpr float   xAxisWidth = 100.f;
-        constexpr float   yAxisWidth = 100.f;
-        const std::size_t nAxesX     = axis::activeAxisCount(_xCategories);
-        const std::size_t nAxesY     = axis::activeAxisCount(_yCategories);
+    void setupAxes(const ImVec2& plotSize, bool showGrid = true) {
+        const std::size_t nAxesX = axis::activeAxisCount(_xCategories);
+        const std::size_t nAxesY = axis::activeAxisCount(_yCategories);
 
         for (std::size_t i = 0; i < _xCategories.size(); ++i) {
             const auto dashCfg = parseAxisConfig(this->ui_constraints.value, true, i);
@@ -141,7 +139,8 @@ struct XYChart : gr::Block<XYChart, gr::Drawable<gr::UICategory::Content, "ImGui
             }
 
             const LabelFormat format = dashCfg ? dashCfg->format : LabelFormat::Auto;
-            const float       width  = dashCfg && std::isfinite(dashCfg->width) ? dashCfg->width : xAxisWidth;
+            const auto        axisId = ImAxis_X1 + static_cast<int>(i);
+            const float       width  = axisLabelWidthOrDefault(dashCfg, defaultAxisLabelWidthFor(axisId, plotSize));
             const AxisScale   scale  = dashCfg ? dashCfg->scale.value_or(AxisScale::Linear) : AxisScale::Linear;
 
             if (_xCategories[i].has_value()) {
@@ -149,7 +148,7 @@ struct XYChart : gr::Block<XYChart, gr::Drawable<gr::UICategory::Content, "ImGui
             }
 
             auto xCond = trackLimitsCond(true, minLimit, maxLimit, i);
-            axis::setupAxis(ImAxis_X1 + static_cast<int>(i), _xCategories[i], format, width, minLimit, maxLimit, nAxesX, scale, _unitStringStorage, showGrid, /*foreground=*/false, xCond);
+            axis::setupAxis(axisId, _xCategories[i], format, width, minLimit, maxLimit, nAxesX, scale, _unitStringStorage, showGrid, /*foreground=*/false, xCond);
         }
 
         for (std::size_t i = 0; i < _yCategories.size(); ++i) {
@@ -165,7 +164,8 @@ struct XYChart : gr::Block<XYChart, gr::Drawable<gr::UICategory::Content, "ImGui
             }
 
             const LabelFormat format = dashCfg ? dashCfg->format : LabelFormat::Auto;
-            const float       width  = dashCfg && std::isfinite(dashCfg->width) ? dashCfg->width : yAxisWidth;
+            const auto        axisId = ImAxis_Y1 + static_cast<int>(i);
+            const float       width  = axisLabelWidthOrDefault(dashCfg, defaultAxisLabelWidthFor(axisId, plotSize));
             const AxisScale   scale  = dashCfg ? dashCfg->scale.value_or(AxisScale::Linear) : AxisScale::Linear;
 
             if (_yCategories[i].has_value()) {
@@ -173,7 +173,7 @@ struct XYChart : gr::Block<XYChart, gr::Drawable<gr::UICategory::Content, "ImGui
             }
 
             auto yCond = trackLimitsCond(false, minLimit, maxLimit, i);
-            axis::setupAxis(ImAxis_Y1 + static_cast<int>(i), _yCategories[i], format, width, minLimit, maxLimit, nAxesY, scale, _unitStringStorage, showGrid, /*foreground=*/false, yCond);
+            axis::setupAxis(axisId, _yCategories[i], format, width, minLimit, maxLimit, nAxesY, scale, _unitStringStorage, showGrid, /*foreground=*/false, yCond);
         }
     }
 

--- a/src/ui/charts/YYChart.hpp
+++ b/src/ui/charts/YYChart.hpp
@@ -121,18 +121,20 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
 
         // X-axis: Time, Y-axis: signal name with unit
         {
-            AxisScale xScale    = static_cast<AxisScale>(x_axis_scale.value);
-            double    xMinLimit = x_auto_scale.value[0] ? std::numeric_limits<double>::quiet_NaN() : x_min.value[0];
-            double    xMaxLimit = x_auto_scale.value[0] ? std::numeric_limits<double>::quiet_NaN() : x_max.value[0];
-            auto      xCond     = trackLimitsCond(true, xMinLimit, xMaxLimit);
-            axis::setupAxis(ImAxis_X1, AxisCategory{.quantity = "Time", .unit = "s"}, LabelFormat::Auto, 100.f, xMinLimit, xMaxLimit, 1UZ, xScale, _unitStringStorage, showGrid, /*foreground=*/false, xCond);
+            const auto xDashCfg  = parseAxisConfig(this->ui_constraints.value, true);
+            AxisScale  xScale    = static_cast<AxisScale>(x_axis_scale.value);
+            double     xMinLimit = x_auto_scale.value[0] ? std::numeric_limits<double>::quiet_NaN() : x_min.value[0];
+            double     xMaxLimit = x_auto_scale.value[0] ? std::numeric_limits<double>::quiet_NaN() : x_max.value[0];
+            auto       xCond     = trackLimitsCond(true, xMinLimit, xMaxLimit);
+            axis::setupAxis(ImAxis_X1, AxisCategory{.quantity = "Time", .unit = "s"}, LabelFormat::Auto, axisLabelWidthOrDefault(xDashCfg, defaultAxisLabelWidthFor(ImAxis_X1, size)), xMinLimit, xMaxLimit, 1UZ, xScale, _unitStringStorage, showGrid, /*foreground=*/false, xCond);
 
+            const auto   yDashCfg  = parseAxisConfig(this->ui_constraints.value, false);
             AxisScale    yScale    = static_cast<AxisScale>(y_axis_scale.value);
             double       yMinLimit = y_auto_scale.value[0] ? std::numeric_limits<double>::quiet_NaN() : y_min.value[0];
             double       yMaxLimit = y_auto_scale.value[0] ? std::numeric_limits<double>::quiet_NaN() : y_max.value[0];
             auto         yCond     = trackLimitsCond(false, yMinLimit, yMaxLimit);
             AxisCategory yCat{.quantity = std::string(sinkPtr->signalQuantity()), .unit = std::string(sinkPtr->signalUnit()), .color = sinkPtr->color()};
-            axis::setupAxis(ImAxis_Y1, yCat, LabelFormat::Auto, 100.f, yMinLimit, yMaxLimit, 1UZ, yScale, _unitStringStorage, showGrid, /*foreground=*/false, yCond);
+            axis::setupAxis(ImAxis_Y1, yCat, LabelFormat::Auto, axisLabelWidthOrDefault(yDashCfg, defaultAxisLabelWidthFor(ImAxis_Y1, size)), yMinLimit, yMaxLimit, 1UZ, yScale, _unitStringStorage, showGrid, /*foreground=*/false, yCond);
         }
         ImPlot::SetupFinish();
 
@@ -207,19 +209,21 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
 
         // Build axis categories from sink metadata
         {
+            const auto   xDashCfg  = parseAxisConfig(this->ui_constraints.value, true);
             AxisScale    xScale    = static_cast<AxisScale>(x_axis_scale.value);
             double       xMinLimit = x_auto_scale.value[0] ? std::numeric_limits<double>::quiet_NaN() : x_min.value[0];
             double       xMaxLimit = x_auto_scale.value[0] ? std::numeric_limits<double>::quiet_NaN() : x_max.value[0];
             auto         xCond     = trackLimitsCond(true, xMinLimit, xMaxLimit);
             AxisCategory xCat{.quantity = sinkXPtr->signalQuantity().empty() ? std::string(sinkXPtr->signalName()) : std::string(sinkXPtr->signalQuantity()), .unit = std::string(sinkXPtr->signalUnit()), .color = sinkXPtr->color()};
-            axis::setupAxis(ImAxis_X1, xCat, LabelFormat::Auto, 100.f, xMinLimit, xMaxLimit, 1UZ, xScale, _unitStringStorage, showGrid, /*foreground=*/false, xCond);
+            axis::setupAxis(ImAxis_X1, xCat, LabelFormat::Auto, axisLabelWidthOrDefault(xDashCfg, defaultAxisLabelWidthFor(ImAxis_X1, size)), xMinLimit, xMaxLimit, 1UZ, xScale, _unitStringStorage, showGrid, /*foreground=*/false, xCond);
 
+            const auto   yDashCfg  = parseAxisConfig(this->ui_constraints.value, false);
             AxisScale    yScale    = static_cast<AxisScale>(y_axis_scale.value);
             double       yMinLimit = y_auto_scale.value[0] ? std::numeric_limits<double>::quiet_NaN() : y_min.value[0];
             double       yMaxLimit = y_auto_scale.value[0] ? std::numeric_limits<double>::quiet_NaN() : y_max.value[0];
             auto         yCond     = trackLimitsCond(false, yMinLimit, yMaxLimit);
             AxisCategory yCat{.quantity = sinkYPtr->signalQuantity().empty() ? std::string(sinkYPtr->signalName()) : std::string(sinkYPtr->signalQuantity()), .unit = std::string(sinkYPtr->signalUnit()), .color = sinkYPtr->color()};
-            axis::setupAxis(ImAxis_Y1, yCat, LabelFormat::Auto, 100.f, yMinLimit, yMaxLimit, 1UZ, yScale, _unitStringStorage, showGrid, /*foreground=*/false, yCond);
+            axis::setupAxis(ImAxis_Y1, yCat, LabelFormat::Auto, axisLabelWidthOrDefault(yDashCfg, defaultAxisLabelWidthFor(ImAxis_Y1, size)), yMinLimit, yMaxLimit, 1UZ, yScale, _unitStringStorage, showGrid, /*foreground=*/false, yCond);
         }
         ImPlot::SetupFinish();
 
@@ -314,11 +318,12 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
         // X-axis from sink[0]'s signal metadata (no data lock needed for metadata accessors)
         {
             std::optional<AxisCategory> xCategory = AxisCategory{.quantity = sinkXPtr->signalQuantity().empty() ? std::string(sinkXPtr->signalName()) : std::string(sinkXPtr->signalQuantity()), .unit = std::string(sinkXPtr->signalUnit()), .color = sinkXPtr->color()};
+            const auto                  xDashCfg  = parseAxisConfig(this->ui_constraints.value, true);
             AxisScale                   xScale    = static_cast<AxisScale>(x_axis_scale.value);
             double                      xMinLimit = x_auto_scale.value[0] ? std::numeric_limits<double>::quiet_NaN() : x_min.value[0];
             double                      xMaxLimit = x_auto_scale.value[0] ? std::numeric_limits<double>::quiet_NaN() : x_max.value[0];
             auto                        xCond     = trackLimitsCond(true, xMinLimit, xMaxLimit);
-            axis::setupAxis(ImAxis_X1, xCategory, LabelFormat::Auto, 100.f, xMinLimit, xMaxLimit, 1UZ, xScale, _unitStringStorage, showGrid, /*foreground=*/false, xCond);
+            axis::setupAxis(ImAxis_X1, xCategory, LabelFormat::Auto, axisLabelWidthOrDefault(xDashCfg, defaultAxisLabelWidthFor(ImAxis_X1, size)), xMinLimit, xMaxLimit, 1UZ, xScale, _unitStringStorage, showGrid, /*foreground=*/false, xCond);
         }
 
         // Y-axes (up to 3) grouped by quantity+unit
@@ -327,10 +332,12 @@ struct YYChart : gr::Block<YYChart, gr::Drawable<gr::UICategory::Content, "ImGui
             if (!yCategories[i].has_value()) {
                 continue;
             }
-            double yMinLimit = y_auto_scale.value[i] ? std::numeric_limits<double>::quiet_NaN() : y_min.value[i];
-            double yMaxLimit = y_auto_scale.value[i] ? std::numeric_limits<double>::quiet_NaN() : y_max.value[i];
-            auto   yCond     = trackLimitsCond(false, yMinLimit, yMaxLimit, i);
-            axis::setupAxis(ImAxis_Y1 + static_cast<int>(i), yCategories[i], LabelFormat::Auto, 100.f, yMinLimit, yMaxLimit, nYAxes, yScale, _unitStringStorage, showGrid, /*foreground=*/false, yCond);
+            double     yMinLimit = y_auto_scale.value[i] ? std::numeric_limits<double>::quiet_NaN() : y_min.value[i];
+            double     yMaxLimit = y_auto_scale.value[i] ? std::numeric_limits<double>::quiet_NaN() : y_max.value[i];
+            auto       yCond     = trackLimitsCond(false, yMinLimit, yMaxLimit, i);
+            auto       yDashCfg  = parseAxisConfig(this->ui_constraints.value, false, i);
+            const auto axisId    = ImAxis_Y1 + static_cast<int>(i);
+            axis::setupAxis(axisId, yCategories[i], LabelFormat::Auto, axisLabelWidthOrDefault(yDashCfg, defaultAxisLabelWidthFor(axisId, size)), yMinLimit, yMaxLimit, nYAxes, yScale, _unitStringStorage, showGrid, /*foreground=*/false, yCond);
         }
 
         ImPlot::SetupFinish();


### PR DESCRIPTION
* Use a plot-size based label budget instead of the fixed 100 px fallback.
* Axis labels now default to 90% of the visible plot extent, using plot width for X axes and plot height for Y axes.
* Explicit axis width config still overrides the automatic budget.
<img width="45%"  alt="Screenshot From 2026-06-17 15-41-48" src="https://github.com/user-attachments/assets/873c40a9-e45f-4d60-8bfe-0faa82eb1616" />
<img width="45%" alt="Screenshot From 2026-06-17 15-42-13" src="https://github.com/user-attachments/assets/dc927827-7183-4e97-96f0-46b35976e69b" />

