### PR TITLE
Group and ungroup operations

### DIFF
--- a/src/service/gnuradio/examples/function_generator.grc
+++ b/src/service/gnuradio/examples/function_generator.grc
@@ -34,28 +34,28 @@ blocks:
       signal_type: Const
       start_value: 0
     ctx_parameters:
-      - context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1
-        ctx_time: !!uint64 0
+      - gr:context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=1
+        gr:ctx_time: !!uint64 0
         parameters:
           sample_rate: 1000
           signal_type: Const
           start_value: 5
-      - context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2
-        ctx_time: !!uint64 0
+      - gr:context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=2
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.2
           final_value: 30
           sample_rate: 1000
           signal_type: LinearRamp
           start_value: 5
-      - context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=3
-        ctx_time: !!uint64 0
+      - gr:context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=3
+        gr:ctx_time: !!uint64 0
         parameters:
           sample_rate: 1000
           signal_type: Const
           start_value: 30
-      - context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=4
-        ctx_time: !!uint64 0
+      - gr:context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=4
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.1
           final_value: 20.0
@@ -63,28 +63,28 @@ blocks:
           sample_rate: 1000.0
           signal_type: ParabolicRamp
           start_value: 30.0
-      - context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=5
-        ctx_time: !!uint64 0
+      - gr:context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=5
+        gr:ctx_time: !!uint64 0
         parameters:
           sample_rate: 1000
           signal_type: Const
           start_value: 20
-      - context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=6
-        ctx_time: !!uint64 0
+      - gr:context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=6
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.1
           final_value: 10
           sample_rate: 1000
           signal_type: CubicSpline
           start_value: 20
-      - context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=7
-        ctx_time: !!uint64 0
+      - gr:context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=7
+        gr:ctx_time: !!uint64 0
         parameters:
           sample_rate: 1000
           signal_type: Const
           start_value: 10
-      - context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=8
-        ctx_time: !!uint64 0
+      - gr:context: CMD_BP_START/FAIR.SELECTOR.C=1:S=1:P=8
+        gr:ctx_time: !!uint64 0
         parameters:
           final_value: 20
           impulse_time0: 0.02

--- a/src/ui/FlowgraphPage.cpp
+++ b/src/ui/FlowgraphPage.cpp
@@ -823,6 +823,8 @@ void FlowgraphEditor::draw(const ImVec2& contentTopLeft, const ImVec2& contentSi
             _graphModel->requestFullUpdate();
             _graphModel->requestAvailableBlocksTypesUpdate();
         }
+
+        drawGroupingMenuItems(selectedBlockUniqueNames());
     }
 
     if (auto menu = IMW::Popup("block_ctx_menu", 0)) {
@@ -835,6 +837,19 @@ void FlowgraphEditor::draw(const ImVec2& contentTopLeft, const ImVec2& contentSi
                 requestGraphEdit(_selectedBlock);
             }
         }
+
+        auto groupNames = selectedBlockUniqueNames();
+        if (std::ranges::find(groupNames, _selectedBlock->blockUniqueName) == groupNames.end()) {
+            groupNames.push_back(_selectedBlock->blockUniqueName);
+        }
+
+        if (_selectedBlock->isGraph() || _selectedBlock->isScheduler()) {
+            if (ImGui::MenuItem("Ungroup blocks")) {
+                requestBlocksUngrouping(_selectedBlock->blockUniqueName);
+            }
+        }
+
+        drawGroupingMenuItems(std::move(groupNames));
 
         auto typeParams = _graphModel->availableParametrizationsFor(_selectedBlock->blockTypeName);
         if (typeParams.availableParametrizations && typeParams.availableParametrizations->size() > 1) {
@@ -894,6 +909,13 @@ void FlowgraphEditor::draw(const ImVec2& contentTopLeft, const ImVec2& contentSi
             exportedPortsMenu("Exported input ports...", "input", _selectedBlock->_inputPorts);
             exportedPortsMenu("Exported output ports...", "output", _selectedBlock->_outputPorts);
         }
+    }
+
+    if (_pendingGroupBlocksRequest) {
+        if (openGroupBlocksSelectorCallback) {
+            openGroupBlocksSelectorCallback(std::move(*_pendingGroupBlocksRequest));
+        }
+        _pendingGroupBlocksRequest.reset();
     }
 
     // Create a new ImGui window for an overlay over the NodeEditor , where we can place our buttons
@@ -956,6 +978,60 @@ void FlowgraphEditor::requestBlockDeletion(const std::string& blockName) {
     _graphModel->sendMessage(std::move(message));
 }
 
+void FlowgraphEditor::requestBlocksGrouping(std::string graphType, const std::vector<std::string>& uniqueNames) {
+    gr::Tensor<gr::pmt::Value> names(gr::extents_from, {uniqueNames.size()});
+    for (std::size_t i = 0; i < uniqueNames.size(); ++i) {
+        names[i] = uniqueNames[i];
+    }
+
+    gr::Message message;
+    message.cmd         = gr::message::Command::Set;
+    message.endpoint    = gr::scheduler::property::kGroupBlocks;
+    auto owner          = ownersForRoot();
+    message.serviceName = owner.scheduler;
+    message.data        = gr::property_map{       //
+        {"type", std::move(graphType)},    //
+        {"uniqueNames", std::move(names)}, //
+        {"_targetGraph", owner.graph}};
+    _graphModel->sendMessage(std::move(message));
+}
+
+void FlowgraphEditor::requestBlocksUngrouping(const std::string& uniqueName) {
+    gr::Message message;
+    message.cmd         = gr::message::Command::Set;
+    message.endpoint    = gr::scheduler::property::kUngroupBlocks;
+    auto owner          = ownersForRoot();
+    message.serviceName = owner.scheduler;
+    message.data        = gr::property_map{{"uniqueName", uniqueName}, {"_targetGraph", owner.graph}};
+    _graphModel->sendMessage(std::move(message));
+}
+
+std::vector<std::string> FlowgraphEditor::selectedBlockUniqueNames() {
+    makeCurrent();
+    std::vector<ax::NodeEditor::NodeId> selectedNodes(static_cast<std::size_t>(ax::NodeEditor::GetSelectedObjectCount()));
+    const auto                          nodeCount = ax::NodeEditor::GetSelectedNodes(selectedNodes.data(), static_cast<int>(selectedNodes.size()));
+
+    std::vector<std::string> result;
+    result.reserve(static_cast<std::size_t>(nodeCount));
+    for (const auto& nodeId : selectedNodes | std::views::take(nodeCount)) {
+        if (const auto* block = nodeId.AsPointer<UiGraphBlock>()) {
+            result.push_back(block->blockUniqueName);
+        }
+    }
+    return result;
+}
+
+void FlowgraphEditor::drawGroupingMenuItems(std::vector<std::string> uniqueNames) {
+    const bool haveSelection = !uniqueNames.empty();
+    const bool singular      = uniqueNames.size() == 1;
+    if (ImGui::MenuItem(singular ? "Group block" : "Group blocks", nullptr, false, haveSelection)) {
+        requestBlocksGrouping("gr::Graph", uniqueNames);
+    }
+    if (ImGui::MenuItem(singular ? "Group block and pick graph type..." : "Group blocks and pick graph type...", nullptr, false, haveSelection)) {
+        _pendingGroupBlocksRequest = std::move(uniqueNames);
+    }
+}
+
 void FlowgraphEditor::requestExportPort(const ExportPortMessageData& request) {
     gr::Message message;
 
@@ -969,6 +1045,15 @@ void FlowgraphEditor::requestExportPort(const ExportPortMessageData& request) {
         {"exportedName", request.exportedName},       //
         {"exportFlag", request.exportFlag}};
     graphModel()->sendMessage(std::move(message));
+}
+
+void sendEmplaceBlockMessage(UiGraphModel& graphModel, const FlowgraphEditor::SchedulerGraphPair& owner, std::string type) {
+    gr::Message message;
+    message.cmd         = gr::message::Command::Set;
+    message.endpoint    = gr::scheduler::property::kEmplaceBlock;
+    message.serviceName = owner.scheduler;
+    message.data        = gr::property_map{{"type", std::move(type)}, {"_targetGraph", owner.graph}};
+    graphModel.sendMessage(std::move(message));
 }
 
 FlowgraphPage::FlowgraphPage(std::shared_ptr<opencmw::client::RestClient> restClient) : _restClient{std::move(restClient)} {}
