### PR TITLE
Fix all OD warnings + treat warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ if(USE_DWARF4)
 endif()
 
 option(OPENDIGITIZER_ENABLE_TESTING "Enable unit tests" ON)
+option(OPENDIGITIZER_WARNINGS_AS_ERRORS "Treat OpenDigitizer compiler warnings as errors" ON)
 
 # Set proper default for ENABLE_IMGUI_TEST_ENGINE, the idea is:
 
@@ -60,10 +61,10 @@ include(cmake/StandardProjectSettings.cmake)
 include(cmake/PreventInSourceBuilds.cmake)
 include(cmake/Cache.cmake) # enable cache system
 include(cmake/CMakeRC.cmake)
-add_library(project_warnings INTERFACE) # Link this 'library' to use the warnings specified in CompilerWarnings.cmake
+add_library(opendigitizer-options INTERFACE)
 # standard compiler warnings
 include(cmake/CompilerWarnings.cmake)
-set_project_warnings(project_warnings)
+set_project_warnings(opendigitizer-options)
 
 if(NOT EMSCRIPTEN)
   add_subdirectory(src/acquisition)
@@ -93,7 +94,8 @@ if(NOT DISABLE_WASM_BUILD)
       ${EMCMAKE_COMMAND} ${CMAKE_COMMAND} -G "Unix Makefiles" -S ${CMAKE_SOURCE_DIR}/src/ui -B ${BUILD_DIR}/ui-wasm
       -DCMAKE_PREFIX_PATH:STRING=${_wasm_cmake_prefix_path} -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
       -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE} -DCMAKE_MAKE_PROGRAM=${CMAKE_SOURCE_DIR}/emmake_make.sh
-      -DGNURADIO_PARSE_REGISTRATIONS_TOOL_CXX_COMPLILER=${CMAKE_CXX_COMPILER} ${OD_WASM_CMAKE_OPTIONS}
+      -DGNURADIO_PARSE_REGISTRATIONS_TOOL_CXX_COMPLILER=${CMAKE_CXX_COMPILER}
+      -DOPENDIGITIZER_WARNINGS_AS_ERRORS=${OPENDIGITIZER_WARNINGS_AS_ERRORS} ${OD_WASM_CMAKE_OPTIONS}
     BUILD_COMMAND cmake --build ${BUILD_DIR}/ui-wasm
     BINARY_DIR ${BUILD_DIR}/ui-wasm
     BUILD_ALWAYS 1

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -3,8 +3,6 @@
 # https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md
 
 function(set_project_warnings project_name)
-  option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" FALSE) #TODO: re-enable as soon as the refl-cpp macro issue is fixed https://github.com/veselink1/refl-cpp/issues/63
-
   set(MSVC_WARNINGS
       /W4 # Baseline reasonable warnings
       /w14242 # 'identifier': conversion from 'type1' to 'type1', possible loss of data
@@ -50,7 +48,7 @@ function(set_project_warnings project_name)
       -Wno-unknown-pragmas # ignore IDE, GCC/CLANG specific pragmas
   )
 
-  if(WARNINGS_AS_ERRORS)
+  if(OPENDIGITIZER_WARNINGS_AS_ERRORS)
     set(CLANG_WARNINGS ${CLANG_WARNINGS} -Werror)
     set(MSVC_WARNINGS ${MSVC_WARNINGS} /WX)
   endif()
@@ -77,6 +75,6 @@ function(set_project_warnings project_name)
     message(AUTHOR_WARNING "No compiler warnings set for '${CMAKE_CXX_COMPILER_ID}' compiler.")
   endif()
 
-  target_compile_options(${project_name} INTERFACE ${PROJECT_WARNINGS})
+  target_compile_options(${project_name} INTERFACE $<BUILD_INTERFACE:${PROJECT_WARNINGS}>)
 
 endfunction()

--- a/src/acquisition/daq_api.hpp
+++ b/src/acquisition/daq_api.hpp
@@ -63,9 +63,18 @@ inline std::expected<flowgraph::Flowgraph, std::string> getFlowgraphFromMessage(
 
 } // namespace opendigitizer::flowgraph
 