@@ -1000,15 +1085,21 @@ void FlowgraphPage::pushEditor(std::string name, UiGraphModel& graphModel, UiGra
     // This lambda is owned by editor, so it is safe to take it by reference
     editor.openNewBlockSelectorCallback = [this, &editor](UiGraphModel* /*_graphModel*/) {
         _newBlockSelector.data = editor.graphModel()->knownBlockTypes;
-        auto owner             = editor.ownersForRoot();
-        _newBlockSelector.open(owner.scheduler, owner.graph);
+        _newBlockSelector.open([graphModel = editor.graphModel(), owner = editor.ownersForRoot()](std::string type) { sendEmplaceBlockMessage(*graphModel, owner, std::move(type)); });
     };
 
     // This lambda is owned by editor, so it is safe to take it by reference
     editor.openNewSubGraphSelectorCallback = [this, &editor](UiGraphModel* /*_graphModel*/) {
         _newBlockSelector.data = editor.graphModel()->knownSchedulerTypes;
-        auto owner             = editor.ownersForRoot();
-        _newBlockSelector.open(owner.scheduler, owner.graph);
+        _newBlockSelector.open([graphModel = editor.graphModel(), owner = editor.ownersForRoot()](std::string type) { sendEmplaceBlockMessage(*graphModel, owner, std::move(type)); });
+    };
+
+    // This lambda is owned by editor, so it is safe to take it by reference
+    editor.openGroupBlocksSelectorCallback = [this, &editor](std::vector<std::string> uniqueNames) {
+        _newBlockSelector.data = editor.graphModel()->knownSchedulerTypes;
+        _newBlockSelector.open([&editor, uniqueNames = std::move(uniqueNames)](std::string graphType) { //
+            editor.requestBlocksGrouping(std::move(graphType), uniqueNames);
+        });
     };
 
     // We can add remote signals only to the root graph

--- a/src/ui/FlowgraphPage.cpp
+++ b/src/ui/FlowgraphPage.cpp
@@ -567,6 +567,7 @@ void FlowgraphEditor::drawGraph(const ImVec2& size /*, const UiGraphBlock*& filt
     const auto& graphEdges  = _rootBlock->childEdges;
 
     makeCurrent();
+    dropReferencesToDeletedBlocks();
 
     IMW::NodeEditor::Editor nodeEditor(_editorName.c_str(), size);
     const auto              padding = ax::NodeEditor::GetStyle().NodePadding;
@@ -827,89 +828,7 @@ void FlowgraphEditor::draw(const ImVec2& contentTopLeft, const ImVec2& contentSi
         drawGroupingMenuItems(selectedBlockUniqueNames());
     }
 
-    if (auto menu = IMW::Popup("block_ctx_menu", 0)) {
-        if (ImGui::MenuItem("Delete this block")) {
-            requestBlockDeletion(_selectedBlock->blockUniqueName);
-        }
-
-        if (_selectedBlock->blockCategory == "TransparentBlockGroup" || _selectedBlock->blockCategory == "ScheduledBlockGroup") {
-            if (ImGui::MenuItem("Edit block graph...")) {
-                requestGraphEdit(_selectedBlock);
-            }
-        }
-
-        auto groupNames = selectedBlockUniqueNames();
-        if (std::ranges::find(groupNames, _selectedBlock->blockUniqueName) == groupNames.end()) {
-            groupNames.push_back(_selectedBlock->blockUniqueName);
-        }
-
-        if (_selectedBlock->isGraph() || _selectedBlock->isScheduler()) {
-            if (ImGui::MenuItem("Ungroup blocks")) {
-                requestBlocksUngrouping(_selectedBlock->blockUniqueName);
-            }
-        }
-
-        drawGroupingMenuItems(std::move(groupNames));
-
-        auto typeParams = _graphModel->availableParametrizationsFor(_selectedBlock->blockTypeName);
-        if (typeParams.availableParametrizations && typeParams.availableParametrizations->size() > 1) {
-            if (IMW::Menu blockTypesMenu("Change type to...", /*enabled*/ true); blockTypesMenu) {
-                for (const auto& availableParametrization : *typeParams.availableParametrizations) {
-                    if (availableParametrization != typeParams.parametrization) {
-                        if (ImGui::MenuItem(availableParametrization.c_str())) {
-                            gr::Message message;
-                            message.cmd         = gr::message::Command::Set;
-                            message.endpoint    = gr::scheduler::property::kReplaceBlock;
-                            auto owner          = ownersForRoot();
-                            message.serviceName = owner.scheduler;
-                            message.data        = gr::property_map{                                         //
-                                {"uniqueName", _selectedBlock->blockUniqueName},                     //
-                                {"type", std::move(typeParams.baseType) + availableParametrization}, //
-                                {"_targetGraph", owner.graph}};
-
-                            _graphModel->sendMessage(std::move(message));
-                        }
-                    }
-                }
-            }
-        }
-
-        const auto exportedPortsMenu = [this](auto text, auto portDirection, const auto& blockPorts) {
-            auto selectedBlockUniqueName = _selectedBlock->blockUniqueName;
-
-            auto exportPortsSubMenu = IMW::Menu{text, /*enabled*/ true};
-            if (!exportPortsSubMenu) {
-                return;
-            }
-
-            for (const UiGraphPort& knownPort : blockPorts) {
-                const auto  exportedName = knownPort.getExportedName(this->_exportPortTargetBlock);
-                std::string itemText     = exportedName ? std::format("{} (as {})", knownPort.portName, *exportedName) : knownPort.portName;
-
-                if (!ImGui::MenuItem(itemText.c_str(), nullptr, exportedName.has_value())) {
-                    continue;
-                }
-
-                ExportPortMessageData request{                          //
-                    .uniqueBlockName = _selectedBlock->blockUniqueName, //
-                    .portDirection   = portDirection,                   //
-                    .portName        = knownPort.portName,              //
-                    .exportedName    = {},                              //
-                    .exportFlag      = !exportedName.has_value()};
-                if (exportedName.has_value()) {
-                    requestExportPort(std::move(request));
-                } else {
-                    exportPortTextField = _selectedBlock->blockName + "." + knownPort.portName;
-                    exportPortRequest   = std::move(request);
-                }
-            }
-        };
-
-        if (_editorLevel > 0) {
-            exportedPortsMenu("Exported input ports...", "input", _selectedBlock->_inputPorts);
-            exportedPortsMenu("Exported output ports...", "output", _selectedBlock->_outputPorts);
-        }
-    }
+    drawBlockContextMenu();
 
     if (_pendingGroupBlocksRequest) {
         if (openGroupBlocksSelectorCallback) {
@@ -932,6 +851,101 @@ void FlowgraphEditor::draw(const ImVec2& contentTopLeft, const ImVec2& contentSi
     } else {
         const float h = contentSize.y * ratio;
         requestBlockControlsPanel(_editPaneContext, {contentTopLeft.x, contentTopLeft.y + contentSize.y - h + halfSplitterWidth}, {contentSize.x, h - halfSplitterWidth}, false);
+    }
+}
+
+void FlowgraphEditor::drawBlockContextMenu() {
+    auto menu = IMW::Popup("block_ctx_menu", 0);
+    if (!menu) {
+        return;
+    }
+
+    if (_selectedBlock == nullptr) {
+        // the block was deleted while the menu was open
+        ImGui::CloseCurrentPopup();
+        return;
+    }
+
+    if (ImGui::MenuItem("Delete this block")) {
+        requestBlockDeletion(_selectedBlock->blockUniqueName);
+    }
+
+    if (_selectedBlock->blockCategory == "TransparentBlockGroup" || _selectedBlock->blockCategory == "ScheduledBlockGroup") {
+        if (ImGui::MenuItem("Edit block graph...")) {
+            requestGraphEdit(_selectedBlock);
+        }
+    }
+
+    auto groupNames = selectedBlockUniqueNames();
+    if (std::ranges::find(groupNames, _selectedBlock->blockUniqueName) == groupNames.end()) {
+        groupNames.push_back(_selectedBlock->blockUniqueName);
+    }
+
+    if (_selectedBlock->isGraph() || _selectedBlock->isScheduler()) {
+        if (ImGui::MenuItem("Ungroup blocks")) {
+            requestBlocksUngrouping(_selectedBlock->blockUniqueName);
+        }
+    }
+
+    drawGroupingMenuItems(std::move(groupNames));
+
+    auto typeParams = _graphModel->availableParametrizationsFor(_selectedBlock->blockTypeName);
+    if (typeParams.availableParametrizations && typeParams.availableParametrizations->size() > 1) {
+        if (IMW::Menu blockTypesMenu("Change type to...", /*enabled*/ true); blockTypesMenu) {
+            for (const auto& availableParametrization : *typeParams.availableParametrizations) {
+                if (availableParametrization != typeParams.parametrization) {
+                    if (ImGui::MenuItem(availableParametrization.c_str())) {
+                        gr::Message message;
+                        message.cmd         = gr::message::Command::Set;
+                        message.endpoint    = gr::scheduler::property::kReplaceBlock;
+                        auto owner          = ownersForRoot();
+                        message.serviceName = owner.scheduler;
+                        message.data        = gr::property_map{                                         //
+                            {"uniqueName", _selectedBlock->blockUniqueName},                     //
+                            {"type", std::move(typeParams.baseType) + availableParametrization}, //
+                            {"_targetGraph", owner.graph}};
+
+                        _graphModel->sendMessage(std::move(message));
+                    }
+                }
+            }
+        }
+    }
+
+    const auto exportedPortsMenu = [this](auto text, auto portDirection, const auto& blockPorts) {
+        auto selectedBlockUniqueName = _selectedBlock->blockUniqueName;
+
+        auto exportPortsSubMenu = IMW::Menu{text, /*enabled*/ true};
+        if (!exportPortsSubMenu) {
+            return;
+        }
+
+        for (const UiGraphPort& knownPort : blockPorts) {
+            const auto  exportedName = knownPort.getExportedName(this->_exportPortTargetBlock);
+            std::string itemText     = exportedName ? std::format("{} (as {})", knownPort.portName, *exportedName) : knownPort.portName;
+
+            if (!ImGui::MenuItem(itemText.c_str(), nullptr, exportedName.has_value())) {
+                continue;
+            }
+
+            ExportPortMessageData request{                          //
+                .uniqueBlockName = _selectedBlock->blockUniqueName, //
+                .portDirection   = portDirection,                   //
+                .portName        = knownPort.portName,              //
+                .exportedName    = {},                              //
+                .exportFlag      = !exportedName.has_value()};
+            if (exportedName.has_value()) {
+                requestExportPort(std::move(request));
+            } else {
+                exportPortTextField = _selectedBlock->blockName + "." + knownPort.portName;
+                exportPortRequest   = std::move(request);
+            }
+        }
+    };
+
+    if (_editorLevel > 0) {
+        exportedPortsMenu("Exported input ports...", "input", _selectedBlock->_inputPorts);
+        exportedPortsMenu("Exported output ports...", "output", _selectedBlock->_outputPorts);
     }
 }
 
@@ -1006,8 +1020,33 @@ void FlowgraphEditor::requestBlocksUngrouping(const std::string& uniqueName) {
     _graphModel->sendMessage(std::move(message));
 }
 
+void FlowgraphEditor::dropReferencesToDeletedBlocks() {
+    if (_seenBlockDestructionCount == _graphModel->blockDestructionCount) {
+        return;
+    }
+    _seenBlockDestructionCount = _graphModel->blockDestructionCount;
+
+    // unfortunately we must always clear the selection if any block has been
+    // destroyed, because we do not have a way to identify whether a given
+    // NodeId points to a now-freed block. Could be solved by generation/index
+    // for node ID?
+    makeCurrent();
+    ax::NodeEditor::ClearSelection();
+
+    const auto isLiveChild = [this](const UiGraphBlock* block) { //
+        return std::ranges::contains(_rootBlock->childBlocks, block, [](const auto& child) { return child.get(); });
+    };
+    if (_selectedBlock != nullptr && !isLiveChild(_selectedBlock)) {
+        _selectedBlock = nullptr;
+    }
+    if (_filterBlock != nullptr && !isLiveChild(_filterBlock)) {
+        _filterBlock = nullptr;
+    }
+}
+
 std::vector<std::string> FlowgraphEditor::selectedBlockUniqueNames() {
     makeCurrent();
+    dropReferencesToDeletedBlocks();
     std::vector<ax::NodeEditor::NodeId> selectedNodes(static_cast<std::size_t>(ax::NodeEditor::GetSelectedObjectCount()));
     const auto                          nodeCount = ax::NodeEditor::GetSelectedNodes(selectedNodes.data(), static_cast<int>(selectedNodes.size()));
 

--- a/src/ui/FlowgraphPage.hpp
+++ b/src/ui/FlowgraphPage.hpp
@@ -42,6 +42,10 @@ private:
     const UiGraphBlock* _filterBlock   = nullptr;
     UiGraphBlock*       _selectedBlock = nullptr;
 
+    // keep track of whether a block has been destroyed and if so refresh things, so we don't have dangling NodeIds
+    std::uint64_t _seenBlockDestructionCount = 0;
+    void          dropReferencesToDeletedBlocks();
+
     struct ExportPortMessageData {
         std::string uniqueBlockName;
         std::string portDirection;
@@ -176,6 +180,8 @@ public:
     [[nodiscard]] std::vector<std::string> selectedBlockUniqueNames();
 
     void drawGroupingMenuItems(std::vector<std::string> uniqueNames);
+
+    void drawBlockContextMenu();
 
     void setFilterBlock(const UiGraphBlock* block) { _filterBlock = block; }
 

--- a/src/ui/FlowgraphPage.hpp
+++ b/src/ui/FlowgraphPage.hpp
@@ -56,6 +56,9 @@ private:
     float                                _timeSpentHoldingPin = 0.0;
     std::optional<ExportPortMessageData> _draggingPinExportRequest;
 
+    // set from within a context menu, handled once the menu popup is closed (a modal opened from inside a popup would be nested in it)
+    std::optional<std::vector<std::string>> _pendingGroupBlocksRequest;
+
     static constexpr float borderExteriorHoverFadeTransitionDurationSeconds = 0.4f;
     float                  _timeSpentHoveringBoundingBoxExterior            = 0.0;
     bool                   _wasHoveringBoundingBoxExteriorThisFrame         = false;
@@ -91,9 +94,10 @@ public:
 
     std::function<void()> closeRequestedCallback;
 
-    std::function<void(UiGraphModel*)> openNewBlockSelectorCallback;
-    std::function<void(UiGraphModel*)> openNewSubGraphSelectorCallback;
-    std::function<void(UiGraphModel*)> openAddRemoteSignalCallback;
+    std::function<void(UiGraphModel*)>            openNewBlockSelectorCallback;
+    std::function<void(UiGraphModel*)>            openNewSubGraphSelectorCallback;
+    std::function<void(UiGraphModel*)>            openAddRemoteSignalCallback;
+    std::function<void(std::vector<std::string>)> openGroupBlocksSelectorCallback;
 
     std::string                          exportPortTextField;
     std::optional<ExportPortMessageData> exportPortRequest;
@@ -165,6 +169,14 @@ public:
 
     void requestBlockDeletion(const std::string& blockName);
 
+    void requestBlocksGrouping(std::string graphType, const std::vector<std::string>& uniqueNames);
+
+    void requestBlocksUngrouping(const std::string& uniqueName);
+
+    [[nodiscard]] std::vector<std::string> selectedBlockUniqueNames();
+
+    void drawGroupingMenuItems(std::vector<std::string> uniqueNames);
+
     void setFilterBlock(const UiGraphBlock* block) { _filterBlock = block; }
 
     UiGraphModel* graphModel() const { return _graphModel; }
@@ -227,7 +239,6 @@ public:
 
     void setDashboard(Dashboard* dashboard) {
         _dashboard = dashboard;
-        _newBlockSelector.setGraphModel(dashboard ? std::addressof(dashboard->graphModel) : nullptr);
         if (dashboard) {
             _remoteSignalSelector = std::make_unique<SignalSelector>(dashboard->graphModel);
         } else {

--- a/src/ui/GraphModel.cpp
+++ b/src/ui/GraphModel.cpp
@@ -150,6 +150,12 @@ void UiGraphBlock::handlePortExported(const gr::property_map& data) {
         }
     }
 
+    // refresh our ports based on what is now exported, and adjust any edges in
+    // the parent graph which might now have invalid pointers
+    if (subgraphRebuildVisiblePortsFromExportedPorts() && parentBlock) {
+        parentBlock->graphResolveEdgePortPointersAndRemoveIfInvalid();
+    }
+
     requestBlockUpdate();
 }
 
@@ -198,10 +204,11 @@ void UiGraphBlock::setGraphChildren(const gr::property_map& data) {
                 handleChildBlockEmplaced(*blockData);
             }
         }
-    } else {
-        const auto& children = getProperty<gr::Tensor<gr::pmt::Value>>(data, "graph"s, "blocks"s);
-        for (const auto& blockData : children) {
-            const auto mapOpt = blockData.get_if<gr::property_map>();
+    } else if (const auto graphData = getOptionalProperty<gr::property_map>(data, "graph"s); graphData.has_value()) {
+        using TensorView = gr::TensorView<gr::pmt::Value>;
+        auto maybeView   = graphData->template get_if<TensorView>("blocks");
+        for (auto blockData : maybeView.value_or(TensorView{})) {
+            const auto mapOpt = blockData.template get_if<gr::property_map>();
             if (!mapOpt) {
                 continue;
             }
@@ -244,6 +251,23 @@ void UiGraphBlock::setGraphChildren(const gr::property_map& data) {
                 childEdges.emplace_back(std::move(*edge));
             } else {
                 components::Notification::error("Invalid edge ignored");
+            }
+        }
+    } else if (const auto graphData = getOptionalProperty<gr::property_map>(data, "graph"s); graphData.has_value()) {
+        // this is an alternative way edges may appear for unmanaged subgraphs...
+        // these could probably be made consistent in GR?
+        using TensorView = gr::TensorView<gr::pmt::Value>;
+        auto maybeView   = graphData->template get_if<TensorView>("connections");
+        for (auto connection_ : maybeView.value_or(TensorView{})) {
+            const auto connection = connection_.template get_if<gr::TensorView<gr::pmt::Value>>();
+            if (!connection) {
+                continue;
+            }
+            auto edge = parseSubgraphEdgeData(*connection);
+            if (edge) {
+                childEdges.emplace_back(std::move(*edge));
+            } else {
+                components::Notification::error("Invalid connection ignored");
             }
         }
     }
@@ -298,6 +322,12 @@ void UiGraphBlock::setBlockData(const gr::property_map& data) {
         message.data        = gr::property_map{};
         ownerGraph->sendMessage(std::move(message));
     }
+
+    if (subgraphRebuildVisiblePortsFromExportedPorts() && parentBlock && !parentBlock->newGraphDataBeingSet) {
+        // this update did not come through the parent, so the parent's edges may
+        // point into the port collections we have just rebuilt
+        parentBlock->graphResolveEdgePortPointersAndRemoveIfInvalid();
+    }
 }
 
 void UiGraphBlock::setBasicBlockData(const gr::property_map& blockData) {
@@ -338,42 +368,11 @@ void UiGraphBlock::setBasicBlockData(const gr::property_map& blockData) {
         updateFieldFrom(blockTypeName, blockData, {}, gr::serialization_fields::BLOCK_ID);
     }
 
-    // Meta information needs special handling as it contains the
-    // information about the exported ports
-    if (auto metaInformation = getOptionalProperty<gr::property_map>(blockData, gr::serialization_fields::BLOCK_META_INFORMATION); metaInformation.has_value()) {
+    updateFieldFrom(blockMetaInformation, blockData, {}, gr::serialization_fields::BLOCK_META_INFORMATION);
 
-        blockMetaInformation   = *metaInformation;
-        auto readExportedPorts = [this](auto& destination, const std::string& key) {
-            auto it = blockMetaInformation.find(key);
-            if (it == blockMetaInformation.end()) {
-                return;
-            }
-
-            destination.clear();
-            auto map = it->second.get_if<gr::property_map>();
-            if (!map) {
-                return;
-            }
-
-            for (const auto& [subBlockName, portMappings_] : *map) {
-                const auto portMappings = portMappings_.template get_if<gr::property_map>();
-                if (!portMappings) {
-                    continue;
-                }
-                for (const auto& [portName, portMapping_] : *portMappings) {
-                    const auto portMapping = portMapping_.template get_if<gr::property_map>();
-                    if (!portMapping) {
-                        continue;
-                    }
-                    if (auto portIt = portMapping->find("exportedName"); portIt != portMapping->end()) {
-                        destination[std::string(subBlockName)].insert(PortNameMapper{std::string(portName), portIt->second.value_or(std::string())});
-                    }
-                }
-            }
-        };
-
-        readExportedPorts(exportedInputPorts, "exportedInputPorts"s);
-        readExportedPorts(exportedOutputPorts, "exportedOutputPorts"s);
+    // subgraphs have a "graph" entry for exported ports
+    if (const auto graphData = getOptionalProperty<gr::property_map>(blockData, "graph"s); graphData.has_value()) {
+        parseExportedPorts(*graphData);
     }
 
     blockSettings.erase(std::pmr::string(gr::serialization_fields::BLOCK_UNIQUE_NAME));
@@ -384,43 +383,22 @@ void UiGraphBlock::setBasicBlockData(const gr::property_map& blockData) {
     updateFieldFrom(blockIsBlocking, blockData, blockIsBlocking, "is_blocking"s);
 
     auto processPorts = [&blockData, this](auto& portsCollection, std::string_view portsField, gr::PortDirection direction) {
+        // we traverse the children of graphs and look for exported ports to figure out what ports are exposed from a
+        // subgraph, see subgraphRebuildVisiblePortsFromExportedPorts()
+        if (isGraph() || isScheduler()) {
+            return;
+        }
+
         portsCollection.clear();
-
-        // if (exportedInputPorts.empty() && exportedOutputPorts.empty()) {
-        if (blockCategory != "ScheduledBlockGroup") {
-            for (const auto& [portName, portData_] : getProperty<gr::property_map>(blockData, portsField)) {
-                const auto portData = portData_.get_if<gr::property_map>();
-                if (!portData) {
-                    continue;
-                }
-                auto& port         = portsCollection.emplace_back(/*owner*/ this);
-                port.portName      = portName;
-                port.portType      = getProperty<std::string>(*portData, "type"s);
-                port.portDirection = direction;
+        for (const auto& [portName, portData_] : getProperty<gr::property_map>(blockData, portsField)) {
+            const auto portData = portData_.get_if<gr::property_map>();
+            if (!portData) {
+                continue;
             }
-        } else {
-            assert(childBlocks.size() <= 1);
-            if (childBlocks.size() != 0) {
-                auto* graph         = childBlocks[0].get();
-                auto& exportedPorts = direction == gr::PortDirection::INPUT ? exportedInputPorts : exportedOutputPorts;
-                for (const auto& [childBlockName, portDefinitions] : exportedPorts) {
-                    auto* child = graph->findBlockByUniqueName(childBlockName);
-                    if (child == nullptr) {
-                        continue;
-                    }
-                    for (const auto& portDefinition : portDefinitions) {
-                        auto portFound = child->findPortIteratorByName(direction == gr::PortDirection::INPUT ? child->inputPorts() : child->outputPorts(), portDefinition.internalName);
-                        if (!portFound.second) {
-                            continue;
-                        }
-
-                        auto& port         = portsCollection.emplace_back(/*owner*/ this);
-                        port.portName      = portDefinition.exportedName;
-                        port.portType      = (portFound.first)->portType;
-                        port.portDirection = direction;
-                    }
-                }
-            }
+            auto& port         = portsCollection.emplace_back(/*owner*/ this);
+            port.portName      = portName;
+            port.portType      = getProperty<std::string>(*portData, "type"s);
+            port.portDirection = direction;
         }
     };
 
@@ -450,6 +428,88 @@ void UiGraphBlock::setBasicBlockData(const gr::property_map& blockData) {
     shouldRearrangeBlocks = true;
 }
 
+void UiGraphBlock::parseExportedPorts(const gr::property_map& graphData) {
+    const auto exportedPorts = graphData.get_if<gr::TensorView<gr::pmt::Value>>("exported_ports");
+    if (!exportedPorts) {
+        return;
+    }
+
+    exportedInputPorts.clear();
+    exportedOutputPorts.clear();
+
+    for (const auto& entry_ : *exportedPorts) {
+        // each entry is [inner block unique name, "INPUT"/"OUTPUT", {internalPortName: {"exportedName": ...}}]
+        const auto entryView = entry_.template get_if<gr::TensorView<gr::pmt::Value>>();
+        if (!entryView || entryView->size() != 3) {
+            continue;
+        }
+        const gr::Tensor<gr::pmt::Value> entry = entryView->owned();
+
+        const auto innerBlockUniqueName = entry.data()[0].value_or(std::string());
+        const auto direction            = entry.data()[1].value_or(std::string());
+        const auto portMappings         = entry.data()[2].template get_if<gr::property_map>();
+        if (innerBlockUniqueName.empty() || !portMappings) {
+            continue;
+        }
+
+        auto& destination = direction == "INPUT"s ? exportedInputPorts : exportedOutputPorts;
+        for (const auto& [internalPortName, portMapping_] : *portMappings) {
+            const auto portMapping = portMapping_.template get_if<gr::property_map>();
+            if (!portMapping) {
+                continue;
+            }
+            if (auto exportedNameIt = portMapping->find("exportedName"); exportedNameIt != portMapping->end()) {
+                destination[innerBlockUniqueName].insert(PortNameMapper{std::string(internalPortName), exportedNameIt->second.value_or(std::string())});
+            } else {
+            }
+        }
+    }
+}
+
+UiGraphBlock* UiGraphBlock::getBlockWithGraphChildren() {
+    if (isGraph()) {
+        return this;
+    }
+    if (isScheduler()) {
+        // schedulers keep their blocks in the single wrapped graph child
+        assert(childBlocks.size() <= 1);
+        return childBlocks.empty() ? nullptr : childBlocks[0].get();
+    }
+    return nullptr;
+}
+
+bool UiGraphBlock::subgraphRebuildVisiblePortsFromExportedPorts() {
+    if (!isGraph() && !isScheduler()) {
+        return false;
+    }
+
+    _inputPorts.clear();
+    _outputPorts.clear();
+
+    UiGraphBlock* graph     = getBlockWithGraphChildren();
+    auto          fillPorts = [this, graph](std::vector<UiGraphPort>& portsCollection, gr::PortDirection direction) {
+        const auto& exportedPorts = direction == gr::PortDirection::INPUT ? exportedInputPorts : exportedOutputPorts;
+        for (const auto& [childBlockName, portDefinitions] : exportedPorts) {
+            UiGraphBlock* child = graph ? graph->findBlockByUniqueName(childBlockName) : nullptr;
+            for (const auto& portDefinition : portDefinitions) {
+                auto& port         = portsCollection.emplace_back(/*owner*/ this);
+                port.portName      = portDefinition.exportedName;
+                port.portDirection = direction;
+                if (child) {
+                    auto portFound = child->findPortIteratorByName(direction == gr::PortDirection::INPUT ? child->_inputPorts : child->_outputPorts, portDefinition.internalName);
+                    if (portFound.second) {
+                        port.portType = portFound.first->portType;
+                    }
+                }
+            }
+        }
+    };
+
+    fillPorts(_inputPorts, gr::PortDirection::INPUT);
+    fillPorts(_outputPorts, gr::PortDirection::OUTPUT);
+    return true;
+}
+
 std::optional<UiGraphEdge> UiGraphBlock::parseEdgeData(const gr::property_map& edgeData) {
     UiGraphEdge edge;
     updateFieldFrom(edge.edgeSourceBlockName, edgeData, {}, gr::serialization_fields::EDGE_SOURCE_BLOCK);
@@ -469,39 +529,8 @@ std::optional<UiGraphEdge> UiGraphBlock::parseEdgeData(const gr::property_map& e
     edge.edgeSourcePortDefinition      = portDefinitionFor(std::string(gr::serialization_fields::EDGE_SOURCE_PORT));
     edge.edgeDestinationPortDefinition = portDefinitionFor(std::string(gr::serialization_fields::EDGE_DESTINATION_PORT));
 
-    auto findPortFor = [this](std::string& currentBlockName, auto member, const gr::PortDefinition& portDefinition_) -> UiGraphPort* {
-        auto [it, found] = findBlockIteratorByUniqueName(currentBlockName);
-        if (!found) {
-            return nullptr;
-        }
-
-        auto& block = *it;
-        auto& ports = std::invoke(member, block);
-
-        return std::visit(gr::meta::overloaded{//
-                              [&ports](const gr::PortDefinition::IndexBased& indexBasedDefinition) -> UiGraphPort* {
-                                  // TODO: sub-index for ports -- when we add UI support for
-                                  // port arrays
-                                  if (indexBasedDefinition.topLevel >= ports.size()) {
-                                      return nullptr;
-                                  }
-
-                                  return std::addressof(ports[indexBasedDefinition.topLevel]);
-                              },
-                              [&ports](const gr::PortDefinition::StringBased& stringBasedDefinition) -> UiGraphPort* { //
-                                  auto portIt = std::ranges::find_if(ports, [&](const auto& port) {                    //
-                                      return port.portName == stringBasedDefinition.name;
-                                  });
-                                  if (portIt == ports.end()) {
-                                      return nullptr;
-                                  }
-                                  return std::addressof(*portIt);
-                              }},
-            portDefinition_.definition);
-    };
-
-    edge.edgeSourcePort      = findPortFor(edge.edgeSourceBlockName, &UiGraphBlock::_outputPorts, edge.edgeSourcePortDefinition);
-    edge.edgeDestinationPort = findPortFor(edge.edgeDestinationBlockName, &UiGraphBlock::_inputPorts, edge.edgeDestinationPortDefinition);
+    edge.edgeSourcePort      = resolveChildPort(edge.edgeSourceBlockName, gr::PortDirection::OUTPUT, edge.edgeSourcePortDefinition);
+    edge.edgeDestinationPort = resolveChildPort(edge.edgeDestinationBlockName, gr::PortDirection::INPUT, edge.edgeDestinationPortDefinition);
 
     if (!edge.edgeSourcePort || !edge.edgeDestinationPort) {
         std::println("Warning: Edge definition invalid source {} destination {}", !!edge.edgeSourcePort, !!edge.edgeDestinationPort);
@@ -519,16 +548,121 @@ std::optional<UiGraphEdge> UiGraphBlock::parseEdgeData(const gr::property_map& e
     return edge;
 }
 
+UiGraphPort* UiGraphBlock::resolveChildPort(const std::string& childUniqueName, gr::PortDirection direction, const gr::PortDefinition& portDefinition) {
+    auto [it, found] = findBlockIteratorByUniqueName(childUniqueName);
+    if (!found) {
+        return nullptr;
+    }
+
+    auto& ports = direction == gr::PortDirection::INPUT ? (*it)->_inputPorts : (*it)->_outputPorts;
+
+    return std::visit(gr::meta::overloaded{//
+                          [&ports](const gr::PortDefinition::IndexBased& indexBasedDefinition) -> UiGraphPort* {
+                              // TODO: sub-index for ports -- when we add UI support for
+                              // port arrays
+                              if (indexBasedDefinition.topLevel >= ports.size()) {
+                                  return nullptr;
+                              }
+
+                              return std::addressof(ports[indexBasedDefinition.topLevel]);
+                          },
+                          [&ports](const gr::PortDefinition::StringBased& stringBasedDefinition) -> UiGraphPort* { //
+                              auto portIt = std::ranges::find_if(ports, [&](const auto& port) {                    //
+                                  return port.portName == stringBasedDefinition.name;
+                              });
+                              if (portIt == ports.end()) {
+                                  return nullptr;
+                              }
+                              return std::addressof(*portIt);
+                          }},
+        portDefinition.definition);
+}
+
+std::optional<UiGraphEdge> UiGraphBlock::parseSubgraphEdgeData(const gr::TensorView<gr::pmt::Value>& connectionView) {
+    // connections are of the format [sourceBlockName, sourcePort, destinationBlockName, destinationPort, ?minBufferSize]
+    if (connectionView.size() < 4) {
+        return {};
+    }
+    // copy so that indexing returns an owned thing instead of a temporary
+    const gr::Tensor<gr::pmt::Value> connection = connectionView.owned();
+
+    const auto uniqueNameForBlockName = [this](const std::string& childName) -> std::optional<std::string> {
+        auto [it, found] = findBlockIteratorBy({SearchProperty::Name}, childName);
+        if (!found) {
+            return {};
+        }
+        return (*it)->blockUniqueName;
+    };
+
+    const auto portDefinitionFor = [](const gr::pmt::Value& portField) -> std::optional<gr::PortDefinition> {
+        if (portField.is_string()) {
+            return gr::PortDefinition(portField.value_or(std::string()));
+        }
+        if (const auto indexPair = portField.get_if<gr::TensorView<gr::pmt::Value>>(); indexPair && indexPair->size() == 2) {
+            const gr::Tensor<gr::pmt::Value> indices = indexPair->owned();
+
+            const auto topLevel = indices.data()[0].get_if<std::int64_t>();
+            const auto subIndex = indices.data()[1].get_if<std::int64_t>();
+            if (!topLevel || !subIndex) {
+                return {};
+            }
+            return gr::PortDefinition(static_cast<std::size_t>(*topLevel), static_cast<std::size_t>(*subIndex));
+        }
+        if (const auto index = portField.get_if<std::int64_t>()) {
+            return gr::PortDefinition(static_cast<std::size_t>(*index));
+        }
+        return {};
+    };
+
+    const auto sourceBlockUniqueName      = uniqueNameForBlockName(connection.data()[0].value_or(std::string()));
+    const auto sourcePort                 = portDefinitionFor(connection.data()[1]);
+    const auto destinationBlockUniqueName = uniqueNameForBlockName(connection.data()[2].value_or(std::string()));
+    const auto destinationPort            = portDefinitionFor(connection.data()[3]);
+    if (!sourceBlockUniqueName || !sourcePort || !destinationBlockUniqueName || !destinationPort) {
+        return {};
+    }
+
+    UiGraphEdge edge;
+    edge.edgeSourceBlockName           = *sourceBlockUniqueName;
+    edge.edgeSourcePortDefinition      = *sourcePort;
+    edge.edgeDestinationBlockName      = *destinationBlockUniqueName;
+    edge.edgeDestinationPortDefinition = *destinationPort;
+    edge.edgeSourcePort                = resolveChildPort(edge.edgeSourceBlockName, gr::PortDirection::OUTPUT, edge.edgeSourcePortDefinition);
+    edge.edgeDestinationPort           = resolveChildPort(edge.edgeDestinationBlockName, gr::PortDirection::INPUT, edge.edgeDestinationPortDefinition);
+    if (!edge.edgeSourcePort || !edge.edgeDestinationPort) {
+        return {};
+    }
+
+    if (connection.size() >= 5) {
+        if (const auto minBufferSize = connection.data()[4].get_if<gr::Size_t>()) {
+            edge.edgeMinBufferSize = static_cast<std::size_t>(*minBufferSize);
+        }
+    }
+    return edge;
+}
+
+void UiGraphBlock::graphResolveEdgePortPointersAndRemoveIfInvalid() {
+    std::erase_if(childEdges, [this](UiGraphEdge& edge) {
+        edge.edgeSourcePort      = resolveChildPort(edge.edgeSourceBlockName, gr::PortDirection::OUTPUT, edge.edgeSourcePortDefinition);
+        edge.edgeDestinationPort = resolveChildPort(edge.edgeDestinationBlockName, gr::PortDirection::INPUT, edge.edgeDestinationPortDefinition);
+        return edge.edgeSourcePort == nullptr || edge.edgeDestinationPort == nullptr;
+    });
+}
+
 void UiGraphBlock::removeEdgesForBlock(UiGraphBlock& block) {
     std::erase_if(childEdges, [blockPtr = std::addressof(block)](const auto& edge) {
         return edge.edgeSourcePort->ownerBlock == blockPtr || //
                edge.edgeDestinationPort->ownerBlock == blockPtr;
     });
 
-    if (parentBlock) {
-        parentBlock->exportedInputPorts.erase(block.blockUniqueName);
-        parentBlock->exportedOutputPorts.erase(block.blockUniqueName);
-        parentBlock->requestBlockUpdate();
+    UiGraphBlock* exportOwner = (parentBlock && parentBlock->isScheduler()) ? parentBlock : this;
+    const bool    hadExports  = exportOwner->exportedInputPorts.erase(block.blockUniqueName) > 0 || //
+                            exportOwner->exportedOutputPorts.erase(block.blockUniqueName) > 0;
+    if (hadExports) {
+        if (exportOwner->subgraphRebuildVisiblePortsFromExportedPorts() && exportOwner->parentBlock) {
+            exportOwner->parentBlock->graphResolveEdgePortPointersAndRemoveIfInvalid();
+        }
+        exportOwner->requestBlockUpdate();
     }
 }
 
@@ -909,6 +1043,9 @@ bool UiGraphModel::processMessage(const gr::Message& message) {
         // setBlockData, but force setting children data
         targetBlock.block->setBasicBlockData(data);
         targetBlock.block->setSchedulerGraph(data);
+        if (targetBlock.block->subgraphRebuildVisiblePortsFromExportedPorts() && targetBlock.parentGraph) {
+            targetBlock.parentGraph->graphResolveEdgePortPointersAndRemoveIfInvalid();
+        }
         targetBlock.block->blockCategoryInfo = UiGraphBlock::SchedulerBlockInfo{.childrenLoaded = true};
         requestedFullUpdate                  = false;
 
@@ -951,6 +1088,9 @@ bool UiGraphModel::processMessage(const gr::Message& message) {
         }
     } else if (message.endpoint == graph::kSubgraphExportedPort) {
         targetBlock.block->handlePortExported(data);
+
+    } else if (message.endpoint == scheduler::kBlocksGrouped || message.endpoint == scheduler::kBlocksUngrouped) {
+        requestFullUpdate();
 
     } else {
         if (!message.data) {

--- a/src/ui/GraphModel.cpp
+++ b/src/ui/GraphModel.cpp
@@ -16,6 +16,15 @@
 
 using namespace std::string_literals;
 
+UiGraphBlock::~UiGraphBlock() {
+    if (ownerGraph) {
+        ownerGraph->blockDestructionCount++;
+        if (ownerGraph->selectedBlock == this) {
+            ownerGraph->selectedBlock = nullptr;
+        }
+    }
+}
+
 auto UiGraphBlock::findBlockIteratorBy(std::initializer_list<SearchProperty> searchProperties, std::string_view value) {
     assert(std::get_if<GraphBlockInfo>(&blockCategoryInfo) && "This makes sense only for graphs");
     auto it = std::ranges::find_if(childBlocks, [&](const auto& block) {
@@ -108,10 +117,6 @@ bool UiGraphBlock::handleChildBlockRemoved(const std::string& uniqueName) {
     }
 
     removeEdgesForBlock(*blockIt->get());
-
-    if (blockIt->get() == ownerGraph->selectedBlock) {
-        ownerGraph->selectedBlock = nullptr;
-    }
 
     childBlocks.erase(blockIt);
     shouldRearrangeBlocks = true;

--- a/src/ui/GraphModel.hpp
+++ b/src/ui/GraphModel.hpp
@@ -1,6 +1,7 @@
 #ifndef GRAPHMODEL_H
 #define GRAPHMODEL_H
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>
@@ -235,6 +236,8 @@ public:
 
     UiGraphBlock(UiGraphModel* ownerGraph_, UiGraphBlock* parentBlock_) : ownerGraph(ownerGraph_), parentBlock(parentBlock_) {}
 
+    ~UiGraphBlock();
+
     UiGraphBlock(const UiGraphBlock&)            = delete;
     UiGraphBlock& operator=(const UiGraphBlock&) = delete;
     UiGraphBlock(UiGraphBlock&&)                 = delete;
@@ -274,6 +277,10 @@ public:
     std::map<std::string, std::set<std::string>> knownSchedulerTypes;
 
     UiGraphBlock* selectedBlock = nullptr;
+
+    // child blocks will increment this when they are destroyed. it serves as a
+    // generation so the editor can know its node id pointers are invalid
+    std::uint64_t blockDestructionCount = 0;
 
     /**
      * @return true if consumed the message

--- a/src/ui/GraphModel.hpp
+++ b/src/ui/GraphModel.hpp
@@ -114,7 +114,20 @@ struct UiGraphBlock {
     void                       setBasicBlockData(const gr::property_map& blockData);
     void                       setGraphChildren(const gr::property_map& data);
     void                       setSchedulerGraph(const gr::property_map& data);
+    void                       parseExportedPorts(const gr::property_map& graphData);
     std::optional<UiGraphEdge> parseEdgeData(const gr::property_map& edgeData);
+    /// Alternative format for edges that happens when you inspect a scheduler and get a
+    /// description of a child subgraph
+    std::optional<UiGraphEdge> parseSubgraphEdgeData(const gr::TensorView<gr::pmt::Value>& connection);
+
+    /// Should only be called on schedulers/graphs, populates _outputPorts and
+    /// _inputPorts based on the values of exportedInputPorts and exportedOutputPorts.
+    /// Returns true if a change in ports may have occurred.
+    [[nodiscard]] bool subgraphRebuildVisiblePortsFromExportedPorts();
+    /// Resolves all childEdges' port pointers based on port and block names, removing
+    /// any that don't resolve to an actual port. This is necessary because subgraph
+    /// blocks can change their ports due to changes in exported/imported ports.
+    void graphResolveEdgePortPointersAndRemoveIfInvalid();
 
     [[nodiscard]] constexpr bool isPlotSink() const { return this->blockTypeName.starts_with("opendigitizer::ImPlotSink"); }
     [[nodiscard]] constexpr bool isScheduler() const { return std::holds_alternative<SchedulerBlockInfo>(blockCategoryInfo); }
@@ -139,9 +152,11 @@ struct UiGraphBlock {
 
 private:
     enum class SearchProperty { UniqueName, Name };
-    auto findBlockIteratorBy(std::initializer_list<SearchProperty>, std::string_view value);
-    auto findBlockIteratorByUniqueName(std::string_view uniqueName);
-    auto findPortIteratorByName(auto& ports, const std::string& portName);
+    auto          findBlockIteratorBy(std::initializer_list<SearchProperty>, std::string_view value);
+    auto          findBlockIteratorByUniqueName(std::string_view uniqueName);
+    auto          findPortIteratorByName(auto& ports, const std::string& portName);
+    UiGraphPort*  resolveChildPort(const std::string& childUniqueName, gr::PortDirection direction, const gr::PortDefinition& portDefinition);
+    UiGraphBlock* getBlockWithGraphChildren();
 
 public:
     void removeEdgesForBlock(UiGraphBlock& block);

--- a/src/ui/assets/sampleDashboards/DemoDashboard.grc
+++ b/src/ui/assets/sampleDashboards/DemoDashboard.grc
@@ -86,14 +86,14 @@ blocks:
       start_value: 0
       signal_trigger: "CMD_BP_START"
     ctx_parameters:
-      - context: "FAIR.SELECTOR.C=1:S=1:P=1"
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=1"
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 100
           sample_rate: 1000
           signal_type: Const
-      - context: "FAIR.SELECTOR.C=1:S=1:P=2"  # start pre-ramp
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=2"  # start pre-ramp
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.1
           start_value: 100
@@ -101,14 +101,14 @@ blocks:
           round_off_time: 0.02
           sample_rate: 1000
           signal_type: ParabolicRamp
-      - context: "FAIR.SELECTOR.C=1:S=1:P=3"  # lower-plateau
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=3"  # lower-plateau
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 500
           sample_rate: 1000
           signal_type: Const
-      - context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.5
           start_value: 500
@@ -116,22 +116,22 @@ blocks:
           round_off_time: 0.2
           sample_rate: 1000
           signal_type: ParabolicRamp
-      - context: "FAIR.SELECTOR.C=1:S=1:P=5" # upper-plateau
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=5" # upper-plateau
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 3000
           sample_rate: 1000
           signal_type: Const
-      - context: "FAIR.SELECTOR.C=1:S=1:P=6" # start ramp-down
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=6" # start ramp-down
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.3
           start_value: 3000
           final_value: 100
           sample_rate: 1000
           signal_type: CubicSpline
-      - context: "FAIR.SELECTOR.C=1:S=1:P=7" # upper-plateau
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=7" # upper-plateau
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 100
           sample_rate: 1000
@@ -144,22 +144,22 @@ blocks:
       start_value: 0
       signal_trigger: "CMD_BP_START"
     ctx_parameters:
-      - context: "FAIR.SELECTOR.C=1:S=1:P=3" # lower-plateau
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=3" # lower-plateau
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: !!float32 40e9
           sample_rate: 1000
           signal_type: Const
-      - context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.500000
           start_value: !!float32 40e9
           final_value: !!float32 38e9
           sample_rate: 1000
           signal_type: CubicSpline
-      - context: "FAIR.SELECTOR.C=1:S=1:P=5"
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=5"
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 2
           start_value: !!float32 38e9
@@ -167,8 +167,8 @@ blocks:
           round_off_time: 0.3
           sample_rate: 1000
           signal_type: ParabolicRamp
-      - context: "FAIR.SELECTOR.C=1:S=1:P=6"
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=6"
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 0
           sample_rate: 1000

--- a/src/ui/assets/sampleDashboards/PropertyControlDashboard.grc
+++ b/src/ui/assets/sampleDashboards/PropertyControlDashboard.grc
@@ -74,14 +74,14 @@ blocks:
       start_value: 0
       signal_trigger: "CMD_BP_START"
     ctx_parameters:
-      - context: "FAIR.SELECTOR.C=1:S=1:P=1"
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=1"
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 100
           sample_rate: 1000
           signal_type: Const
-      - context: "FAIR.SELECTOR.C=1:S=1:P=2"  # start pre-ramp
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=2"  # start pre-ramp
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.1
           start_value: 100
@@ -89,14 +89,14 @@ blocks:
           round_off_time: 0.02
           sample_rate: 1000
           signal_type: ParabolicRamp
-      - context: "FAIR.SELECTOR.C=1:S=1:P=3"  # lower-plateau
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=3"  # lower-plateau
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 500
           sample_rate: 1000
           signal_type: Const
-      - context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.5
           start_value: 500
@@ -104,22 +104,22 @@ blocks:
           round_off_time: 0.2
           sample_rate: 1000
           signal_type: ParabolicRamp
-      - context: "FAIR.SELECTOR.C=1:S=1:P=5" # upper-plateau
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=5" # upper-plateau
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 3000
           sample_rate: 1000
           signal_type: Const
-      - context: "FAIR.SELECTOR.C=1:S=1:P=6" # start ramp-down
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=6" # start ramp-down
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.3
           start_value: 3000
           final_value: 100
           sample_rate: 1000
           signal_type: CubicSpline
-      - context: "FAIR.SELECTOR.C=1:S=1:P=7" # upper-plateau
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=7" # upper-plateau
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 100
           sample_rate: 1000
@@ -132,22 +132,22 @@ blocks:
       start_value: 0
       signal_trigger: "CMD_BP_START"
     ctx_parameters:
-      - context: "FAIR.SELECTOR.C=1:S=1:P=3" # lower-plateau
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=3" # lower-plateau
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: !!float32 40e9
           sample_rate: 1000
           signal_type: Const
-      - context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.500000
           start_value: !!float32 40e9
           final_value: !!float32 38e9
           sample_rate: 1000
           signal_type: CubicSpline
-      - context: "FAIR.SELECTOR.C=1:S=1:P=5"
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=5"
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 2
           start_value: !!float32 38e9
@@ -155,8 +155,8 @@ blocks:
           round_off_time: 0.3
           sample_rate: 1000
           signal_type: ParabolicRamp
-      - context: "FAIR.SELECTOR.C=1:S=1:P=6"
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=6"
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 0
           sample_rate: 1000

--- a/src/ui/components/NewBlockSelector.cpp
+++ b/src/ui/components/NewBlockSelector.cpp
@@ -7,13 +7,10 @@
 #include "../components/Dialog.hpp"
 #include "../components/ListBox.hpp"
 
-#include "../ui/GraphModel.hpp"
-
 #include "NewBlockSelectorFuzzySearch.hpp"
 #include "scope_exit.hpp"
 
-#include <gnuradio-4.0/Message.hpp>
-#include <gnuradio-4.0/Scheduler.hpp>
+#include <gnuradio-4.0/meta/utils.hpp>
 
 using namespace std::string_literals;
 using DigitizerUi::components::FilterResult;
@@ -287,20 +284,13 @@ void NewBlockSelector::draw() {
         }
     }
 
-    const bool okEnabled = !m_currentlySelectedType.empty();
-    if (components::DialogButtons(okEnabled) == components::DialogButton::Ok) {
-        if (!m_currentlySelectedType.empty() && selectedParametrization) {
-            gr::Message message;
-            std::string type    = std::format("{}{}", m_currentlySelectedType, selectedParametrization.value_or(std::string{}));
-            message.cmd         = gr::message::Command::Set;
-            message.endpoint    = gr::scheduler::property::kEmplaceBlock;
-            message.serviceName = m_targetSchedulerUniqueName;
-            message.data        = gr::property_map{{"type", std::move(type)}};
-            if (!m_targetGraphUniqueName.empty()) {
-                (*message.data)["_targetGraph"] = m_targetGraphUniqueName;
-            }
-            m_graphModel->sendMessage(message);
-        }
+    const bool okEnabled    = !m_currentlySelectedType.empty();
+    const auto dialogResult = components::DialogButtons(okEnabled);
+    if (dialogResult == components::DialogButton::Ok && !m_currentlySelectedType.empty() && selectedParametrization && m_onTypeSelected) {
+        m_onTypeSelected(std::format("{}{}", m_currentlySelectedType, selectedParametrization.value_or(std::string{})));
+    }
+    if (dialogResult != components::DialogButton::None) {
+        m_onTypeSelected = {}; // release captured state once the popup closes
     }
 }
 } // namespace DigitizerUi

--- a/src/ui/components/NewBlockSelector.hpp
+++ b/src/ui/components/NewBlockSelector.hpp
@@ -3,13 +3,12 @@
 
 #include <imgui.h>
 
+#include <functional>
 #include <map>
 #include <set>
 #include <string>
 
 namespace DigitizerUi {
-
-class UiGraphModel;
 
 class NewBlockSelector {
 private:
@@ -20,25 +19,21 @@ private:
     std::string m_currentlySelectedType;
     std::string m_previouslySelectedType;
     std::string m_selectedTypeParametrizationListName;
-    std::string m_targetSchedulerUniqueName;
-    std::string m_targetGraphUniqueName;
 
-    UiGraphModel* m_graphModel = nullptr;
+    std::function<void(std::string)> m_onTypeSelected;
 
     void drawNamespaceTree(const ImVec2& size);
 
 public:
     std::map<std::string, std::set<std::string>> data;
 
-    void open(std::string targetSchedulerUniqueName, std::string targetGraphUniqueName) {
-        m_targetSchedulerUniqueName = targetSchedulerUniqueName;
-        m_targetGraphUniqueName     = targetGraphUniqueName;
-        assert(!m_targetGraphUniqueName.empty() && !m_targetSchedulerUniqueName.empty());
+    /// onTypeSelected is invoked with the chosen type when the user confirms with OK
+    void open(std::function<void(std::string)> onTypeSelected) {
+        m_onTypeSelected = std::move(onTypeSelected);
+        assert(m_onTypeSelected);
         ImGui::OpenPopup(m_windowName.c_str());
     }
     void draw();
-
-    void setGraphModel(UiGraphModel* newModel) { m_graphModel = newModel; }
 };
 } // namespace DigitizerUi
 

--- a/src/ui/test/CMakeLists.txt
+++ b/src/ui/test/CMakeLists.txt
@@ -63,6 +63,7 @@ if(ENABLE_IMGUI_TEST_ENGINE)
     NAMESPACE
     ui_test_assets
     examples/fg_dipole_intensity_ramp.grc
+    examples/qa_grouping.grc
     examples/qa_layout.grc
     examples/qa_subgraph.grc)
 

--- a/src/ui/test/examples/fg_dipole_intensity_ramp.grc
+++ b/src/ui/test/examples/fg_dipole_intensity_ramp.grc
@@ -34,14 +34,14 @@ blocks:
       start_value: 0
       signal_trigger: "CMD_BP_START"
     ctx_parameters:
-      - context: "FAIR.SELECTOR.C=1:S=1:P=1"
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=1"
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 1
           sample_rate: 1000
           signal_type: Const
-      - context: "FAIR.SELECTOR.C=1:S=1:P=2"  # start pre-ramp
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=2"  # start pre-ramp
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.1
           start_value: 1
@@ -49,14 +49,14 @@ blocks:
           round_off_time: 0.02
           sample_rate: 1000
           signal_type: ParabolicRamp
-      - context: "FAIR.SELECTOR.C=1:S=1:P=3"  # lower-plateau
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=3"  # lower-plateau
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 5
           sample_rate: 1000
           signal_type: Const
-      - context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.5
           start_value:  5
@@ -64,22 +64,22 @@ blocks:
           round_off_time: 0.2
           sample_rate: 1000
           signal_type: ParabolicRamp
-      - context: "FAIR.SELECTOR.C=1:S=1:P=5" # upper-plateau
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=5" # upper-plateau
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 30
           sample_rate: 1000
           signal_type: Const
-      - context: "FAIR.SELECTOR.C=1:S=1:P=6" # start ramp-down
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=6" # start ramp-down
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.3
           start_value: 30
           final_value:  1
           sample_rate: 1000
           signal_type: CubicSpline
-      - context: "FAIR.SELECTOR.C=1:S=1:P=7" # upper-plateau
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=7" # upper-plateau
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 1
           sample_rate: 1000
@@ -92,22 +92,22 @@ blocks:
       start_value: 0
       signal_trigger: "CMD_BP_START"
     ctx_parameters:
-      - context: "FAIR.SELECTOR.C=1:S=1:P=3" # lower-plateau
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=3" # lower-plateau
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: !!float32 40e9
           sample_rate: 1000
           signal_type: Const
-      - context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=4" # start main-ramp
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 0.500000
           start_value: !!float32 40e9
           final_value: !!float32 38e9
           sample_rate: 1000
           signal_type: CubicSpline
-      - context: "FAIR.SELECTOR.C=1:S=1:P=5"
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=5"
+        gr:ctx_time: !!uint64 0
         parameters:
           duration: 2
           start_value: !!float32 38e9
@@ -115,8 +115,8 @@ blocks:
           round_off_time: 0.3
           sample_rate: 1000
           signal_type: ParabolicRamp
-      - context: "FAIR.SELECTOR.C=1:S=1:P=6"
-        ctx_time: !!uint64 0
+      - gr:context: "FAIR.SELECTOR.C=1:S=1:P=6"
+        gr:ctx_time: !!uint64 0
         parameters:
           start_value: 0
           sample_rate: 1000

--- a/src/ui/test/examples/qa_grouping.grc
+++ b/src/ui/test/examples/qa_grouping.grc
@@ -1,0 +1,23 @@
+blocks:
+  - id: opendigitizer::SineSource<float32>
+    parameters:
+      name: source
+  - id: gr::testing::Copy<float32>
+    parameters:
+      name: middleA
+  - id: gr::testing::Copy<float32>
+    parameters:
+      name: middleB
+  - id: gr::basic::DataSink<float32>
+    parameters:
+      name: sink
+  - id: opendigitizer::SineSource<float32>
+    parameters:
+      name: loner1
+  - id: opendigitizer::SineSource<float32>
+    parameters:
+      name: loner2
+connections:
+  - [source, 0, middleA, 0]
+  - [middleA, 0, middleB, 0]
+  - [middleB, 0, sink, 0]

--- a/src/ui/test/qa_GraphModel.cpp
+++ b/src/ui/test/qa_GraphModel.cpp
@@ -91,6 +91,16 @@ struct TestApp : public DigitizerUi::test::ImGuiTestApp {
         graphModel.sendMessage(std::move(message));
     }
 
+    static void sendRemoveBlock(const std::string& uniqueName) {
+        auto&       graphModel = g_state.dashboard->graphModel;
+        gr::Message message;
+        message.cmd         = gr::message::Command::Set;
+        message.endpoint    = gr::scheduler::property::kRemoveBlock;
+        message.serviceName = graphModel.rootBlock.blockUniqueName;
+        message.data        = gr::property_map{{"uniqueName", uniqueName}, {"_targetGraph", rootGraph()->blockUniqueName}};
+        graphModel.sendMessage(std::move(message));
+    }
+
     static const UiGraphEdge* findEdge(const UiGraphBlock* graph, std::string_view sourceBlockUniqueName, std::string_view destinationBlockUniqueName) {
         auto it = std::ranges::find_if(graph->childEdges, [&](const UiGraphEdge& edge) { //
             return edge.edgeSourceBlockName == sourceBlockUniqueName && edge.edgeDestinationBlockName == destinationBlockUniqueName;
@@ -404,6 +414,89 @@ struct TestApp : public DigitizerUi::test::ImGuiTestApp {
                 expect(edge == nullptr || (edge->edgeSourcePort != nullptr && edge->edgeDestinationPort != nullptr)) << "restored edge should resolve its ports";
             }
 
+            g_state.stopScheduler();
+        });
+
+        registerMessageTest("removing the selected block clears the selection", [](ImGuiTestContext* ctx) {
+            reloadAndWait(ctx, reloadGrouping);
+
+            UiGraphBlock* loner1 = findByName("loner1");
+            expect(loner1 != nullptr) << fatal;
+            const auto loner1UniqueName = loner1->blockUniqueName;
+
+            g_state.dashboard->graphModel.selectedBlock = loner1;
+
+            sendRemoveBlock(loner1UniqueName);
+            expect(waitForReplyOnEndpoint(ctx, gr::scheduler::property::kBlockRemoved)) << "scheduler did not confirm block removal";
+            expect(awaitCondition(ctx, [loner1UniqueName] { return rootGraph()->findBlockByUniqueName(loner1UniqueName) == nullptr; })) << fatal << "removed block should disappear from the graph model";
+
+            expect(g_state.dashboard->graphModel.selectedBlock == nullptr) << "selection should be cleared when the selected block is deleted";
+            g_state.stopScheduler();
+        });
+
+        registerMessageTest("removing a subgraph clears the selection of an inner block", [](ImGuiTestContext* ctx) {
+            reloadAndWait(ctx, reloadGrouping);
+
+            UiGraphBlock* loner1 = findByName("loner1");
+            UiGraphBlock* loner2 = findByName("loner2");
+            expect(loner1 != nullptr && loner2 != nullptr) << fatal;
+            const auto loner1UniqueName = loner1->blockUniqueName;
+            const auto loner2UniqueName = loner2->blockUniqueName;
+
+            UiGraphBlock* subgraph = groupAndWait(ctx, {loner1UniqueName, loner2UniqueName});
+            expect(subgraph != nullptr) << fatal;
+
+            g_state.dashboard->graphModel.selectedBlock = subgraph;
+
+            sendRemoveBlock(subgraph->blockUniqueName);
+            expect(waitForReplyOnEndpoint(ctx, gr::scheduler::property::kBlockRemoved)) << "scheduler did not confirm subgraph removal";
+            expect(awaitCondition(ctx, [] { return findSubgraphIn(rootGraph()) == nullptr; })) << fatal << "removed subgraph should disappear from the graph model";
+
+            expect(g_state.dashboard->graphModel.selectedBlock == nullptr) << "selection should be cleared when the selected block is deleted";
+            g_state.stopScheduler();
+        });
+
+        registerMessageTest("reinspection not reporting the selected block clears the selection", [](ImGuiTestContext* ctx) {
+            reloadAndWait(ctx, reloadGrouping);
+
+            UiGraphBlock* loner1 = findByName("loner1");
+            expect(loner1 != nullptr) << fatal;
+            g_state.dashboard->graphModel.selectedBlock = loner1;
+
+            // simulate an inspection reply which no longer reports any of the child blocks
+            rootGraph()->setGraphChildren(gr::property_map{});
+            expect(rootGraph()->childBlocks.empty()) << fatal;
+
+            expect(g_state.dashboard->graphModel.selectedBlock == nullptr) << "selection should be cleared when the selected block is deleted";
+            g_state.stopScheduler();
+        });
+
+        registerMessageTest("ungrouping clears the selection of an inner block", [](ImGuiTestContext* ctx) {
+            reloadAndWait(ctx, reloadGrouping);
+
+            UiGraphBlock* loner1 = findByName("loner1");
+            UiGraphBlock* loner2 = findByName("loner2");
+            expect(loner1 != nullptr && loner2 != nullptr) << fatal;
+            const auto loner1UniqueName = loner1->blockUniqueName;
+            const auto loner2UniqueName = loner2->blockUniqueName;
+
+            UiGraphBlock* subgraph = groupAndWait(ctx, {loner1UniqueName, loner2UniqueName});
+            expect(subgraph != nullptr) << fatal;
+
+            g_state.dashboard->graphModel.selectedBlock = subgraph;
+
+            sendUngroupBlocks(subgraph->blockUniqueName);
+            expect(waitForReplyOnEndpoint(ctx, gr::scheduler::property::kBlocksUngrouped)) << "scheduler did not confirm ungrouping";
+            expect(awaitCondition(ctx,
+                [loner1UniqueName, loner2UniqueName] {
+                    UiGraphBlock* root = rootGraph();
+                    return root->findBlockByUniqueName(loner1UniqueName) != nullptr && //
+                           root->findBlockByUniqueName(loner2UniqueName) != nullptr && //
+                           findSubgraphIn(root) == nullptr;
+                }))
+                << fatal << "ungrouped blocks should return to the root graph";
+
+            expect(g_state.dashboard->graphModel.selectedBlock == nullptr) << "selection should be cleared when the selected block is deleted";
             g_state.stopScheduler();
         });
     }

--- a/src/ui/test/qa_GraphModel.cpp
+++ b/src/ui/test/qa_GraphModel.cpp
@@ -13,6 +13,9 @@
 #include <gnuradio-4.0/GrBasicBlocks.hpp>
 #include <gnuradio-4.0/GrFourierBlocks.hpp>
 #include <gnuradio-4.0/GrTestingBlocks.hpp>
+#include <gnuradio-4.0/Scheduler.hpp>
+
+#include <scope_exit.hpp>
 
 #include <boost/ut.hpp>
 
@@ -20,13 +23,80 @@ CMRC_DECLARE(ui_test_assets);
 
 using namespace boost;
 using namespace boost::ut;
+using namespace std::string_literals;
 
 opendigitizer::test::TestDashboardRunner g_state;
 
 void reloadSubgraph() { g_state.reload(cmrc::ui_test_assets::get_filesystem(), "examples/qa_subgraph.grc", "subgraph_test"); }
+void reloadGrouping() { g_state.reload(cmrc::ui_test_assets::get_filesystem(), "examples/qa_grouping.grc", "grouping_test"); }
 
 struct TestApp : public DigitizerUi::test::ImGuiTestApp {
     using DigitizerUi::test::ImGuiTestApp::ImGuiTestApp;
+
+    static bool awaitCondition(ImGuiTestContext* ctx, const std::function<bool()>& condition, std::chrono::milliseconds timeout = std::chrono::seconds(10)) {
+        const auto start = std::chrono::high_resolution_clock::now();
+        while (!condition() && (std::chrono::high_resolution_clock::now() - start < timeout)) {
+            ctx->Yield();
+            std::this_thread::sleep_for(std::chrono::milliseconds(16));
+        }
+        return condition();
+    }
+
+    [[nodiscard]] static bool waitForReplyOnEndpoint(ImGuiTestContext* ctx, std::string_view endpoint) {
+        std::optional<gr::Message>   outReply;
+        auto                         subscription = g_state.dashboard->graphModel.subscribeToResponses([&outReply, endpoint](const gr::Message& reply) {
+            if (reply.endpoint == endpoint) {
+                outReply = reply;
+            }
+        });
+        Digitizer::utils::scope_exit unsubscribe  = [subscription] { g_state.dashboard->graphModel.unsubscribeFromResponses(subscription); };
+
+        return awaitCondition(ctx, [&outReply] { return outReply.has_value(); });
+    }
+
+    static UiGraphBlock* rootGraph() {
+        auto& rootChildren = g_state.dashboard->graphModel.rootBlock.childBlocks;
+        expect(rootChildren.size() == 1UZ) << fatal;
+        return rootChildren[0].get();
+    }
+
+    static UiGraphBlock* findByName(std::string_view name) { return g_state.dashboard->graphModel.recursiveFindBlockByName(name).block; }
+
+    static UiGraphBlock* findSubgraphIn(UiGraphBlock* graph) {
+        auto it = std::ranges::find_if(graph->childBlocks, [](const auto& child) { return child->isGraph() || child->isScheduler(); });
+        return it == graph->childBlocks.end() ? nullptr : it->get();
+    }
+
+    static void sendGroupBlocks(std::vector<std::string> uniqueNames) {
+        auto&                      graphModel = g_state.dashboard->graphModel;
+        gr::Tensor<gr::pmt::Value> names;
+        for (auto& name : uniqueNames) {
+            names.push_back(gr::pmt::Value(std::move(name)));
+        }
+        gr::Message message;
+        message.cmd         = gr::message::Command::Set;
+        message.endpoint    = gr::scheduler::property::kGroupBlocks;
+        message.serviceName = graphModel.rootBlock.blockUniqueName;
+        message.data        = gr::property_map{{"type", "gr::Graph"s}, {"uniqueNames", std::move(names)}, {"_targetGraph", rootGraph()->blockUniqueName}};
+        graphModel.sendMessage(std::move(message));
+    }
+
+    static void sendUngroupBlocks(const std::string& subgraphUniqueName) {
+        auto&       graphModel = g_state.dashboard->graphModel;
+        gr::Message message;
+        message.cmd         = gr::message::Command::Set;
+        message.endpoint    = gr::scheduler::property::kUngroupBlocks;
+        message.serviceName = graphModel.rootBlock.blockUniqueName;
+        message.data        = gr::property_map{{"uniqueName", subgraphUniqueName}, {"_targetGraph", rootGraph()->blockUniqueName}};
+        graphModel.sendMessage(std::move(message));
+    }
+
+    static const UiGraphEdge* findEdge(const UiGraphBlock* graph, std::string_view sourceBlockUniqueName, std::string_view destinationBlockUniqueName) {
+        auto it = std::ranges::find_if(graph->childEdges, [&](const UiGraphEdge& edge) { //
+            return edge.edgeSourceBlockName == sourceBlockUniqueName && edge.edgeDestinationBlockName == destinationBlockUniqueName;
+        });
+        return it == graph->childEdges.end() ? nullptr : std::addressof(*it);
+    }
 
     void registerTests() override {
         {
@@ -134,6 +204,249 @@ struct TestApp : public DigitizerUi::test::ImGuiTestApp {
                 g_state.stopScheduler();
             };
         }
+
+        registerMessageTest("export returns kSubgraphExportedPort and model gets updated accordingly", [](ImGuiTestContext* ctx) {
+            reloadAndWait(ctx, reloadSubgraph);
+
+            UiGraphBlock* subgraph    = findByName("simpleScheduler");
+            UiGraphBlock* innerSource = findByName("subgraphSineSource");
+            expect(subgraph != nullptr && innerSource != nullptr) << fatal;
+
+            sendExportPort(subgraph, innerSource, "output", "out", "sigOut");
+            expect(waitForReplyOnEndpoint(ctx, gr::graph::property::kSubgraphExportedPort)) << "scheduler never replied about the port export";
+
+            const auto subgraphHasExportedPort = [uniqueName = subgraph->blockUniqueName] {
+                UiGraphBlock* block = g_state.dashboard->graphModel.recursiveFindBlockByUniqueName(uniqueName).block;
+                return block && std::ranges::count(block->outputPorts(), "sigOut", &DigitizerUi::UiGraphPort::portName) == 1;
+            };
+            expect(awaitCondition(ctx, subgraphHasExportedPort)) << "exported port did not show up on the subgraph block";
+
+            g_state.stopScheduler();
+        });
+
+        registerMessageTest("connect to an exported port", [](ImGuiTestContext* ctx) {
+            reloadAndWait(ctx, reloadSubgraph);
+
+            UiGraphBlock* subgraph    = findByName("simpleScheduler");
+            UiGraphBlock* innerSource = findByName("subgraphSineSource");
+            expect(subgraph != nullptr && innerSource != nullptr) << fatal;
+            const auto subgraphUniqueName = subgraph->blockUniqueName;
+
+            sendExportPort(subgraph, innerSource, "output", "out", "sigOut");
+            expect(waitForReplyOnEndpoint(ctx, gr::graph::property::kSubgraphExportedPort)) << "scheduler never replied about the port export";
+            expect(awaitCondition(ctx,
+                [subgraphUniqueName] {
+                    UiGraphBlock* block = g_state.dashboard->graphModel.recursiveFindBlockByUniqueName(subgraphUniqueName).block;
+                    return block && !block->outputPorts().empty();
+                }))
+                << fatal << "exported port did not show up on the subgraph block";
+
+            auto& graphModel = g_state.dashboard->graphModel;
+            {
+                gr::Message message;
+                message.cmd         = gr::message::Command::Set;
+                message.endpoint    = gr::scheduler::property::kEmplaceBlock;
+                message.serviceName = graphModel.rootBlock.blockUniqueName;
+                message.data        = gr::property_map{{"type", "gr::basic::DataSink<float32>"s}, {"_targetGraph", rootGraph()->blockUniqueName}};
+                graphModel.sendMessage(std::move(message));
+            }
+
+            const auto findOuterSink = [subgraphUniqueName]() -> UiGraphBlock* {
+                auto& children = rootGraph()->childBlocks;
+                auto  it       = std::ranges::find_if(children, [&](const auto& child) { //
+                    return child->blockUniqueName != subgraphUniqueName && child->blockTypeName.starts_with("gr::basic::DataSink");
+                });
+                return it == children.end() ? nullptr : it->get();
+            };
+            expect(awaitCondition(ctx, [&] { return findOuterSink() != nullptr; })) << fatal << "emplaced sink did not show up in the root graph";
+            const auto outerSinkUniqueName = findOuterSink()->blockUniqueName;
+
+            {
+                gr::Message message;
+                message.cmd         = gr::message::Command::Set;
+                message.endpoint    = gr::scheduler::property::kEmplaceEdge;
+                message.serviceName = graphModel.rootBlock.blockUniqueName;
+                message.data        = gr::property_map{                                                               //
+                    {"_targetGraph", rootGraph()->blockUniqueName},                                            //
+                    {std::pmr::string(gr::serialization_fields::EDGE_SOURCE_BLOCK), subgraphUniqueName},       //
+                    {std::pmr::string(gr::serialization_fields::EDGE_SOURCE_PORT), "sigOut"s},                 //
+                    {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_BLOCK), outerSinkUniqueName}, //
+                    {std::pmr::string(gr::serialization_fields::EDGE_DESTINATION_PORT), "in"s},                //
+                    {std::pmr::string(gr::serialization_fields::EDGE_MIN_BUFFER_SIZE), gr::Size_t(4096)},      //
+                    {std::pmr::string(gr::serialization_fields::EDGE_WEIGHT), 1},                              //
+                    {std::pmr::string(gr::serialization_fields::EDGE_NAME), "edge"s}};
+                graphModel.sendMessage(std::move(message));
+            }
+
+            expect(waitForReplyOnEndpoint(ctx, gr::scheduler::property::kEdgeEmplaced)) << "edge should be reported as emplaced by the scheduler";
+
+            expect(awaitCondition(ctx, [&] {
+                const UiGraphEdge* edge = findEdge(rootGraph(), subgraphUniqueName, outerSinkUniqueName);
+                return edge && edge->edgeSourcePort && edge->edgeDestinationPort && edge->edgeSourcePort->portName == "sigOut";
+            })) << "edge did not get created to exported port in our graph model";
+
+            g_state.stopScheduler();
+        });
+
+        registerMessageTest("group middle blocks of a chain", [](ImGuiTestContext* ctx) {
+            reloadAndWait(ctx, reloadGrouping);
+
+            UiGraphBlock* source  = findByName("source");
+            UiGraphBlock* middleA = findByName("middleA");
+            UiGraphBlock* middleB = findByName("middleB");
+            UiGraphBlock* sink    = findByName("sink");
+            expect(source != nullptr && middleA != nullptr && middleB != nullptr && sink != nullptr) << fatal;
+            const auto sourceUniqueName  = source->blockUniqueName;
+            const auto middleAUniqueName = middleA->blockUniqueName;
+            const auto middleBUniqueName = middleB->blockUniqueName;
+            const auto sinkUniqueName    = sink->blockUniqueName;
+
+            UiGraphBlock* subgraph = groupAndWait(ctx, {middleAUniqueName, middleBUniqueName});
+            expect(subgraph != nullptr) << fatal;
+            expect(awaitCondition(ctx, [] { return rootGraph()->childEdges.size() == 2UZ; })) << fatal << "boundary edges did not show up in the root graph";
+
+            UiGraphBlock* innerA = subgraph->findBlockByUniqueName(middleAUniqueName);
+            UiGraphBlock* innerB = subgraph->findBlockByUniqueName(middleBUniqueName);
+            expect(innerA != nullptr && innerB != nullptr) << fatal;
+
+            const UiGraphEdge* interiorEdge = findEdge(subgraph, middleAUniqueName, middleBUniqueName);
+            expect(interiorEdge != nullptr) << fatal << "interior edge middleA->middleB should stay inside the subgraph";
+            expect(interiorEdge->edgeSourcePort != nullptr && interiorEdge->edgeDestinationPort != nullptr);
+            expect(eq(subgraph->childEdges.size(), 1UZ));
+
+            expect(subgraph->inputPorts().size() == 1UZ) << fatal << "middleA's input should be the only exported input";
+            expect(subgraph->outputPorts().size() == 1UZ) << fatal << "middleB's output should be the only exported output";
+            expect(subgraph->inputPorts().front().portName.starts_with("middleA.")) << "exported input should be named after middleA";
+            expect(subgraph->outputPorts().front().portName.starts_with("middleB.")) << "exported output should be named after middleB";
+            expect(innerA->_inputPorts.front().getExportedName(subgraph) == subgraph->inputPorts().front().portName);
+            expect(innerB->_outputPorts.front().getExportedName(subgraph) == subgraph->outputPorts().front().portName);
+
+            const UiGraphEdge* inEdge = findEdge(rootGraph(), sourceUniqueName, subgraph->blockUniqueName);
+            expect(inEdge != nullptr) << fatal << "source should be connected to the subgraph";
+            expect(inEdge->edgeDestinationPort != nullptr && inEdge->edgeDestinationPort->ownerBlock == subgraph);
+            expect(inEdge->edgeDestinationPort->portName == subgraph->inputPorts().front().portName);
+
+            const UiGraphEdge* outEdge = findEdge(rootGraph(), subgraph->blockUniqueName, sinkUniqueName);
+            expect(outEdge != nullptr) << fatal << "subgraph should be connected to the sink";
+            expect(outEdge->edgeSourcePort != nullptr && outEdge->edgeSourcePort->ownerBlock == subgraph);
+            expect(outEdge->edgeSourcePort->portName == subgraph->outputPorts().front().portName);
+
+            g_state.stopScheduler();
+        });
+
+        registerMessageTest("group and ungroup unconnected blocks", [](ImGuiTestContext* ctx) {
+            reloadAndWait(ctx, reloadGrouping);
+
+            UiGraphBlock* loner1 = findByName("loner1");
+            UiGraphBlock* loner2 = findByName("loner2");
+            expect(loner1 != nullptr && loner2 != nullptr) << fatal;
+            const auto loner1UniqueName = loner1->blockUniqueName;
+            const auto loner2UniqueName = loner2->blockUniqueName;
+
+            UiGraphBlock* subgraph = groupAndWait(ctx, {loner1UniqueName, loner2UniqueName});
+            expect(subgraph != nullptr) << fatal;
+
+            expect(subgraph != nullptr) << fatal;
+
+            expect(subgraph->isGraph()) << "grouping into gr::Graph should create a transparent subgraph";
+            expect(subgraph->inputPorts().empty()) << "no connections + nothing to export";
+            expect(subgraph->outputPorts().empty()) << "no connections + nothing to export";
+            expect(subgraph->childEdges.empty());
+            expect(subgraph->exportedInputPorts.empty());
+            expect(subgraph->exportedOutputPorts.empty());
+            expect(subgraph->findBlockByUniqueName(loner1UniqueName) != nullptr);
+            expect(subgraph->findBlockByUniqueName(loner2UniqueName) != nullptr);
+            expect(rootGraph()->findBlockByUniqueName(loner1UniqueName) == nullptr) << "grouped block should no longer be a direct child of the root graph";
+            expect(eq(rootGraph()->childEdges.size(), 3UZ)) << "other edges should still be intact after grouping";
+
+            sendUngroupBlocks(subgraph->blockUniqueName);
+            expect(waitForReplyOnEndpoint(ctx, gr::scheduler::property::kBlocksUngrouped)) << "scheduler did not confirm ungrouping";
+
+            expect(awaitCondition(ctx, [loner1UniqueName, loner2UniqueName] {
+                UiGraphBlock* root = rootGraph();
+                return root->findBlockByUniqueName(loner1UniqueName) != nullptr && //
+                       root->findBlockByUniqueName(loner2UniqueName) != nullptr && //
+                       findSubgraphIn(root) == nullptr;
+            })) << "ungrouped blocks should return to the root graph and the empty subgraph should disappear";
+
+            g_state.stopScheduler();
+        });
+
+        registerMessageTest("ungroup restores boundary connections", [](ImGuiTestContext* ctx) {
+            reloadAndWait(ctx, reloadGrouping);
+
+            UiGraphBlock* source  = findByName("source");
+            UiGraphBlock* middleA = findByName("middleA");
+            UiGraphBlock* middleB = findByName("middleB");
+            UiGraphBlock* sink    = findByName("sink");
+            expect(source != nullptr && middleA != nullptr && middleB != nullptr && sink != nullptr) << fatal;
+            const auto sourceUniqueName  = source->blockUniqueName;
+            const auto middleAUniqueName = middleA->blockUniqueName;
+            const auto middleBUniqueName = middleB->blockUniqueName;
+            const auto sinkUniqueName    = sink->blockUniqueName;
+
+            UiGraphBlock* subgraph = groupAndWait(ctx, {middleAUniqueName, middleBUniqueName});
+            expect(subgraph != nullptr) << fatal;
+
+            sendUngroupBlocks(subgraph->blockUniqueName);
+            expect(waitForReplyOnEndpoint(ctx, gr::scheduler::property::kBlocksUngrouped)) << "scheduler did not confirm ungrouping";
+
+            expect(awaitCondition(ctx,
+                [middleAUniqueName] {
+                    UiGraphBlock* root = rootGraph();
+                    return root->findBlockByUniqueName(middleAUniqueName) != nullptr && findSubgraphIn(root) == nullptr && root->childEdges.size() == 3UZ;
+                }))
+                << fatal << "chain was not restored in the root graph";
+
+            for (const auto& [from, to] : {std::pair{sourceUniqueName, middleAUniqueName}, {middleAUniqueName, middleBUniqueName}, {middleBUniqueName, sinkUniqueName}}) {
+                const UiGraphEdge* edge = findEdge(rootGraph(), from, to);
+                expect(edge != nullptr) << std::format("edge {} -> {} should be restored", from, to);
+                expect(edge == nullptr || (edge->edgeSourcePort != nullptr && edge->edgeDestinationPort != nullptr)) << "restored edge should resolve its ports";
+            }
+
+            g_state.stopScheduler();
+        });
+    }
+
+    static void reloadAndWait(ImGuiTestContext* ctx, void (*reloadFunction)()) {
+        reloadFunction();
+        g_state.waitForScheduler(ctx);
+        while (!g_state.hasBlocks()) {
+            ctx->Yield();
+        }
+    }
+
+    static void sendExportPort(UiGraphBlock* subgraph, UiGraphBlock* innerBlock, const std::string& direction, const std::string& portName, const std::string& exportedName) {
+        gr::Message message;
+        message.cmd         = gr::message::Command::Set;
+        message.endpoint    = gr::graph::property::kSubgraphExportPort;
+        message.serviceName = subgraph->blockUniqueName;
+        message.data        = gr::property_map{{"uniqueBlockName", innerBlock->blockUniqueName}, {"portDirection", direction}, {"portName", portName}, {"exportedName", exportedName}, {"exportFlag", true}};
+        g_state.dashboard->graphModel.sendMessage(std::move(message));
+    }
+
+    static UiGraphBlock* groupAndWait(ImGuiTestContext* ctx, const std::vector<std::string>& uniqueNames) {
+        sendGroupBlocks(uniqueNames);
+        expect(waitForReplyOnEndpoint(ctx, gr::scheduler::property::kBlocksGrouped)) << "scheduler should confirm grouping";
+
+        const bool grouped = awaitCondition(ctx, [expectedChildren = uniqueNames.size()] {
+            UiGraphBlock* subgraph = findSubgraphIn(rootGraph());
+            return subgraph && subgraph->childBlocks.size() == expectedChildren;
+        });
+        expect(grouped) << "subgraph with grouped blocks should also appear in the graph model";
+        return grouped ? findSubgraphIn(rootGraph()) : nullptr;
+    }
+
+    void registerMessageTest(const char* name, ImGuiTestTestFunc testFunc) {
+        ImGuiTest* t = IM_REGISTER_TEST(engine(), "graphmodel", name);
+        t->SetVarsDataType<opendigitizer::test::TestDashboardRunner>();
+        t->GuiFunc = [](ImGuiTestContext*) {
+            IMW::Window window("Test Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoSavedSettings);
+            ImGui::SetWindowPos({0, 0});
+            ImGui::SetWindowSize(ImVec2(800, 800));
+            g_state.dashboard->handleMessages();
+        };
+        t->TestFunc = testFunc;
     }
 };
 

--- a/src/ui/test/qa_flowgraph.cpp
+++ b/src/ui/test/qa_flowgraph.cpp
@@ -6,6 +6,7 @@
 
 #include <boost/ut.hpp>
 
+#include <algorithm>
 #include <format>
 #include <gnuradio-4.0/Graph_yaml_importer.hpp>
 #include <gnuradio-4.0/Profiler.hpp>
@@ -115,6 +116,8 @@ struct TestState : public opendigitizer::test::TestDashboardRunner {
     }
 
     void reloadSubgraph() { reload(cmrc::ui_test_assets::get_filesystem(), "examples/qa_subgraph.grc", "subgraph_test"); }
+
+    void reloadGrouping() { reload(cmrc::ui_test_assets::get_filesystem(), "examples/qa_grouping.grc", "grouping_test"); }
 
     void enterSubgraphEditor() {
         auto& graphChildren = blocks();
@@ -265,6 +268,60 @@ struct TestApp : public DigitizerUi::test::ImGuiTestApp {
                 expect(recievedReplyAboutExport) << "Scheduler never responded about the request to export a port\n";
 
                 expect(targetPort->isExportedTo(editor._exportPortTargetBlock)) << "ui action should have caused port to become exported\n";
+
+                g_state.stopScheduler();
+            };
+        }
+
+        {
+            ImGuiTest* t = IM_REGISTER_TEST(engine(), "flowgraph", "Selection does not report blocks deleted by grouping");
+            t->SetVarsDataType<TestState>();
+
+            t->GuiFunc = basicGuiFunc;
+
+            t->TestFunc = [](ImGuiTestContext* ctx) {
+                g_state.reloadGrouping();
+                g_state.waitForScheduler(ctx);
+                while (!g_state.hasBlocks()) {
+                    ctx->Yield();
+                }
+
+                auto& graphModel = g_state.dashboard->graphModel;
+                auto& editor     = g_state.flowgraphPage.currentEditor();
+
+                DigitizerUi::UiGraphBlock* loner1 = graphModel.recursiveFindBlockByName("loner1").block;
+                DigitizerUi::UiGraphBlock* loner2 = graphModel.recursiveFindBlockByName("loner2").block;
+                expect(loner1 != nullptr && loner2 != nullptr) << fatal;
+                const std::vector<std::string> groupedNames{loner1->blockUniqueName, loner2->blockUniqueName};
+
+                ctx->Yield(2); // the node editor needs a frame before nodes become selectable
+
+                editor.makeCurrent();
+                ax::NodeEditor::SelectNode(ax::NodeEditor::NodeId(loner1), true);
+                ax::NodeEditor::SelectNode(ax::NodeEditor::NodeId(loner2), true);
+                expect(eq(editor.selectedBlockUniqueNames().size(), 2UZ)) << fatal << "both blocks should report as selected before grouping";
+
+                editor.requestBlocksGrouping("gr::Graph", groupedNames);
+                expect(waitForReplyOnEndpoint(ctx, gr::scheduler::property::kBlocksGrouped)) << "scheduler should confirm grouping";
+
+                const auto groupedBlocksLeftRootGraph = [&] {
+                    return std::ranges::none_of(editor.rootBlock()->childBlocks, [&](const auto& child) { //
+                        return std::ranges::contains(groupedNames, child->blockUniqueName);
+                    });
+                };
+                const auto start = std::chrono::high_resolution_clock::now();
+                while (!groupedBlocksLeftRootGraph() && std::chrono::high_resolution_clock::now() - start < std::chrono::seconds(10)) {
+                    ctx->Yield();
+                }
+                expect(groupedBlocksLeftRootGraph()) << fatal << "grouped blocks should have moved into the subgraph";
+
+                ctx->Yield(); // draw a frame so the editor can observe the model change
+
+                const std::vector<std::string> selectedAfter = editor.selectedBlockUniqueNames();
+                for (const std::string& name : selectedAfter) {
+                    expect(graphModel.recursiveFindBlockByUniqueName(name).block != nullptr) << "selection reported a block that does not exist: " << name;
+                }
+                expect(selectedAfter.empty()) << "blocks deleted by grouping should not be reported as selected";
 
                 g_state.stopScheduler();
             };


### PR DESCRIPTION
Adds three new context menu options in the flowgraph page for grouping blocks into a subgraph, a managed subgraph, or ungrouping what is already a subgraph.

It also fixes some bugs which were noticable when using this feature, first that we would crash when deleting the currently selected block, and one where we would too eagerly look for exported ports in child blocks of a subgraph, before they had been inspected/were up to date.

https://github.com/user-attachments/assets/3bec7b53-b11c-44cd-8f32-080d979f1983