+#if defined(__EMSCRIPTEN__) && defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc2y-extensions" // refl-cpp uses __COUNTER__ issue
+#endif
+
 ENABLE_REFLECTION_FOR(opendigitizer::flowgraph::FilterContext, contentType)
 ENABLE_REFLECTION_FOR(opendigitizer::flowgraph::Flowgraph, serialisedFlowgraph, serialisedUiLayout)
 ENABLE_REFLECTION_FOR(opendigitizer::flowgraph::SerialisedFlowgraphMessage, data);
+
+#if defined(__EMSCRIPTEN__) && defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 namespace opendigitizer::gnuradio {
 // Yaml to gr::message and back, TODO should be moved to GR
@@ -232,6 +241,12 @@ struct FreqDomainContext {
 };
 
 } // namespace opendigitizer::acq
+
+#if defined(__EMSCRIPTEN__) && defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc2y-extensions" // refl-cpp uses __COUNTER__ issue
+#endif
+
 ENABLE_REFLECTION_FOR(opendigitizer::acq::Acquisition, refTriggerName, refTriggerStamp, channelTimeSinceRefTrigger, channelUserDelay, channelActualDelay, channelNames, channelValues, channelErrors, channelQuantities, //
     channelUnits, status, channelRangeMin, channelRangeMax, temperature, processIndex, sequenceIndex, chainIndex, eventNumber, timingGroupID, acquisitionStamp, eventStamp, processStartStamp, sequenceStartStamp,       //
     chainStartStamp, acqLocalTimeStamp, triggerIndices, triggerEventNames, triggerTimestamps, triggerOffsets, triggerYamlPropertyMaps, acqErrors)
@@ -239,5 +254,9 @@ ENABLE_REFLECTION_FOR(opendigitizer::acq::AcquisitionSpectra, selectedFilter, ac
     channelMagnitude_dim1_labels, channelMagnitude_dim2_labels, channelPhase, channelPhase_labels, channelPhase_dim1_labels, channelPhase_dim2_labels)
 ENABLE_REFLECTION_FOR(opendigitizer::acq::TimeDomainContext, channelNameFilter, acquisitionModeFilter, triggerNameFilter, maxClientUpdateFrequencyFilter, preSamples, postSamples, maximumWindowSize, snapshotDelay, contentType)
 ENABLE_REFLECTION_FOR(opendigitizer::acq::FreqDomainContext, channelNameFilter, acquisitionModeFilter, triggerNameFilter, maxClientUpdateFrequencyFilter, contentType)
+
+#if defined(__EMSCRIPTEN__) && defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #endif

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -127,6 +127,7 @@ target_link_libraries(
           majordomo
           services
           client
+          opendigitizer-options
           project_options
           fair-picoscope
           timing

--- a/src/service/gnuradio/CMakeLists.txt
+++ b/src/service/gnuradio/CMakeLists.txt
@@ -20,4 +20,5 @@ target_link_libraries(
   PRIVATE core
           client
           od_acquisition
+          opendigitizer-options
           project_options)

--- a/src/service/gnuradio/test/CMakeLists.txt
+++ b/src/service/gnuradio/test/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(
           od_gnuradio_worker
           digitizer_common_utils
           client
+          opendigitizer-options
           od_rest
           zmq)
 

--- a/src/service/gnuradio/test/qa_GnuRadioWorker.cpp
+++ b/src/service/gnuradio/test/qa_GnuRadioWorker.cpp
@@ -1,3 +1,8 @@
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference" // OpenCMW headers
+#endif
+
 #include <Client.hpp>
 #include <IoSerialiserCmwLight.hpp>
 #include <IoSerialiserJson.hpp>
@@ -8,6 +13,10 @@
 #include <majordomo/Settings.hpp>
 #include <majordomo/Worker.hpp>
 #include <zmq/ZmqUtils.hpp>
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #include <gnuradio-4.0/basic/StreamToDataSet.hpp>
 #include <gnuradio-4.0/fourier/fft.hpp>

--- a/src/service/main.cpp
+++ b/src/service/main.cpp
@@ -1,3 +1,8 @@
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference" // OpenCMW includes
+#endif
+
 #include <Client.hpp>
 #include <RestDefaultClientCertificates.hpp>
 #include <cmrc/cmrc.hpp>
@@ -9,6 +14,10 @@
 #include <services/dns.hpp>
 #include <services/dns_client.hpp>
 #include <zmq/ZmqUtils.hpp>
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #include <algorithm>
 #include <format>

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -71,6 +71,13 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../cmake")
 include(../../cmake/CMakeRC.cmake)
 include(cmake/Dependencies.cmake)
 
+if(NOT TARGET opendigitizer-options)
+  option(OPENDIGITIZER_WARNINGS_AS_ERRORS "Treat OpenDigitizer compiler warnings as errors" ON)
+  add_library(opendigitizer-options INTERFACE)
+  include(../../cmake/CompilerWarnings.cmake)
+  set_project_warnings(opendigitizer-options)
+endif()
+
 add_compile_definitions(GR_MAX_WASM_THREAD_COUNT=${GR_MAX_WASM_THREAD_COUNT}) # propagate to C++
 
 if(NOT TARGET od_acquisition)
@@ -269,6 +276,7 @@ target_sources(${target_name} PRIVATE main.cpp)
 
 target_link_libraries(
   ${target_name}lib
+  PRIVATE opendigitizer-options
   PUBLIC implot
          implot3d
          imgui-node-editor
@@ -303,12 +311,11 @@ if(OD_DISABLE_DEMO_FLOWGRAPHS)
 else()
   target_link_libraries(${target_name}lib PUBLIC sample_dashboards)
 endif()
-target_compile_options(${target_name}lib PUBLIC "-Wfatal-errors")
 target_compile_definitions(${target_name}lib PUBLIC IMGUI_DEFINE_MATH_OPERATORS)
 if(NOT EMSCRIPTEN)
   target_compile_definitions(${target_name}lib PUBLIC GL_GLEXT_PROTOTYPES)
 endif()
-target_link_libraries(${target_name} PRIVATE ${target_name}lib)
+target_link_libraries(${target_name} PRIVATE ${target_name}lib opendigitizer-options)
 
 if(OPENDIGITIZER_ENABLE_TESTING)
   add_subdirectory(test)

--- a/src/ui/Dashboard.cpp
+++ b/src/ui/Dashboard.cpp
@@ -39,7 +39,16 @@ struct FlowgraphMessage {
     std::string layout;
 };
 
+#if defined(__EMSCRIPTEN__) && defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc2y-extensions" // refl-cpp uses __COUNTER__ issue
+#endif
+
 ENABLE_REFLECTION_FOR(FlowgraphMessage, flowgraph, layout)
+
+#if defined(__EMSCRIPTEN__) && defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 namespace DigitizerUi {
 
@@ -244,11 +253,11 @@ std::string Dashboard::generateUniqueNameForUiWindow(gr::BlockModel& block, std:
 std::unordered_set<std::string_view> Dashboard::getAllWindowNamesInUse() const {
     std::unordered_set<std::string_view> output;
     for (const auto& window : uiWindows) {
-        auto [_, wasEmplaced] = output.emplace(std::string_view{window.window->name});
+        [[maybe_unused]] auto [_, wasEmplaced] = output.emplace(std::string_view{window.window->name});
         assert(wasEmplaced);
     }
     for (const auto& [id, controlWindow] : propertyControlWindows) {
-        auto [_, wasEmplaced] = output.emplace(std::string_view{controlWindow.window->name});
+        [[maybe_unused]] auto [_, wasEmplaced] = output.emplace(std::string_view{controlWindow.window->name});
         assert(wasEmplaced);
     }
     return output;
@@ -344,7 +353,7 @@ void Dashboard::loadAndThen(std::string_view grcData, std::function<void(gr::Gra
 
         if (const auto dashboardUri = opencmw::URI<>(std::string(description->storageInfo->path)); dashboardUri.hostName().has_value()) {
             const auto remoteUri = dashboardUri.factory().hostName(*dashboardUri.hostName()).port(dashboardUri.port().value_or(8080)).scheme(dashboardUri.scheme().value_or("https")).build();
-            gr::graph::forEachBlock<gr::block::Category::NormalBlock>(grGraph, [&remoteUri, this](auto& block) {
+            gr::graph::forEachBlock<gr::block::Category::NormalBlock>(grGraph, [&remoteUri](auto& block) {
                 if (block->typeName().starts_with("opendigitizer::RemoteStreamSource") || block->typeName().starts_with("opendigitizer::RemoteDataSetSource")) {
                     auto* sourceBlock = static_cast<opendigitizer::RemoteSourceBase*>(block->raw());
                     sourceBlock->host = remoteUri.str();

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -24,7 +24,6 @@ namespace DigitizerUi {
 namespace {
 constexpr inline auto kMaxPlots   = 16u;
 constexpr inline auto kGridWidth  = 16u;
-constexpr inline auto kGridHeight = 16u;
 } // namespace
 
 static bool plotButton(const char* glyph, const char* tooltip, float buttonSize) noexcept {
@@ -380,7 +379,6 @@ ImVec2 DashboardPage::drawCharts(Mode mode, const ExportedPropertyPairsByWindowI
     paneSize.y -= _legendBox.y;
 
     const float w = paneSize.x / float(kGridWidth);
-    // const float h = paneSize.y / float(kGridHeight);
 
     // Draw layout grid in Layout mode
     if (mode == Mode::Layout) {

--- a/src/ui/DashboardPage.cpp
+++ b/src/ui/DashboardPage.cpp
@@ -22,8 +22,8 @@
 namespace DigitizerUi {
 
 namespace {
-constexpr inline auto kMaxPlots   = 16u;
-constexpr inline auto kGridWidth  = 16u;
+constexpr inline auto kMaxPlots  = 16u;
+constexpr inline auto kGridWidth = 16u;
 } // namespace
 
 static bool plotButton(const char* glyph, const char* tooltip, float buttonSize) noexcept {

--- a/src/ui/FlowgraphPage.cpp
+++ b/src/ui/FlowgraphPage.cpp
@@ -332,21 +332,20 @@ void FlowgraphEditor::drawGraph(const ImVec2& size /*, const UiGraphBlock*& filt
         // over-reserved, but minimizes allocations
         filteredOutNodes.reserve(_filterBlock ? graphBlocks.size() : 0);
 
+        const auto transformPorts = [](const UiGraphBlock& block, const std::vector<UiGraphPort>& ports) {
+            auto sortedPorts = ports | std::views::transform([](const auto& p) { return &p; }) | std::ranges::to<std::vector>();
+            if (block.isScheduler() || block.isGraph()) { // regular blocks define port order by declaration order
+                std::ranges::sort(sortedPorts, {}, [](auto* p) { return std::tie(p->portType, p->portName); });
+            }
+            return sortedPorts;
+        };
+
         // We need to pass all blocks in order for NodeEditor to calculate
         // the sizes. Then, we can arrange those that are newly created
         for (auto& block : graphBlocks) {
-            auto blockId = ax::NodeEditor::NodeId(block.get());
-
-            const auto transformPorts = [](UiGraphBlock& block, const std::vector<UiGraphPort>& ports) {
-                auto sortedPorts = ports | std::views::transform([](const auto& p) { return &p; }) | std::ranges::to<std::vector>();
-                if (block.isScheduler() || block.isGraph()) { // regular blocks define port order by declaration order
-                    std::ranges::sort(sortedPorts, {}, [](auto* p) { return std::tie(p->portType, p->portName); });
-                }
-                return sortedPorts;
-            };
-
-            auto inputPorts  = transformPorts(*block, block->inputPorts());
-            auto outputPorts = transformPorts(*block, block->outputPorts());
+            const auto blockId     = ax::NodeEditor::NodeId(block.get());
+            auto       inputPorts  = transformPorts(*block, block->inputPorts());
+            auto       outputPorts = transformPorts(*block, block->outputPorts());
 
             const bool filteredOut = _filterBlock && !_graphModel->blockInTree(*block.get(), *_filterBlock);
 

--- a/src/ui/GraphModel.hpp
+++ b/src/ui/GraphModel.hpp
@@ -267,10 +267,10 @@ public:
     struct FindBlockResult {
         operator bool() const { return block != nullptr; }
 
-        UiGraphBlock*                                 parentGraph = nullptr;
-        UiGraphBlock*                                 block       = nullptr;
-        decltype(UiGraphBlock::childBlocks)*          owningCollection;
-        decltype(UiGraphBlock::childBlocks)::iterator owningCollectionIt;
+        UiGraphBlock*                                 parentGraph        = nullptr;
+        UiGraphBlock*                                 block              = nullptr;
+        decltype(UiGraphBlock::childBlocks)*          owningCollection   = nullptr;
+        decltype(UiGraphBlock::childBlocks)::iterator owningCollectionIt = {};
     };
     FindBlockResult recursiveFindBlockByUniqueName(std::string_view uniqueName);
     FindBlockResult recursiveFindBlockByName(std::string_view name);

--- a/src/ui/blocks/RemoteSource.hpp
+++ b/src/ui/blocks/RemoteSource.hpp
@@ -134,7 +134,7 @@ struct RemoteSourceSubscription {
         const auto         guard      = std::scoped_lock{callbacksMutex};
         std::size_t        id         = lastUsedId;
         ++lastUsedId;
-        const auto wasEmplaced = userCallbacks.try_emplace(id, std::move(callback)).second;
+        [[maybe_unused]] const auto wasEmplaced = userCallbacks.try_emplace(id, std::move(callback)).second;
         assert(wasEmplaced);
         return id;
     }

--- a/src/ui/components/Block.cpp
+++ b/src/ui/components/Block.cpp
@@ -266,7 +266,7 @@ gr::pmt::Value editBlockProperty(const char* label, const std::string& propertyN
         assert(currentPropertyValue.is_arithmetic());
         gr::pmt::ValueVisitor([&out, &meta, label]<typename T>(const T& num) {
             if constexpr (std::floating_point<T>) {
-                double temp = num;
+                auto temp = static_cast<double>(num);
                 if (ImGui::SliderScalar(label, ImGuiDataType_Double, &temp, &*meta.minValue, &*meta.maxValue, "%d", {})) {
                     out = static_cast<T>(temp);
                 }

--- a/src/ui/components/ExportedPropertiesList.hpp
+++ b/src/ui/components/ExportedPropertiesList.hpp
@@ -40,9 +40,9 @@ public:
     struct Params {
         Flags flags = {};
         // filter the displayed exported properties to only ones that match this type
-        std::optional<UiGraphBlock::SettingsControlType> typeFilter;
+        std::optional<UiGraphBlock::SettingsControlType> typeFilter = std::nullopt;
         // items in this vector will not be interactable
-        std::span<const ExportedPropertyPair> disabledList;
+        std::span<const ExportedPropertyPair> disabledList = {};
     };
 
     enum class Action {

--- a/src/ui/components/Keypad.hpp
+++ b/src/ui/components/Keypad.hpp
@@ -6,6 +6,7 @@
 
 #include <any>
 #include <charconv>
+#include <cstdlib>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -799,7 +800,13 @@ private:
             if constexpr (std::same_as<std::string, EdTy>) {
                 *value = _editBuffer;
             } else if constexpr (std::floating_point<EdTy>) {
-                *value = strtof(_editBuffer.c_str(), nullptr);
+                if constexpr (std::same_as<float, EdTy>) {
+                    *value = std::strtof(_editBuffer.c_str(), nullptr);
+                } else if constexpr (std::same_as<double, EdTy>) {
+                    *value = std::strtod(_editBuffer.c_str(), nullptr);
+                } else {
+                    *value = std::strtold(_editBuffer.c_str(), nullptr);
+                }
             } else {
                 EdTy             converted = 0;
                 std::string_view a{_editBuffer};

--- a/src/ui/components/NewBlockSelector.cpp
+++ b/src/ui/components/NewBlockSelector.cpp
@@ -85,19 +85,33 @@ struct NamespaceOrSymbol {
     explicit NamespaceOrSymbol(const Symbol& symbol) : variant(symbol) {}
     explicit NamespaceOrSymbol(NamespaceTag) : variant(Namespace{}) {}
 
-    NamespaceOrSymbol* insertOrFindNameSpaceChild(std::string_view key) { //
-        return nameSpace()->insertOrLeaveExistingElement(key, NamespaceTag{});
+    [[nodiscard]] NamespaceOrSymbol* insertOrFindNameSpaceChild(std::string_view key) { //
+        auto* namespaceNode = nameSpace();
+        if (namespaceNode == nullptr) {
+            assert(false && "insertOrFindNameSpaceChild requires a namespace node");
+            return nullptr;
+        }
+        return namespaceNode->insertOrLeaveExistingElement(key, NamespaceTag{});
     }
     void insertElementChild(std::string_view key, std::string_view element, const FilterResult& filter) { //
-        nameSpace()->insertOrLeaveExistingElement(key, Symbol{element, filter});
+        auto* namespaceNode = nameSpace();
+        if (namespaceNode == nullptr) {
+            assert(false && "insertElementChild requires a namespace node");
+            return;
+        }
+        namespaceNode->insertOrLeaveExistingElement(key, Symbol{element, filter});
     }
 
     /// If nonempty, the returned string view is the full symbol name of the selected symbol
     [[nodiscard]] std::string_view drawTreeRecursive(std::string_view currentlySelected, std::string& keyBuffer, bool scrollToSelected, std::optional<bool> newOpenValue) const {
         std::string_view selected;
-        assert(nameSpace());
+        const auto*      namespaceNode = nameSpace();
+        if (namespaceNode == nullptr) {
+            assert(false && "drawTreeRecursive requires a namespace node");
+            return {};
+        }
 
-        for (const auto& [key, child] : nameSpace()->children) {
+        for (const auto& [key, child] : namespaceNode->children) {
             const auto namespaceCase = [&keyBuffer, key, &newOpenValue, &child, &selected, scrollToSelected, currentlySelected](const Namespace&) {
                 // this is a branch
                 keyBuffer = key;
@@ -214,6 +228,9 @@ void NewBlockSelector::drawNamespaceTree(const ImVec2& size) {
                 cursor->insertElementChild(std::string_view{namespaceElement}, entry.blockTypeName(), *entry.filterResult);
             } else {
                 cursor = cursor->insertOrFindNameSpaceChild(std::string_view{namespaceElement});
+                if (cursor == nullptr) {
+                    break;
+                }
             }
         }
     }

--- a/src/ui/components/SignalSelector.cpp
+++ b/src/ui/components/SignalSelector.cpp
@@ -165,10 +165,8 @@ std::vector<SignalData> SignalSelector::drawSignalSelector() {
     }
 
     if (filtersChanged) {
-        std::vector<FilterData*> filters;
-        filters.resize(m_selectedFilters.labels().size());
-        std::ranges::transform(m_selectedFilters.labels(), filters.begin(), [](const auto& filter) { return filter.data; });
-        startSearching(m_shownSearchString, filters);
+        auto filters = m_selectedFilters.labels() | std::views::transform([](const auto& filter) { return filter.data; }) | std::ranges::to<std::vector>();
+        startSearching(m_shownSearchString, std::move(filters));
         while (loadMoreItems()) {
         }
     }

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -158,7 +158,7 @@ static void renderFrameOnly(App* app, gr::profiling::PeriodicTimer& tim) {
 // Track visibility for power saving
 static bool g_isVisible = true;
 
-static EM_BOOL emVisibilityCallback(int eventType, const EmscriptenVisibilityChangeEvent* event, void* /*userData*/) {
+static EM_BOOL emVisibilityCallback([[maybe_unused]] int eventType, const EmscriptenVisibilityChangeEvent* event, void* /*userData*/) {
     g_isVisible = !event->hidden;
     if (g_isVisible) {
         // Waking up from hidden: request a frame

--- a/src/ui/test/CMakeLists.txt
+++ b/src/ui/test/CMakeLists.txt
@@ -2,24 +2,29 @@
 
 # Headless chart abstraction tests (links opendigitizer-uilib for shared TestSinks.hpp)
 add_executable(qa_SignalSink qa_SignalSink.cpp)
-target_link_libraries(qa_SignalSink PRIVATE ut opendigitizer-uilib)
+target_link_libraries(qa_SignalSink PRIVATE ut opendigitizer-uilib opendigitizer-options)
 target_include_directories(qa_SignalSink PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 add_test(NAME qa_SignalSink COMMAND qa_SignalSink)
 
 # Chart abstraction tests for SignalSink/SinkRegistry/Chart mixin APIs Note: links opendigitizer-uilib because Chart.hpp
 # menu helpers reference LookAndFeel
 add_executable(qa_ChartAbstraction qa_ChartAbstraction.cpp)
-target_link_libraries(qa_ChartAbstraction PRIVATE ut opendigitizer-uilib)
+target_link_libraries(qa_ChartAbstraction PRIVATE ut opendigitizer-uilib opendigitizer-options)
 target_include_directories(qa_ChartAbstraction PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 add_test(NAME qa_ChartAbstraction COMMAND qa_ChartAbstraction)
 
 add_executable(qa_FuzzySearch qa_FuzzySearch.cpp)
-target_link_libraries(qa_FuzzySearch PRIVATE ut opendigitizer-uilib)
+target_link_libraries(qa_FuzzySearch PRIVATE ut opendigitizer-uilib opendigitizer-options)
 target_include_directories(qa_FuzzySearch PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 add_test(NAME qa_FuzzySearch COMMAND qa_FuzzySearch)
 
 add_executable(qa_TestSpectrumGenerator qa_TestSpectrumGenerator.cpp)
-target_link_libraries(qa_TestSpectrumGenerator PRIVATE ut gnuradio4::gnuradio-core gnuradio4::gnuradio-blocklib-core)
+target_link_libraries(
+  qa_TestSpectrumGenerator
+  PRIVATE ut
+          gnuradio4::gnuradio-core
+          gnuradio4::gnuradio-blocklib-core
+          opendigitizer-options)
 target_include_directories(qa_TestSpectrumGenerator PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..
                                                             ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/include)
 add_test(NAME qa_TestSpectrumGenerator COMMAND qa_TestSpectrumGenerator)
@@ -31,6 +36,7 @@ target_link_libraries(
   qa_play_stop_bar
   PRIVATE ut
           core
+          opendigitizer-options
           gnuradio4::gnuradio-core
           gnuradio4::gnuradio-meta
           gnuradio4::gnuradio-algorithm
@@ -63,6 +69,7 @@ if(ENABLE_IMGUI_TEST_ENGINE)
   add_library(imgui_tests_common STATIC ImGuiTestApp.cpp)
   target_link_libraries(
     imgui_tests_common
+    PRIVATE opendigitizer-options
     PUBLIC opendigitizer-uilib
            raii_wrapper
            ui_assets
@@ -78,6 +85,7 @@ if(ENABLE_IMGUI_TEST_ENGINE)
     target_link_libraries(
       ${NAME}
       PRIVATE opendigitizer-uilib
+              opendigitizer-options
               ut
               imgui_tests_common
               gnuradio4::gnuradio-blocklib-core

--- a/src/ui/test/qa_ChartAbstraction.cpp
+++ b/src/ui/test/qa_ChartAbstraction.cpp
@@ -444,8 +444,11 @@ int main() {
             const auto&      registry = opendigitizer::charts::detail::chartSignalCompatibilityRegistry();
             std::string_view name     = gr::refl::type_name<T>;
             auto             iterator = std::ranges::find_if(registry, [name](const auto& pair) { return pair.first.find(name) != std::string::npos; });
-            expect(iterator != registry.end()) << name << " should be registered";
-            expect(iterator->second == T::supportedSignals);
+            if (iterator == registry.end()) {
+                expect(false) << name << " should be registered";
+            } else {
+                expect(iterator->second == T::supportedSignals);
+            }
         };
 
         expectEntry.template operator()<XYChart>();

--- a/src/ui/test/qa_SignalSink.cpp
+++ b/src/ui/test/qa_SignalSink.cpp
@@ -156,8 +156,11 @@ int main() {
         expect(eq(registry.sinkCount(), initialCount + 2));
 
         auto found = registry.getSink("registry_sink1");
-        expect(found != nullptr);
-        expect(eq(found->uniqueName(), std::string_view("registry_sink1")));
+        if (found == nullptr) {
+            expect(false) << "registry_sink1 should be registered";
+        } else {
+            expect(eq(found->uniqueName(), std::string_view("registry_sink1")));
+        }
 
         registry.unregisterSink("registry_sink1");
         registry.unregisterSink("registry_sink2");

--- a/src/ui/utils/EmscriptenHelper.hpp
+++ b/src/ui/utils/EmscriptenHelper.hpp
@@ -53,15 +53,18 @@ inline bool em_visibilitychange_callback(int, const EmscriptenVisibilityChangeEv
 }
 #endif
 
+// clang-format off
 inline void listPersistentFiles([[maybe_unused]] bool recursive = true) {
 #ifdef __EMSCRIPTEN__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
     EM_ASM_(
         {
             function listDir(path, recursive, indent = "") {
                 try {
                     const entries = FS.readdir(path);
                     for (let entry of entries) {
-                        if (entry == = '.' || entry == = '..') {
+                        if (entry === '.' || entry === '..') {
                             continue;
                         }
                         const fullPath = path + (path.endsWith('/') ? "" : "/") + entry;
@@ -79,12 +82,14 @@ inline void listPersistentFiles([[maybe_unused]] bool recursive = true) {
                     console.error('Error listing directory:', path, e);
                 }
             }
-            listDir('/', $0 != = 0);
+            listDir('/', $0 !== 0);
         },
         recursive ? 1 : 0);
+#pragma clang diagnostic pop
 #else
 
 #endif
 }
+// clang-format on
 
 #endif // EMSCRIPTENHELPER_HPP

--- a/src/ui/utils/ImGuiDockSpaceState.cpp
+++ b/src/ui/utils/ImGuiDockSpaceState.cpp
@@ -113,7 +113,7 @@ gr::property_map saveDockSpaceState(std::span<const std::string_view> relevantWi
     std::unordered_map<std::string_view, ImGuiWindow*> remainingWindowsByName;
     remainingWindowsByName.reserve(relevantWindowsNames.size());
     for (std::string_view windowName : relevantWindowsNames) {
-        auto [_, wasEmplaced] = remainingWindowsByName.try_emplace(windowName, nullptr);
+        [[maybe_unused]] auto [_, wasEmplaced] = remainingWindowsByName.try_emplace(windowName, nullptr);
         assert(wasEmplaced); // non-unique window names
     }
     for (ImGuiWindow* window : g.Windows) {

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -76,5 +76,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version/version.cpp.in ${CMAKE_BINARY
                @ONLY)
 
 add_library(opendigitizer_version STATIC ${CMAKE_BINARY_DIR}/generated_version/version.cpp)
+target_link_libraries(opendigitizer_version PRIVATE opendigitizer-options)
 target_include_directories(opendigitizer_version PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/version/include)
 target_include_directories(opendigitizer_version PUBLIC ${CMAKE_BINARY_DIR}/generated_version)

--- a/src/utils/test/CMakeLists.txt
+++ b/src/utils/test/CMakeLists.txt
@@ -7,18 +7,18 @@ add_executable(qa_DeviceNameHelper qa_DeviceNameHelper.cpp)
 target_include_directories(qa_DeviceNameHelper INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                          $<INSTALL_INTERFACE:include/>)
 
-target_link_libraries(qa_c_wrapper PRIVATE ut)
+target_link_libraries(qa_c_wrapper PRIVATE ut opendigitizer-options)
 add_test(NAME qa_c_wrapper COMMAND qa_c_wrapper)
 
-target_link_libraries(qa_DeviceNameHelper PRIVATE ut)
+target_link_libraries(qa_DeviceNameHelper PRIVATE ut opendigitizer-options)
 add_test(NAME qa_DeviceNameHelper COMMAND qa_DeviceNameHelper)
 
 add_executable(qa_PeriodicTimer qa_PeriodicTimer.cpp)
 target_include_directories(qa_PeriodicTimer INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
                                                       $<INSTALL_INTERFACE:include/>)
 add_test(NAME qa_PeriodicTimer COMMAND qa_PeriodicTimer)
-target_link_libraries(qa_PeriodicTimer PRIVATE ut gnuradio4::gnuradio-core)
+target_link_libraries(qa_PeriodicTimer PRIVATE ut gnuradio4::gnuradio-core opendigitizer-options)
 
 add_executable(qa_Xoshiro256pp qa_Xoshiro256pp.cpp)
-target_link_libraries(qa_Xoshiro256pp PRIVATE ut)
+target_link_libraries(qa_Xoshiro256pp PRIVATE ut opendigitizer-options)
 add_test(NAME qa_Xoshiro256pp COMMAND qa_Xoshiro256pp)


### PR DESCRIPTION
Make OpenDigitizer explicitly compile with warnings treated as errors across native, WASM, service, UI, and test targets.

Previously, -Werror was inherited indirectly from source-built gnuradio4. Installed gnuradio4 does not propagate these build-only flags, so OpenDigitizer CI did not enforce the same warning policy.

Changes include:
  - Added an OD-specific warnings-as-errors option and interface target.
  - Applied warning settings to all compiled OD targets.
  - Propagated the setting to the standalone WASM build.
  - Removed -Wfatal-errors so all diagnostics are reported.
  - Fixed warnings.
